### PR TITLE
Implements fake build_absolute_uri on test client

### DIFF
--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -1,6 +1,7 @@
 from json import dumps as json_dumps, loads as json_loads
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from unittest.mock import Mock
+from urllib.parse import urljoin
 
 import django
 from django.http import QueryDict, StreamingHttpResponse
@@ -8,6 +9,15 @@ from django.urls.resolvers import URLPattern
 
 from ninja import NinjaAPI, Router
 from ninja.responses import Response as HttpResponse
+
+
+def build_absolute_uri(location: Optional[str] = None) -> str:
+    base = "http://testlocation/"
+
+    if location:
+        base = urljoin(base, location)
+
+    return base
 
 
 # TODO: this should be changed
@@ -89,6 +99,7 @@ class NinjaClientBase:
         request.COOKIES = {}
         request._dont_enforce_csrf_checks = True
         request.is_secure.return_value = False
+        request.build_absolute_uri = build_absolute_uri
 
         if "user" not in request_params:
             request.user.is_authenticated = False

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -1,0 +1,30 @@
+import pytest 
+
+from http import HTTPStatus
+from ninja.testing import TestClient
+from ninja import Router
+
+router = Router()
+
+@router.get("/request/build_absolute_uri")
+def request_build_absolute_uri(request):
+    return request.build_absolute_uri()
+
+
+@router.get("/request/build_absolute_uri/location")
+def request_build_absolute_uri_location(request):
+    return request.build_absolute_uri('location')
+
+
+client = TestClient(router)
+
+
+@pytest.mark.parametrize('path,expected_status,expected_response', [
+    ('/request/build_absolute_uri', HTTPStatus.OK, 'http://testlocation/'),
+    ('/request/build_absolute_uri/location', HTTPStatus.OK, 'http://testlocation/location'),
+])
+def test_sync_build_absolute_uri(path, expected_status, expected_response):
+    response = client.get(path)
+
+    assert response.status_code == expected_status
+    assert response.json() == expected_response


### PR DESCRIPTION
I missed this method when I try to write a test for my project.