### PR TITLE
Handle custom exceptions in _run_authentication

### DIFF
--- a/docs/docs/tutorial/authentication.md
+++ b/docs/docs/tutorial/authentication.md
@@ -163,3 +163,14 @@ or using router constructor
 ```Python
 router = Router(auth=BasicAuth())
 ```
+
+
+## Custom exceptions
+
+Raising an exception that has a exception handler will return the response from that handler in the same way a operation would:
+
+```Python hl_lines="1 4"
+{!./src/tutorial/authentication/bearer02.py!}
+```
+
+See [Handling errors](https://django-ninja.rest-framework.com/tutorial/errors/) for more information.

--- a/docs/src/tutorial/authentication/bearer02.py
+++ b/docs/src/tutorial/authentication/bearer02.py
@@ -1,0 +1,22 @@
+from ninja import NinjaAPI
+from ninja.security import HttpBearer
+
+api = NinjaAPI()
+
+class InvalidToken(Exception):
+    pass
+
+@api.exception_handler(InvalidToken)
+def on_invalid_token(request, exc):
+    return api.create_response(request, {"detail": "Invalid token supplied"}, status=401)
+
+class AuthBearer(HttpBearer):
+    def authenticate(self, request, token):
+        if token == "supersecret":
+            return token
+        raise InvalidToken
+
+
+@api.get("/bearer", auth=AuthBearer())
+def bearer(request):
+    return {"token": request.auth}

--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -132,7 +132,11 @@ class Operation:
 
     def _run_authentication(self, request: HttpRequest) -> Optional[HttpResponse]:
         for callback in self.auth_callbacks:
-            result = callback(request)
+            try:
+                result = callback(request)
+            except Exception as exc:
+                return self.api.on_exception(request, exc)
+
             if result:
                 request.auth = result  # type: ignore
                 return None


### PR DESCRIPTION
This small patch catches all exceptions raised by the authentication callback and lets `on_exception` handle them.
This allows us to raise custom exceptions and return different responses depending on what went wrong during authentication.

Ref: #141 

I also added response body checking to `test_auth` since we need to check that the custom response comes through.