### PR TITLE
:memo: fix typos in documentation

### DIFF
--- a/docs/docs/tutorial/response-schema.md
+++ b/docs/docs/tutorial/response-schema.md
@@ -2,7 +2,7 @@
 
 **Django Ninja** allows you define schema of your responses both for validation and documentation purposes.
 
-Let's check the the following example. Imagine you need to create api operation that creates a user. The **input** parameter would be **username+password**, but **output** of this operation should be **id+username** (**without** the password).
+Let's check the following example. Imagine you need to create an api operation that creates a user. The **input** parameter would be **username+password**, but **output** of this operation should be **id+username** (**without** the password).
 
 Let's create input schema:
 
@@ -94,7 +94,7 @@ def tasks(request):
     return list(queryset)
 ```
 
-If you execute this operation you should  get response like this:
+If you execute this operation you should  get a response like this:
 
 ```JSON  hl_lines="6 7 8 9 16"
 [
@@ -119,9 +119,9 @@ If you execute this operation you should  get response like this:
 
 ## Returning querysets
 
-In the previous example we specifically converted queryset to to a list (and executing SQL query during evaluation).
+In the previous example we specifically converted a queryset into a list (and executing SQL query during evaluation).
 
-But you can avoid it and return a queryset as result and it will be automatically evaluated to List:
+But you can avoid it and return a queryset as a result and it will be automatically evaluated to List:
 
 ```Python hl_lines="3"
 @api.get("/tasks", response=List[TaskSchema])
@@ -131,7 +131,7 @@ def tasks(request):
 
 ### Note about async mode
 
-If your [async-support](operation is is async) this example will not work
+If your opertation is [async-support](https://django-ninja.rest-framework.com/async-support) this example will not work
 
 ```Python hl_lines="2 3"
 @api.get("/tasks", response=List[TaskSchema])

--- a/docs/docs/tutorial/response-schema.md
+++ b/docs/docs/tutorial/response-schema.md
@@ -131,7 +131,7 @@ def tasks(request):
 
 ### Note about async mode
 
-If your opertation is [async-support](https://django-ninja.rest-framework.com/async-support) this example will not work
+If your opertation is async [async-support](https://django-ninja.rest-framework.com/async-support) this example will not work
 
 ```Python hl_lines="2 3"
 @api.get("/tasks", response=List[TaskSchema])

--- a/docs/docs/tutorial/routers.md
+++ b/docs/docs/tutorial/routers.md
@@ -97,7 +97,7 @@ Finally let's group this together, in your project folder (next to urls.py) crea
 
 ```
 
-this will will be like:
+this will be like:
 
 ```Python
 from ninja import NinjaAPI


### PR DESCRIPTION
Fixed some typos, and a dead link.