### PR TITLE
Make request object optional on view functions

### DIFF
--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -43,7 +43,7 @@ api = NinjaAPI()
 
 
 @api.get("/hello")
-def hello(request):
+def hello():
     return "Hello world"
 
 ```
@@ -107,3 +107,38 @@ If you need to handle multiple methods with a single function, you can use the `
 def mixed(request):
     ...
 ```
+
+## Passing the request object to the view
+
+Passing the request object to a view is optional.
+
+```python hl_lines="2"
+@api.get("/hello")
+def hello():
+    return "Hello world"
+```
+
+If passing in the request object is required it must be the first parameter.
+
+```python hl_lines="2"
+@api.get("/hello")
+def hello(request, user_name="World"):
+    return f"Hello {user_name}"
+```
+
+If the request object needs to be named something other than `request`, it must be typed
+as `django.http.HttpRequest` or one of its subclasses.
+
+
+```python hl_lines="4"
+from django.http import HttpRequest
+
+@api.get("/hello")
+def hello(a_param_not_named_request: HttpRequest, user_name="World"):
+    return f"Hello {user_name}"
+```
+
+!!! warning
+    Decorators may expect the request object to be passed into the view function.  If the
+    request is not present in decorated view's signature, the request will not be passed
+    to the view function, and may cause some hard to debug errors.

--- a/docs/src/tutorial/path/code01.py
+++ b/docs/src/tutorial/path/code01.py
@@ -1,3 +1,3 @@
 @api.get("/items/{item_id}")
-def read_item(request, item_id):
+def read_item(item_id):
     return {"item_id": item_id}

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -20,7 +20,7 @@ def test_is_pydantic_model():
 
 
 def test_client():
-    "covering evertying in testclient (includeing invalid paths)"
+    "covering everything in testclient (including invalid paths)"
     api = NinjaAPI()
     client = TestClient(api)
     with pytest.raises(Exception):

--- a/tests/test_request_param.py
+++ b/tests/test_request_param.py
@@ -1,0 +1,105 @@
+from typing import List
+from unittest.mock import Mock
+
+import pytest
+from django.http import HttpRequest
+
+from ninja import NinjaAPI, Query, Router
+from ninja.errors import ConfigError
+from ninja.testing import TestClient
+
+api = NinjaAPI()
+
+
+@api.post("/no-request")
+def no_request():
+    return {"result": None}
+
+
+@api.post("/no-request-args")
+def no_request_args(*args):
+    assert isinstance(args[0], Mock)
+    assert args[0].COOKIES == {}
+    return {"result": len(args)}
+
+
+@api.post("/request")
+def just_request(request):
+    assert request.COOKIES == {}
+    return {"result": None}
+
+
+@api.post("/request-args")
+def request_args(request, *args):
+    assert request.COOKIES == {}
+    assert len(args) == 0
+    return {"result": None}
+
+
+@api.post("/request-arg-args")
+def request_arg_args(request: HttpRequest, arg, *args):
+    assert request.COOKIES == {}
+    assert len(args) == 0
+    return {"result": arg}
+
+
+@api.post("/not-named-request-typed-arg")
+def not_named_request_typed_arg(not_named_request: HttpRequest, request):
+    assert not_named_request.COOKIES == {}
+    return {"result": request}
+
+
+@api.post("/no-request-arg-default")
+def no_request_arg_default(arg: int = 3):
+    return {"result": arg}
+
+
+@api.post("/no-request-arg-path/{arg}/")
+def no_request_arg_path(arg):
+    return {"result": arg}
+
+
+@api.post("/no-request-arg-typed")
+def no_request_arg_typed(arg: int):
+    return {"result": arg}
+
+
+@api.post("/no-request-arg-collection")
+def no_request_arg_collection(arg: List[int] = Query(...)):
+    return {"result": arg}
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    (
+        ("/no-request", {"result": None}),
+        ("/no-request-args", {"result": 1}),
+        ("/request", {"result": None}),
+        ("/request-args", {"result": None}),
+        ("/request-arg-args?arg=1", {"result": "1"}),
+        ("/not-named-request-typed-arg?request=2", {"result": "2"}),
+        ("/no-request-arg-default", {"result": 3}),
+        ("/no-request-arg-path/4/", {"result": "4"}),
+        ("/no-request-arg-typed?arg=5", {"result": 5}),
+        ("/no-request-arg-collection?arg=6&arg=7", {"result": [6, 7]}),
+    ),
+)
+def test_request_param(url, expected):
+    client = TestClient(api)
+    assert client.post(url).json() == expected
+
+
+def test_request_param_problems():
+    test_router = Router()
+    with pytest.raises(ConfigError, match="'request' param cannot have a default"):
+
+        @test_router.get("/path")
+        def request_default(request=2):
+            pass
+
+    match = "'request' param type 'int' is not a subclass of django.http.HttpRequest"
+    with pytest.warns(UserWarning, match=match):
+
+        @test_router.get("/path")
+        def request_wrong_type(request: int):
+            pass


### PR DESCRIPTION
A proposal (in the form of a Pull Request) for allowing request view params to be optional.

### Unchanged Behavior
- params in the first position, named "request" are not in the Schema Docs and are passed the request.

### Current Behavior (to be changed from):
- params in the first position, not named "request", are in the Schema Docs, but are actually passed the request, and if a param with a matching name is actually passed, causes an error.
- params not in the first position, named "request" are not in the Schema Docs, but are passed the param value named request.

### Proposed Behavior (to be changed to):
- params in the first position, not named "request", but annotated with HttpRequest, will be passed the request.
- params in the first position, not named "request" and not annotated with HttpRequest, are in the Schema Docs, and will be passed the matching param value.
- params not in the first position, named "request" are in the Schema Docs, and are passed the param value named request.
