### PR TITLE
Authentication AND/OR operators

### DIFF
--- a/docs/src/tutorial/authentication/multiple01.py
+++ b/docs/src/tutorial/authentication/multiple01.py
@@ -1,4 +1,4 @@
-from ninja.security import APIKeyQuery, APIKeyHeader
+from ninja.security import APIKeyQuery, APIKeyHeader, HttpBearer
 
 
 class AuthCheck:
@@ -15,6 +15,12 @@ class HeaderKey(AuthCheck, APIKeyHeader):
     pass
 
 
-@api.get("/multiple", auth=[QueryKey(), HeaderKey()])
+class AuthBearer(HttpBearer):
+    def authenticate(self, request, token):
+        if token == "anothersupersecret":
+            return token
+
+
+@api.get("/multiple", auth=(QueryKey() & HeaderKey()) | AuthBearer())
 def multiple(request):
     return f"Token = {request.auth}"

--- a/ninja/security/apikey.py
+++ b/ninja/security/apikey.py
@@ -13,11 +13,11 @@ class APIKeyBase(AuthBase, ABC):
     openapi_type: str = "apiKey"
     param_name: str = "key"
 
-    def __init__(self) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.openapi_name = self.param_name
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
-    def __call__(self, request: HttpRequest) -> Optional[Any]:
+    def callable(self, request: HttpRequest) -> Optional[Any]:
         key = self._get_key(request)
         return self.authenticate(request, key)
 

--- a/ninja/security/base.py
+++ b/ninja/security/base.py
@@ -14,7 +14,11 @@ class SecuritySchema(dict):
 
 
 class AuthBase(ABC):
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        and_neighbour: Optional["AuthBase"] = None,
+        or_neighbour: Optional["AuthBase"] = None,
+    ) -> None:
         if not hasattr(self, "openapi_type"):
             raise ConfigError("If you extend AuthBase you need to define openapi_type")
 
@@ -25,6 +29,25 @@ class AuthBase(ABC):
                 kwargs[name] = getattr(self, attr)
         self.openapi_security_schema = SecuritySchema(**kwargs)
 
-    @abstractmethod
+        self.and_neighbour = and_neighbour
+        self.or_neighbour = or_neighbour
+
     def __call__(self, request: HttpRequest) -> Optional[Any]:
+        left_operand = self.callable(request)
+        if self.and_neighbour:
+            right_operand = self.and_neighbour(request)
+            return left_operand if left_operand and right_operand else None
+        if self.or_neighbour:
+            right_operand = self.or_neighbour(request)
+            return left_operand if left_operand else right_operand
+        return self.callable(request)
+
+    @abstractmethod
+    def callable(self, request: HttpRequest) -> Optional[Any]:
         pass  # pragma: no cover
+
+    def __and__(self, another: "AuthBase") -> Any:
+        return type(self)(and_neighbour=another)
+
+    def __or__(self, another: "AuthBase") -> Any:
+        return type(self)(or_neighbour=another)

--- a/ninja/security/http.py
+++ b/ninja/security/http.py
@@ -24,7 +24,7 @@ class HttpBearer(HttpAuthBase, ABC):
     openapi_scheme: str = "bearer"
     header: str = "Authorization"
 
-    def __call__(self, request: HttpRequest) -> Optional[Any]:
+    def callable(self, request: HttpRequest) -> Optional[Any]:
         headers = get_headers(request)
         auth_value = headers.get(self.header)
         if not auth_value:
@@ -51,7 +51,7 @@ class HttpBasicAuth(HttpAuthBase, ABC):  # TODO: maybe HttpBasicAuthBase
     openapi_scheme = "basic"
     header = "Authorization"
 
-    def __call__(self, request: HttpRequest) -> Optional[Any]:
+    def callable(self, request: HttpRequest) -> Optional[Any]:
         headers = get_headers(request)
         auth_value = headers.get(self.header)
         if not auth_value:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -77,6 +77,10 @@ for path, auth in [
     ("apikeycookie", KeyCookie()),
     ("basic", BasicAuth()),
     ("bearer", BearerAuth()),
+    ("multiple", [BasicAuth(), BearerAuth()]),
+    ("multiple_or", BasicAuth() | BearerAuth()),
+    ("multiple_and", KeyHeader() & BasicAuth()),
+    ("complex_and_or", (KeyHeader() & BasicAuth()) & (KeyHeader() & BasicAuth())),
     ("customexception", KeyHeaderCustomException()),
 ]:
     api.get(f"/{path}", auth=auth, operation_id=path)(demo_operation)
@@ -110,6 +114,15 @@ BODY_UNAUTHORIZED_DEFAULT = dict(detail="Unauthorized")
         ("/basic", dict(headers={"Authorization": "some invalid value"}), 401, BODY_UNAUTHORIZED_DEFAULT),
         ("/bearer", {}, 401, BODY_UNAUTHORIZED_DEFAULT),
         ("/bearer", dict(headers={"Authorization": "Bearer bearertoken"}), 200, dict(auth="bearertoken")),
+        ("/multiple", dict(headers={"Authorization": "Bearer bearertoken"}), 200, dict(auth="bearertoken")),
+        ("/multiple", dict(headers={"Authorization": "YWRtaW46c2VjcmV0"}), 200, dict(auth="admin")),
+        ("/multiple_or", dict(headers={"Authorization": "YWRtaW46c2VjcmV0"}), 200, dict(auth="admin")),
+        ("/multiple_or", dict(headers={"Authorization": "Bearer bearertoken"}), 200, dict(auth="bearertoken")),
+        ("/multiple_or", dict(headers={"Authorization": "some invalid value"}), 401, BODY_UNAUTHORIZED_DEFAULT),
+        ("/multiple_and", dict(headers={"Authorization": "YWRtaW46c2VjcmV0", "key": "keyheadersecret"}), 200, dict(auth="keyheadersecret")),
+        ("/multiple_and", dict(headers={"Authorization": "YWRtaW46c2VjcmV0"}), 401, BODY_UNAUTHORIZED_DEFAULT),
+        ("/complex_and_or", dict(headers={"Authorization": "YWRtaW46c2VjcmV0", "key": "keyheadersecret"}), 200, dict(auth="keyheadersecret")),
+        ("/complex_and_or", dict(headers={"Authorization": "YWRtaW46c2VjcmV0", "key": "invalid"}), 401, BODY_UNAUTHORIZED_DEFAULT),
         ("/bearer", dict(headers={"Authorization": "Invalid bearertoken"}), 401, BODY_UNAUTHORIZED_DEFAULT),
         ("/customexception", {}, 401, dict(custom=True)),
         ("/customexception", dict(headers={"key": "keyheadersecret"}), 200, dict(auth="keyheadersecret")),
@@ -144,7 +157,7 @@ def test_invalid_setup():
     request.headers = headers
 
     class MyAuth1(AuthBase):
-        def __call__(self, *args, **kwargs):
+        def callable(self, *args, **kwargs):
             pass
 
     class MyAuth2(AuthBase):


### PR DESCRIPTION
That closes #196.

After merging this will be possible:

    @api.get(
        "/",
        auth=(Auth1() & Auth2()) | Auth3()),
    )
    def f(request):
        pass

What I don't like at this moment (marked are solved):

- [ ] `AuthBase.__call__` now is not abstractmethod, I used it for recursive descent. The previous method is called "`callable`" and it's not the best name.

- [ ] Swagger docs is not built for operators. Must be something like this: https://swagger.io/docs/specification/authentication/#multiple

- [x] Django-ninja docs aren't yet written.

- [ ] No clear error messages when trying to pair with "just callable".

The PR is in progress. Comments are welcome!