### PR TITLE
Improve TestClient json argument-serialization

### DIFF
--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -123,8 +123,12 @@ class NinjaClientBase:
             request.POST = data
         else:
             request.POST = QueryDict(mutable=True)
-            for k, v in data.items():
-                request.POST[k] = v
+
+            if isinstance(data, (str, bytes)):
+                request_params['body'] = data
+            elif data:
+                for k, v in data.items():
+                    request.POST[k] = v
 
         if "?" in path:
             request.GET = QueryDict(path.split("?")[1])

--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -7,7 +7,7 @@ import django
 from django.http import QueryDict, StreamingHttpResponse
 
 from ninja import NinjaAPI, Router
-from ninja.responses import Response as HttpResponse
+from ninja.responses import Response as HttpResponse, NinjaJSONEncoder
 
 
 def build_absolute_uri(location: Optional[str] = None) -> str:
@@ -61,7 +61,7 @@ class NinjaClientBase:
         **request_params: Any,
     ) -> "NinjaResponse":
         if json is not None:
-            request_params["body"] = json_dumps(json)
+            request_params["body"] = json_dumps(json, cls=NinjaJSONEncoder)
         func, request, kwargs = self._resolve(method, path, data, request_params)
         return self._call(func, request, kwargs)  # type: ignore
 

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -78,3 +78,12 @@ def test_schema_as_data():
         client.post("/test", json=schema_instance)
         request = call.call_args[0][1]
         assert ClientTestSchema.parse_raw(request.body).json() == schema_instance.json()
+
+
+def test_json_as_body():
+    schema_instance = ClientTestSchema(time=timezone.now().replace(microsecond=0))
+
+    with mock.patch.object(client, "_call") as call:
+        client.post("/test", data=schema_instance.json(), content_type='application/json')
+        request = call.call_args[0][1]
+        assert ClientTestSchema.parse_raw(request.body).json() == schema_instance.json()

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -1,9 +1,12 @@
+from datetime import datetime
 from http import HTTPStatus
 from unittest import mock
 
 import pytest
+from django.utils import timezone
 
 from ninja import Router
+from ninja.schema import Schema
 from ninja.testing import TestClient
 
 router = Router()
@@ -61,3 +64,17 @@ def test_django_2_2_plus_headers(version, has_headers):
             request = call.call_args[0][1]
             # for Django >= 2.2 we apply a HttpHeaders instance to .headers
             assert isinstance(request.headers, mock.Mock) != has_headers
+
+
+class ClientTestSchema(Schema):
+
+    time: datetime
+
+
+def test_schema_as_data():
+    schema_instance = ClientTestSchema(time=timezone.now().replace(microsecond=0))
+
+    with mock.patch.object(client, "_call") as call:
+        client.post("/test", json=schema_instance)
+        request = call.call_args[0][1]
+        assert ClientTestSchema.parse_raw(request.body).json() == schema_instance.json()


### PR DESCRIPTION
I made some incorrect assumptions about the `TestClient` arguments when I tried to use it after using Djangos and DRFs test clients. These commits tries to improve using it:

* Use the NinjaJsonEncoder when serializing the json-parameter to allow passing a Schema directly to the TestClient-methods, and also serializing datetime objects using the parent DjangoJSONEncoder.
  E.g. `client.post('/my-path/', json=SomeSchema(foo=1, bar=2))`, `client.post('/my-path/', json={'now': timezone.now()})`
* Allow passing serialized json as the body-argument for TestClient request-methods for better consistency with the Django test client