### PR TITLE
 Allow NOT_SET to survive copy.deepcopy()

### DIFF
--- a/ninja/constants.py
+++ b/ninja/constants.py
@@ -1,5 +1,14 @@
-from typing import Any
+from typing import Any, Dict
 
 __all__ = ["NOT_SET"]
 
-NOT_SET: Any = object()
+
+class NOT_SET:
+    def __copy__(self) -> Any:
+        return NOT_SET
+
+    def __deepcopy__(self, memodict: Dict = {}) -> Any:
+        return NOT_SET
+
+
+NOT_SET: Any = NOT_SET()  # type: ignore  # noqa: F811

--- a/ninja/main.py
+++ b/ninja/main.py
@@ -65,7 +65,7 @@ class NinjaAPI:
         self._exception_handlers: Dict[Exc, ExcHandler] = {}
         self.set_default_exception_handlers()
 
-        self.auth: Optional[Sequence[Callable]] = NOT_SET
+        self.auth: Union[Sequence[Callable], Type[NOT_SET]] = NOT_SET
         if auth is not None and auth is not NOT_SET:
             self.auth = isinstance(auth, Sequence) and auth or [auth]  # type: ignore
 
@@ -294,7 +294,7 @@ class NinjaAPI:
         tags: Optional[List[str]] = None,
         parent_router: Router = None,
     ) -> None:
-        if auth != NOT_SET:
+        if auth is not NOT_SET:
             router.auth = auth
         if tags is not None:
             router.tags = tags

--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -66,7 +66,7 @@ class Operation:
         self.models: TModels = self.signature.models
 
         self.response_models: Dict[Any, Any]
-        if response == NOT_SET:
+        if response is NOT_SET:
             self.response_models = {200: NOT_SET}
         elif isinstance(response, dict):
             self.response_models = self._create_response_model_multiple(response)
@@ -176,7 +176,7 @@ class Operation:
                 f"Schema for status {status} is not set in response {self.response_models.keys()}"
             )
 
-        if response_model == NOT_SET:
+        if response_model is NOT_SET:
             return self.api.create_response(request, result, status=status)
 
         if response_model is None:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,9 +1,11 @@
+import copy
 import uuid
 
 import pytest
 from pydantic import BaseModel
 
 from ninja import NinjaAPI
+from ninja.constants import NOT_SET
 from ninja.signature.details import is_pydantic_model
 from ninja.signature.utils import NinjaUUIDConverter
 from ninja.testing import TestClient
@@ -48,3 +50,8 @@ def test_kwargs():
 def test_uuid_converter():
     conv = NinjaUUIDConverter()
     assert isinstance(conv.to_url(uuid.uuid4()), str)
+
+
+def test_copy_not_set():
+    assert id(NOT_SET) == id(copy.copy(NOT_SET))
+    assert id(NOT_SET) == id(copy.deepcopy(NOT_SET))


### PR DESCRIPTION
During testing it can be useful to use `deepcopy` on a router or an api, and in those cases it is necessary for the global singleton `NOT_SET` to be preserved.