### PR TITLE
inline the Decorator type alias

### DIFF
--- a/ninja/main.py
+++ b/ninja/main.py
@@ -23,7 +23,7 @@ from ninja.openapi.urls import get_openapi_urls, get_root_url
 from ninja.parser import Parser
 from ninja.renderers import BaseRenderer, JSONRenderer
 from ninja.router import Router
-from ninja.types import Decorator
+from ninja.types import TCallable
 
 if TYPE_CHECKING:
     from .operation import Operation  # pragma: no cover
@@ -89,7 +89,7 @@ class NinjaAPI:
         exclude_none: bool = False,
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
-    ) -> Decorator:
+    ) -> Callable[[TCallable], TCallable]:
         return self.default_router.get(
             path,
             auth=auth is NOT_SET and self.auth or auth,
@@ -124,7 +124,7 @@ class NinjaAPI:
         exclude_none: bool = False,
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
-    ) -> Decorator:
+    ) -> Callable[[TCallable], TCallable]:
         return self.default_router.post(
             path,
             auth=auth is NOT_SET and self.auth or auth,
@@ -159,7 +159,7 @@ class NinjaAPI:
         exclude_none: bool = False,
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
-    ) -> Decorator:
+    ) -> Callable[[TCallable], TCallable]:
         return self.default_router.delete(
             path,
             auth=auth is NOT_SET and self.auth or auth,
@@ -194,7 +194,7 @@ class NinjaAPI:
         exclude_none: bool = False,
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
-    ) -> Decorator:
+    ) -> Callable[[TCallable], TCallable]:
         return self.default_router.patch(
             path,
             auth=auth is NOT_SET and self.auth or auth,
@@ -229,7 +229,7 @@ class NinjaAPI:
         exclude_none: bool = False,
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
-    ) -> Decorator:
+    ) -> Callable[[TCallable], TCallable]:
         return self.default_router.put(
             path,
             auth=auth is NOT_SET and self.auth or auth,
@@ -265,7 +265,7 @@ class NinjaAPI:
         exclude_none: bool = False,
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
-    ) -> Decorator:
+    ) -> Callable[[TCallable], TCallable]:
         return self.default_router.api_operation(
             methods,
             path,

--- a/ninja/router.py
+++ b/ninja/router.py
@@ -14,7 +14,7 @@ from django.urls import URLPattern, path as django_path
 
 from ninja.constants import NOT_SET
 from ninja.operation import PathView
-from ninja.types import Decorator, TCallable
+from ninja.types import TCallable
 from ninja.utils import normalize_path
 
 if TYPE_CHECKING:
@@ -51,7 +51,7 @@ class Router:
         exclude_none: bool = False,
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
-    ) -> Decorator:
+    ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["GET"],
             path,
@@ -87,7 +87,7 @@ class Router:
         exclude_none: bool = False,
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
-    ) -> Decorator:
+    ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["POST"],
             path,
@@ -123,7 +123,7 @@ class Router:
         exclude_none: bool = False,
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
-    ) -> Decorator:
+    ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["DELETE"],
             path,
@@ -159,7 +159,7 @@ class Router:
         exclude_none: bool = False,
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
-    ) -> Decorator:
+    ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["PATCH"],
             path,
@@ -195,7 +195,7 @@ class Router:
         exclude_none: bool = False,
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
-    ) -> Decorator:
+    ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["PUT"],
             path,
@@ -232,7 +232,7 @@ class Router:
         exclude_none: bool = False,
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
-    ) -> Decorator:
+    ) -> Callable[[TCallable], TCallable]:
         def decorator(view_func: TCallable) -> TCallable:
             self.add_api_operation(
                 path,

--- a/ninja/types.py
+++ b/ninja/types.py
@@ -1,8 +1,12 @@
 from typing import Any, Callable, Dict, TypeVar
 
-__all__ = ["DictStrAny", "TCallable", "Decorator"]
+__all__ = ["DictStrAny", "TCallable"]
 
 DictStrAny = Dict[str, Any]
 
-TCallable = TypeVar("TCallable", bound=Callable)
-Decorator = Callable[[TCallable], TCallable]
+TCallable = TypeVar("TCallable", bound=Callable[..., Any])
+
+
+# unfortunately this doesn't work yet, see
+# https://github.com/python/mypy/issues/3924
+# Decorator = Callable[[TCallable], TCallable]


### PR DESCRIPTION
unfortunately the alias doesn't work

see e.g. https://github.com/python/mypy/issues/3924

```python
from typing import Any, Callable, TypeVar

TCallable = TypeVar("TCallable", bound=Callable[..., Any])
Decorator = Callable[[TCallable], TCallable]

def direct() -> Callable[[TCallable], TCallable]:
    ...

def alias() -> Decorator[TCallable]:
    ...

def half_alias() -> Decorator:
    ...

reveal_type(direct())
reveal_type(alias())
reveal_type(half_alias())
```

```bash
$ mypy --strict test.py

test.py:15:21: error: Missing type parameters for generic type "Decorator"
test.py:19:13: note: Revealed type is "def [TCallable <: def (*Any, **Any) -> Any] (TCallable`-1) -> TCallable`-1"
test.py:20:13: note: Revealed type is "def (<nothing>) -> <nothing>"
test.py:21:13: note: Revealed type is "def (Any) -> Any"
Found 1 error in 1 file (checked 1 source file)
```