### PR TITLE
Make operation ids unique and raise error on overlap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.pyc
-.venv
+*venv
+*.sqlite3
+
 .vscode
 .mypy_cache
 .coverage

--- a/docs/src/tutorial/authentication/apikey02.py
+++ b/docs/src/tutorial/authentication/apikey02.py
@@ -13,5 +13,5 @@ header_key = ApiKey()
 
 
 @api.get("/headerkey", auth=header_key)
-def apikey(request):
+def apikey2(request):
     return f"Token = {request.auth}"

--- a/docs/src/tutorial/authentication/apikey03.py
+++ b/docs/src/tutorial/authentication/apikey03.py
@@ -11,5 +11,5 @@ cookie_key = CookieKey()
 
 
 @api.get("/cookiekey", auth=cookie_key)
-def apikey(request):
+def apikey3(request):
     return f"Token = {request.auth}"

--- a/docs/src/tutorial/body/code02.py
+++ b/docs/src/tutorial/body/code02.py
@@ -9,5 +9,5 @@ class Item(Schema):
 
 
 @api.put("/items/{item_id}")
-def update(request, item_id: int, item: Item):
+def update2(request, item_id: int, item: Item):
     return {"item_id": item_id, "item": item.dict()}

--- a/docs/src/tutorial/body/code03.py
+++ b/docs/src/tutorial/body/code03.py
@@ -9,5 +9,5 @@ class Item(Schema):
 
 
 @api.post("/items/{item_id}")
-def update(request, item_id: int, item: Item, q: str):
+def update3(request, item_id: int, item: Item, q: str):
     return {"item_id": item_id, "item": item.dict(), "q": q}

--- a/docs/src/tutorial/path/code02.py
+++ b/docs/src/tutorial/path/code02.py
@@ -1,3 +1,3 @@
 @api.get("/items/{item_id}")
-def read_item(request, item_id: int):
+def read_item2(request, item_id: int):
     return {"item_id": item_id}

--- a/ninja/main.py
+++ b/ninja/main.py
@@ -276,11 +276,6 @@ class NinjaAPI:
             path_prefix = self.root_path
         return get_schema(api=self, path_prefix=path_prefix)
 
-    def get_openapi_operation_id(self, operation: "Operation"):
-        name = operation.view_func.__name__
-        module = operation.view_func.__module__
-        return (module + "_" + name).replace(".", "_")
-
     def _validate(self):
         from ninja.security import APIKeyCookie
 

--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -58,9 +58,8 @@ class OpenAPISchema(OrderedDict):
         return result
 
     def operation_details(self, operation: Operation):
-        op_id = operation.operation_id or self.api.get_openapi_operation_id(operation)
         result = {
-            "operationId": op_id,
+            "operationId": operation.operation_id,
             "summary": operation.summary,
             "parameters": self.operation_parameters(operation),
             "responses": self.responses(operation),

--- a/tests/main.py
+++ b/tests/main.py
@@ -5,7 +5,9 @@ router = Router()
 
 
 @router.get("/text")
-def get_text(request,):
+def get_text(
+    request,
+):
     return "Hello World"
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -63,7 +63,7 @@ for path, auth in [
     ("basic", BasicAuth()),
     ("bearer", BearerAuth()),
 ]:
-    api.get(f"/{path}", auth=auth)(demo_operation)
+    api.get(f"/{path}", auth=auth, operation_id=path)(demo_operation)
 
 
 client = NinjaClient(api)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,0 +1,18 @@
+from ninja import NinjaAPI
+import pytest
+
+api = NinjaAPI()
+
+
+class TestDecorator:
+    def test_assigns_different_operation_ids_when_same_function_names(self):
+
+        with pytest.raises(ValueError):
+
+            @api.get("/foo")
+            def operation(request):
+                pass
+
+            @api.get("/bar")
+            def operation(request):
+                pass

--- a/tests/test_inheritance_routers.py
+++ b/tests/test_inheritance_routers.py
@@ -11,20 +11,26 @@ def global_op(request):
 
 
 first_router = Router()
+
+
 @first_router.get("/endpoint")
 def router_op(request):
     return "first"
 
 
 second_router_one = Router()
+
+
 @second_router_one.get("endpoint_1")
-def router_op(request):
+def router_op2(request):
     return "second 1"
 
 
 second_router_two = Router()
+
+
 @second_router_two.get("endpoint_2")
-def router_op(request):
+def router_op3(request):
     return "second 2"
 
 

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -12,7 +12,9 @@ router = Router()
 
 @router.post("/list1")
 def listview1(
-    request, query: List[int] = Query(...), form: List[int] = Form(...),
+    request,
+    query: List[int] = Query(...),
+    form: List[int] = Form(...),
 ):
     return {
         "query": query,
@@ -22,7 +24,9 @@ def listview1(
 
 @router.post("/list2")
 def listview2(
-    request, body: List[int], query: List[int] = Query(...),
+    request,
+    body: List[int],
+    query: List[int] = Query(...),
 ):
     return {
         "query": query,
@@ -56,7 +60,8 @@ class Filters(Schema):
 
 @router.post("/list4")
 def listview4(
-    request, filters: Filters = Query(...),
+    request,
+    filters: Filters = Query(...),
 ):
     return {
         "filters": filters,

--- a/tests/test_response_multiple.py
+++ b/tests/test_response_multiple.py
@@ -31,7 +31,8 @@ def check_response_schema(request):
 
 
 @api.get(
-    "/check_multiple_codes", response={codes_2xx: int, codes_3xx: str, ...: float},
+    "/check_multiple_codes",
+    response={codes_2xx: int, codes_3xx: str, ...: float},
 )
 def check_multiple_codes(request, code: int):
     return code, 1


### PR DESCRIPTION
This counts as a first contribution so any suggestions with the PR definition are welcomed.

Implementation of the feature described in https://github.com/vitalik/django-ninja/issues/70

Changed the `Operation` class to have a not `None` `operation_id`. It will be the custom one passed as a keyword argument or a generated one using the module and the `view_func` name. 

Added the restriction to check that an API instance can only have one instance of each `operation_id`.

Removed the operation name fallback in the schema generation (the operation now has always an id).

Edited old tests to follow the new restriction.

The biggest doubt about this PR is where to set the tests, I created a test_decorator as as placeholder. Where would be the best location?

