### PR TITLE
Resolve #229 & #240 reporting dev errors under django dev-server

### DIFF
--- a/ninja/router.py
+++ b/ninja/router.py
@@ -13,6 +13,7 @@ from typing import (
 from django.urls import URLPattern, path as django_path
 
 from ninja.constants import NOT_SET
+from ninja.errors import ConfigError
 from ninja.operation import PathView
 from ninja.types import TCallable
 from ninja.utils import normalize_path
@@ -348,7 +349,13 @@ class Router:
             self._routers.append((prefix, router))
 
     def build_routers(self, prefix: str) -> List[Tuple[str, "Router"]]:
-        assert self.api is None
+        if self.api is not None:
+            from ninja.main import debug_server_url_reimport
+
+            if not debug_server_url_reimport():
+                raise ConfigError(
+                    f"Router@'{prefix}' has already been attached to API {self.api.title}:{self.api.version} "
+                )
         internal_routes = []
         for inter_prefix, inter_router in self._routers:
             _route = normalize_path("/".join((prefix, inter_prefix))).lstrip("/")

--- a/ninja/utils.py
+++ b/ninja/utils.py
@@ -1,9 +1,11 @@
+import inspect
 from typing import Callable, Optional
 
+from django.conf import settings
 from django.http import HttpRequest, HttpResponseForbidden
 from django.middleware.csrf import CsrfViewMiddleware
 
-__all__ = ["normalize_path", "check_csrf"]
+__all__ = ["check_csrf", "is_debug_server", "normalize_path"]
 
 
 def normalize_path(path: str) -> str:
@@ -19,3 +21,11 @@ def check_csrf(
     request.csrf_processing_done = False  # type: ignore
     mware.process_request(request)
     return mware.process_view(request, callback, (), {})
+
+
+def is_debug_server() -> bool:
+    """Check if running under the Django Debug Server"""
+    return settings.DEBUG and any(
+        s.filename.endswith("runserver.py") and s.function == "run"
+        for s in inspect.stack()[1:]
+    )

--- a/tests/demo_project/multi_param/urls.py
+++ b/tests/demo_project/multi_param/urls.py
@@ -1,5 +1,3 @@
-import copy
-
 from django.urls import path
 
 from ninja import NinjaAPI
@@ -7,8 +5,6 @@ from ninja import NinjaAPI
 from .api import router
 
 api_multi_param = NinjaAPI(version="1.0.1")
-router = copy.deepcopy(router)
-router.api = None
 api_multi_param.add_router("", router)
 
 urlpatterns = [

--- a/tests/test_api_instance.py
+++ b/tests/test_api_instance.py
@@ -1,4 +1,9 @@
+from unittest import mock
+
+import pytest
+
 from ninja import NinjaAPI, Router
+from ninja.errors import ConfigError
 
 api = NinjaAPI()
 router = Router()
@@ -23,3 +28,20 @@ def test_api_instance():
         for path_ops in rtr.path_operations.values():
             for op in path_ops.operations:
                 assert op.api is api
+
+
+def test_reuse_router_error():
+    test_api = NinjaAPI()
+    test_router = Router()
+    test_api.add_router("/", test_router)
+
+    # django debug server can attempt to import the urls twice when errors exist
+    # verify we get the correct error reported
+    match = "Router@'/another-path' has already been attached to API NinjaAPI:1.0.0"
+    with pytest.raises(ConfigError, match=match):
+        with mock.patch("ninja.main._imported_while_running_in_debug_server", False):
+            test_api.add_router("/another-path", test_router)
+
+    # The error should be ignored under debug server to allow other errors to be reported
+    with mock.patch("ninja.main._imported_while_running_in_debug_server", True):
+        test_api.add_router("/another-path", test_router)


### PR DESCRIPTION
Resolves #229 & #240

When Django loads urls it uses: `django.urls.resolvers.urlconf_module()`

```python
@cached_property
def urlconf_module(self):
    if isinstance(self.urlconf_name, str):
        return import_module(self.urlconf_name)
    else:
        return self.urlconf_name
```

This uses the @cached_property to generally only import once.  But if the import
throws an error when using the development server, the following code in
`django.utils.autoreload.BaseReloader.run()` is used:

```python
# Prevent a race condition where URL modules aren't loaded when the
# reloader starts by accessing the urlconf_module property.
try:
    get_resolver().urlconf_module
except Exception:
    # Loading the urlconf can result in errors during development.
    # If this occurs then swallow the error and continue.
    pass
```

This means the (likely) developer error that caused the Exception is initially ignored. This is
not generally a problem since the error will usually be exercised again, and reported at that
time.  But Ninja has various code which guards against errors where items that cannot be reused,
are attempted to be reused.  This results in Ninja throwing a false error, and hiding the
true error from the developer when running under the development server.