### PR TITLE
Grab http status code phrases from http library

### DIFF
--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -9,6 +9,8 @@ from ninja.operation import Operation
 from ninja.types import DictStrAny
 from ninja.utils import normalize_path
 
+from http.client import responses
+
 if TYPE_CHECKING:
     from ninja import NinjaAPI  # pragma: no cover
 
@@ -178,7 +180,7 @@ class OpenAPISchema(dict):
             if status == Ellipsis:
                 continue  # it's not yet clear what it means if user want's to output any other code
 
-            description = status < 300 and "OK" or "Error"
+            description = responses.get(status, 'Unknown Status Code')
             details: Dict[int, Any] = {status: {"description": description}}
             if model not in [None, NOT_SET]:
                 schema, _ = self._create_schema_from_model(model, by_alias=False)

--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -1,4 +1,5 @@
 import warnings
+from http.client import responses
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Type
 
 from pydantic import BaseModel
@@ -8,8 +9,6 @@ from ninja.constants import NOT_SET
 from ninja.operation import Operation
 from ninja.types import DictStrAny
 from ninja.utils import normalize_path
-
-from http.client import responses
 
 if TYPE_CHECKING:
     from ninja import NinjaAPI  # pragma: no cover
@@ -180,7 +179,7 @@ class OpenAPISchema(dict):
             if status == Ellipsis:
                 continue  # it's not yet clear what it means if user want's to output any other code
 
-            description = responses.get(status, 'Unknown Status Code')
+            description = responses.get(status, "Unknown Status Code")
             details: Dict[int, Any] = {status: {"description": description}}
             if model not in [None, NOT_SET]:
                 schema, _ = self._create_schema_from_model(model, by_alias=False)

--- a/tests/test_response_multiple.py
+++ b/tests/test_response_multiple.py
@@ -147,7 +147,7 @@ def test_schema():
                     "schema": {"$ref": "#/components/schemas/UserModel"}
                 }
             },
-            "description": "OK",
+            "description": "Accepted",
         },
     }
 
@@ -163,7 +163,7 @@ def test_no_content():
 
     schema = api.get_openapi_schema()
     details = schema["paths"]["/api/check_no_content"]["get"]["responses"]
-    assert details == {204: {"description": "OK"}}
+    assert details == {204: {"description": "No Content"}}
 
 
 def test_validates():


### PR DESCRIPTION
This is related to Issue #147.

This PR replaces the status code description with the description in the `http.client` library. This is the same way Django finds HTTP status code descriptions ([Django source](https://github.com/django/django/blob/225d96533a8e05debd402a2bfe566487cc27d95f/django/http/response.py#L133)).

Looking into allowing custom status descriptions, there seems to be no way to override the description Django uses, making the ability to change the description in the OpenAPI schema useless and could encourage incorrect OpenAPI specifications. Feel free to correct me if I'm wrong though!