### PR TITLE
Fix: Fix typo in proposals/v1.md doc

### DIFF
--- a/docs/docs/proposals/v1.md
+++ b/docs/docs/proposals/v1.md
@@ -2,9 +2,11 @@
 
 Django Ninja is already used by tens of companies and by the visitors and downloads stats it's growing.
 
-At this point intorducing changes that will force current users to change their code (or break it) is not acceptable.
+At this point introducing changes that will force current users to change their code (or break it) is not 
+acceptable.
 
-On the other hand some decisions that where initally made does not work well. These  breaking changes will be introduced in version 1.0.0
+On the other hand some decisions that where initially made does not work well. These  breaking changes will be 
+introduced in version 1.0.0
 
 ## Changes that most likely be in v1
 


### PR DESCRIPTION
Hello, I found some typo in proposals/v1.md doc and fixed it 😄 

1. `intorducing` -> `introducing`
2. `initally` -> `initially`

Thank you 😄 
