### PR TITLE
Add support for union type in payload

### DIFF
--- a/ninja/compatibility/util.py
+++ b/ninja/compatibility/util.py
@@ -1,12 +1,16 @@
 from typing import Any, Optional
 
 try:
-    from typing import get_origin  # type: ignore
+    from typing import get_args, get_origin  # type: ignore
 except ImportError:  # pragma: no coverage
 
     def get_origin(tp: Any) -> Optional[Any]:
         "typing.get_origin introduced in python3.8"
         return getattr(tp, "__origin__", None)
 
+    def get_args(tp: Any) -> Optional[Any]:
+        "typing.get_args introduced in python3.8"
+        return getattr(tp, "__args__", None)
 
-__all__ = ["get_origin"]
+
+__all__ = ["get_origin", "get_args"]

--- a/ninja/signature/details.py
+++ b/ninja/signature/details.py
@@ -1,12 +1,12 @@
 import inspect
 import warnings
 from collections import defaultdict, namedtuple
-from typing import Any, Callable, Dict, Generator, List, Tuple
+from typing import Any, Callable, Dict, Generator, List, Tuple, Union
 
 import pydantic
 
 from ninja import UploadedFile, params
-from ninja.compatibility.util import get_origin as get_collection_origin
+from ninja.compatibility.util import get_args, get_origin as get_collection_origin
 from ninja.errors import ConfigError
 from ninja.params import Body, File, Form, _MultiPartBody
 from ninja.params_models import TModel, TModels
@@ -241,6 +241,8 @@ class ViewSignature:
 
 def is_pydantic_model(cls: Any) -> bool:
     try:
+        if get_collection_origin(cls) == Union:
+            return all(issubclass(arg, pydantic.BaseModel) for arg in get_args(cls))
         return issubclass(cls, pydantic.BaseModel)
     except TypeError:
         return False


### PR DESCRIPTION
@vitalik This MR adds support for defining a request body as a union of two schemas. 

Prior to this change, a payload with the union type would be incorrectly classified as a query parameter, and fail to appear within the list of components defined in the OpenAPI schema