### PR TITLE
fixed two docs typos

### DIFF
--- a/docs/src/tutorial/path/code01.py
+++ b/docs/src/tutorial/path/code01.py
@@ -1,3 +1,3 @@
-@app.get("/items/{item_id}")
+@api.get("/items/{item_id}")
 def read_item(request, item_id):
     return {"item_id": item_id}

--- a/docs/src/tutorial/path/code02.py
+++ b/docs/src/tutorial/path/code02.py
@@ -1,3 +1,3 @@
-@app.get("/items/{item_id}")
+@api.get("/items/{item_id}")
 def read_item(request, item_id: int):
     return {"item_id": item_id}


### PR DESCRIPTION
In the `path-params` part of the tutorial I'm pretty it should be `api` decorator instead of `app`.
