### PR TITLE
Removed usage of broad excepts and some print statements

### DIFF
--- a/ninja/params.py
+++ b/ninja/params.py
@@ -27,7 +27,6 @@ class Param(FieldInfo):
         # param_type: Any = None,
         **extra: Any,
     ):
-        # print('alias = ', alias)
         self.deprecated = deprecated
         # self.param_name: str = None
         # self.param_type: Any = None

--- a/ninja/security/http.py
+++ b/ninja/security/http.py
@@ -27,7 +27,6 @@ class HttpBearer(HttpAuthBase, ABC):
         parts = auth_value.split(" ")
 
         if parts[0].lower() != "bearer":
-            print(f"Unexpected auth - '{auth_value}'")
             return None
         token = " ".join(parts[1:])
         return self.authenticate(request, token)
@@ -54,7 +53,6 @@ class HttpBasicAuth(HttpAuthBase, ABC):  # TODO: maybe HttpBasicAuthBase
         try:
             username, password = self.decode_authorization(auth_value)
         except DecodeError as e:
-            print(e)
             return None
         return self.authenticate(request, username, password)
 
@@ -77,5 +75,4 @@ class HttpBasicAuth(HttpAuthBase, ABC):  # TODO: maybe HttpBasicAuthBase
             username, password = b64decode(user_pass_encoded).decode().split(":", 1)
             return unquote(username), unquote(password)
         except Exception as e:
-            print(e)
             raise DecodeError("Invlid Authorization header") from e

--- a/ninja/security/http.py
+++ b/ninja/security/http.py
@@ -52,7 +52,7 @@ class HttpBasicAuth(HttpAuthBase, ABC):  # TODO: maybe HttpBasicAuthBase
 
         try:
             username, password = self.decode_authorization(auth_value)
-        except DecodeError as e:
+        except DecodeError:
             return None
         return self.authenticate(request, username, password)
 
@@ -69,10 +69,10 @@ class HttpBasicAuth(HttpAuthBase, ABC):  # TODO: maybe HttpBasicAuthBase
         elif len(parts) == 2 and parts[0].lower() == "basic":
             user_pass_encoded = parts[1]
         else:
-            raise DecodeError("Invlid Authorization header")
+            raise DecodeError("Invalid Authorization header")
 
         try:
             username, password = b64decode(user_pass_encoded).decode().split(":", 1)
             return unquote(username), unquote(password)
-        except Exception as e:
-            raise DecodeError("Invlid Authorization header") from e
+        except ValueError as e:
+            raise DecodeError("Invalid Authorization header") from e

--- a/ninja/signature/details.py
+++ b/ninja/signature/details.py
@@ -59,7 +59,6 @@ class ViewSignature:
             attrs["_collection_fields"] = detect_collection_fields(args)
 
             base_cls = cls._model
-            # print([cls_name, (base_cls,), attrs])
             model_cls = type(cls_name, (base_cls,), attrs)
             # TODO: https://pydantic-docs.helpmanual.io/usage/models/#dynamic-model-creation - check if anything special in create_model method that I did not use
             result.append(model_cls)


### PR DESCRIPTION
Thanks for this project! 🌟 

I found some usages of broad excepts where `ValueError` can be used instead. It's nice to avoid too broad excepts when it's not needed, let me know if I'm missing something here. 

I also found a couple of `print` statements, I understand that the exception that's printed is caught and silenced but we should probably try and use the logging module if we want some debugging-output for the user.