### PR TITLE
Replace OrderedDict with dict

### DIFF
--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Dict
 
 from pydantic.schema import model_schema
@@ -20,7 +19,7 @@ def get_schema(api: "NinjaAPI", path_prefix=""):
     return openapi
 
 
-class OpenAPISchema(OrderedDict):
+class OpenAPISchema(dict):
     def __init__(self, api: "NinjaAPI", path_prefix: str):
         self.api = api
         self.path_prefix = path_prefix

--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from typing import List, Optional, Union
 
 from django.db.models import ManyToManyRel, ManyToOneRel
@@ -72,7 +71,7 @@ class SchemaFactory:
         exclude: Optional[List[str]] = None,
     ):
         "Returns iterator for model fields based on `exclude` or `fields` arguments"
-        all_fields = OrderedDict([(f.name, f) for f in self._model_fields(model)])
+        all_fields = {f.name: f for f in self._model_fields(model)}
 
         if not fields and not exclude:
             for f in all_fields.values():

--- a/ninja/router.py
+++ b/ninja/router.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from typing import Callable, List, Optional, Tuple
 
 from django.urls import path as django_path
@@ -10,7 +9,7 @@ from ninja.utils import normalize_path
 
 class Router:
     def __init__(self):
-        self.operations = OrderedDict()  # TODO: better rename to path_operations
+        self.operations = {}  # TODO: better rename to path_operations
         self.api = None
         self._routers: List[Tuple[str, Router]] = []
 

--- a/ninja/signature/details.py
+++ b/ninja/signature/details.py
@@ -1,5 +1,5 @@
 import inspect
-from collections import OrderedDict, namedtuple
+from collections import defaultdict, namedtuple
 from typing import Callable, List
 
 import pydantic
@@ -29,11 +29,9 @@ class ViewSignature:
         self.models = self._create_models()
 
     def _create_models(self):
-        grouping = OrderedDict()
+        grouping = defaultdict(list)
         for param in self.params:
             d_type = type(param.source)
-            if d_type not in grouping:
-                grouping[d_type] = []
             grouping[d_type].append(param)
 
         result = []


### PR DESCRIPTION
Starting from Python 3.6+ dictionaries are ordered by default