### PR TITLE
Format releases URL as a link

### DIFF
--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -2,5 +2,5 @@
 
 Follow and subscribe for new releases on GitHub:
 
-https://github.com/vitalik/django-ninja/releases
+<https://github.com/vitalik/django-ninja/releases>
 


### PR DESCRIPTION
The releases link is not formatted as Markdown link. This PR fixes that.

<img width="389" alt="Screenshot 2021-08-20 143211" src="https://user-images.githubusercontent.com/10340167/130278189-2509b27b-bae9-40f9-a9c4-cc40485cd8f3.png">
