### PR TITLE
Request optional

### DIFF
--- a/docs/docs/tutorial/index.md
+++ b/docs/docs/tutorial/index.md
@@ -43,7 +43,7 @@ api = NinjaAPI()
 
 
 @api.get("/hello")
-def hello(request):
+def hello():
     return "Hello world"
 
 ```
@@ -107,3 +107,38 @@ If you need to handle multiple methods with a single function, you can use the `
 def mixed(request):
     ...
 ```
+
+## Passing the request object to the view
+
+Passing the request object to a view is optional.
+
+```python hl_lines="2"
+@api.get("/hello")
+def hello():
+    return "Hello world"
+```
+
+If passing in the request object is required it must be the first parameter.
+
+```python hl_lines="2"
+@api.get("/hello")
+def hello(request, user_name="World"):
+    return f"Hello {user_name}"
+```
+
+If the request object needs to be named something other than `request`, it must be typed
+as `django.http.HttpRequest` or one of its subclasses.
+
+
+```python hl_lines="4"
+from django.http import HttpRequest
+
+@api.get("/hello")
+def hello(a_param_not_named_request: HttpRequest, user_name="World"):
+    return f"Hello {user_name}"
+```
+
+!!! warning
+    Decorators may expect the request object to be passed into the view function.  If the
+    request is not present in decorated view's signature, the request will not be passed
+    to the view function, and may cause some hard to debug errors.

--- a/docs/src/tutorial/path/code01.py
+++ b/docs/src/tutorial/path/code01.py
@@ -1,3 +1,3 @@
 @api.get("/items/{item_id}")
-def read_item(request, item_id):
+def read_item(item_id):
     return {"item_id": item_id}

--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -124,6 +124,9 @@ class OpenAPISchema(dict):
     def operation_parameters(self, operation: Operation) -> List[DictStrAny]:
         result = []
         for model in operation.models:
+            if model._param_source == "_request":
+                # Do not pass request params to OpenAPI schema
+                continue
             if model._param_source not in BODY_CONTENT_TYPES:
                 result.extend(self._extract_parameters(model))
         return result

--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -91,8 +91,8 @@ class Operation:
         if error:
             return error
         try:
-            passed_request, values = self._get_values(request, kw)
-            result = self.view_func(*passed_request, **values)
+            values = self._get_values(request, kw)
+            result = self.view_func(**values)
             return self._result_to_response(request, result)
         except Exception as e:
             if isinstance(e, TypeError) and "required positional argument" in str(e):
@@ -194,9 +194,7 @@ class Operation:
         )["response"]
         return self.api.create_response(request, result, status=status)
 
-    def _get_values(
-        self, request: HttpRequest, path_params: Any
-    ) -> Tuple[Tuple, DictStrAny]:
+    def _get_values(self, request: HttpRequest, path_params: Any) -> DictStrAny:
         values, errors = {}, []
         for model in self.models:
             try:
@@ -212,10 +210,7 @@ class Operation:
                 errors.extend(items)
         if errors:
             raise ValidationError(errors)
-        if self.signature.has_request:
-            return (request,), values
-        else:
-            return (), values
+        return values
 
     def _create_response_model_multiple(
         self, response_param: DictStrAny
@@ -246,8 +241,8 @@ class AsyncOperation(Operation):
         if error:
             return error
         try:
-            passed_request, values = self._get_values(request, kw)
-            result = await self.view_func(*passed_request, **values)
+            values = self._get_values(request, kw)
+            result = await self.view_func(**values)
             return self._result_to_response(request, result)
         except Exception as e:
             return self.api.on_exception(request, e)

--- a/ninja/params.py
+++ b/ninja/params.py
@@ -83,3 +83,7 @@ class File(Param):
 class _MultiPartBody(Param):
     _model = params_models._MultiPartBodyModel
     _param_source = Body._param_source
+
+
+class _Request(Param):
+    _model = params_models._RequestModel

--- a/ninja/params_models.py
+++ b/ninja/params_models.py
@@ -185,3 +185,12 @@ class _MultiPartBodyModel(BodyModel):
                 req.body = data.encode()
                 results[name] = get_request_data(req, api, path_params)
         return results
+
+
+class _RequestModel(ParamModel):
+    @classmethod
+    def get_request_data(
+        cls, request: HttpRequest, api: "NinjaAPI", path_params: DictStrAny
+    ) -> Optional[DictStrAny]:
+        varname = getattr(cls, "_single_attr", None)
+        return {varname: request}

--- a/ninja/signature/details.py
+++ b/ninja/signature/details.py
@@ -186,7 +186,6 @@ class ViewSignature:
         # _EMPTY = self.signature.empty
         annotation = arg.annotation
 
-        print(" !!!! ", self.signature, name, pos, annotation)
         if self._is_http_request_arg(pos, name, arg):
             annotation = HttpRequest
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -20,7 +20,7 @@ def test_is_pydantic_model():
 
 
 def test_client():
-    "covering evertying in testclient (includeing invalid paths)"
+    "covering everything in testclient (including invalid paths)"
     api = NinjaAPI()
     client = TestClient(api)
     with pytest.raises(Exception):

--- a/tests/test_request_param.py
+++ b/tests/test_request_param.py
@@ -1,0 +1,105 @@
+from typing import List
+from unittest.mock import Mock
+
+import pytest
+from django.http import HttpRequest
+
+from ninja import NinjaAPI, Query, Router
+from ninja.errors import ConfigError
+from ninja.testing import TestClient
+
+api = NinjaAPI()
+
+
+@api.post("/no-request")
+def no_request():
+    return {"result": None}
+
+
+@api.post("/no-request-args")
+def no_request_args(*args):
+    assert isinstance(args[0], Mock)
+    assert args[0].COOKIES == {}
+    return {"result": len(args)}
+
+
+@api.post("/request")
+def just_request(request):
+    assert request.COOKIES == {}
+    return {"result": None}
+
+
+@api.post("/request-args")
+def request_args(request, *args):
+    assert request.COOKIES == {}
+    assert len(args) == 0
+    return {"result": None}
+
+
+@api.post("/request-arg-args")
+def request_arg_args(request: HttpRequest, arg, *args):
+    assert request.COOKIES == {}
+    assert len(args) == 0
+    return {"result": arg}
+
+
+@api.post("/not-named-request-typed-arg")
+def not_named_request_typed_arg(not_named_request: HttpRequest, request):
+    assert not_named_request.COOKIES == {}
+    return {"result": request}
+
+
+@api.post("/no-request-arg-default")
+def no_request_arg_default(arg: int = 3):
+    return {"result": arg}
+
+
+@api.post("/no-request-arg-path/{arg}/")
+def no_request_arg_path(arg):
+    return {"result": arg}
+
+
+@api.post("/no-request-arg-typed")
+def no_request_arg_typed(arg: int):
+    return {"result": arg}
+
+
+@api.post("/no-request-arg-collection")
+def no_request_arg_collection(arg: List[int] = Query(...)):
+    return {"result": arg}
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    (
+        ("/no-request", {"result": None}),
+        ("/no-request-args", {"result": 1}),
+        ("/request", {"result": None}),
+        ("/request-args", {"result": None}),
+        ("/request-arg-args?arg=1", {"result": "1"}),
+        ("/not-named-request-typed-arg?request=2", {"result": "2"}),
+        ("/no-request-arg-default", {"result": 3}),
+        ("/no-request-arg-path/4/", {"result": "4"}),
+        ("/no-request-arg-typed?arg=5", {"result": 5}),
+        ("/no-request-arg-collection?arg=6&arg=7", {"result": [6, 7]}),
+    ),
+)
+def test_request_param(url, expected):
+    client = TestClient(api)
+    assert client.post(url).json() == expected
+
+
+def test_request_param_problems():
+    test_router = Router()
+    with pytest.raises(ConfigError, match="'request' param cannot have a default"):
+
+        @test_router.get("/path")
+        def request_default(request=2):
+            pass
+
+    match = "'request' param type 'int' is not a subclass of django.http.HttpRequest"
+    with pytest.warns(UserWarning, match=match):
+
+        @test_router.get("/path")
+        def request_wrong_type(request: int):
+            pass

--- a/tests/test_wraps.py
+++ b/tests/test_wraps.py
@@ -31,9 +31,13 @@ def a_bad_test_wrapper(f):
 
 @router.get("/text")
 @a_good_test_wrapper
-def get_text(
-    request,
-):
+def get_text(request):
+    return "Hello World"
+
+
+@router.get("/text-no-request")
+@a_good_test_wrapper
+def get_text_no_request():
     return "Hello World"
 
 
@@ -58,6 +62,12 @@ def get_query_id(request, item_id, query: int):
 @router.get("/text-bad")
 @a_bad_test_wrapper
 def get_text_bad(request):
+    return "Hello World"
+
+
+@router.get("/text-bad-no-request")
+@a_bad_test_wrapper
+def get_text_bad_no_request():
     return "Hello World"
 
 
@@ -87,10 +97,12 @@ with mock.patch("ninja.signature.details.warnings.warn_explicit"):
     "path,expected_status,expected_response",
     [
         ("/text", 200, "Hello World"),
+        ("/text-no-request", 200, "Hello World"),
         ("/path/id", 200, "id"),
         ("/query?query=1", 200, "foo bar 1"),
         ("/path-query/id?query=2", 200, "foo bar id 2"),
-        ("/text-bad", 200, "Hello World"),  # no params so passes
+        ("/text-bad-no-request", 200, "Hello World"),  # no params so passes
+        ("/text-bad", 200, TypeError),
         ("/path-bad/id", None, TypeError),
         ("/query-bad?query=1", None, TypeError),
         ("/path-query-bad/id?query=2", None, TypeError),


### PR DESCRIPTION
Making `request` argument not required

automatically detecting http request argument if:
 - it's a **first** argument AND it's **not annotated** AND **does not have default** value
 - it's annotated with HttpRequest class
 
in all other cases `request` argument will act as any other parameter