### PR TITLE
Smarter schema that handles dotted aliases and resolver methods

### DIFF
--- a/docs/docs/tutorial/response-schema.md
+++ b/docs/docs/tutorial/response-schema.md
@@ -145,18 +145,28 @@ class TaskSchema(Schema):
 You can also create calculated fields via resolve methods based on the field
 name.
 
-```Python hl_lines="5 7-11" 
+The method must accept a single argument, which will be the object the schema
+is resolving against.
+
+When creating a resolver as a standard method, `self` gives you access to other
+validated and formatted attributes in the schema.
+
+```Python hl_lines="5 7-11"
 class TaskSchema(Schema):
     id: int
     title: str
     is_completed: bool
     owner: Optional[str]
+    lower_title: str
 
     @staticmethod
     def resolve_owner(obj):
         if not obj.owner:
             return
         return f"{obj.owner.first_name} {obj.owner.last_name}"
+
+    def resolve_lower_title(self, obj):
+        return self.title.lower()
 ```
 
 

--- a/ninja/orm/metaclass.py
+++ b/ninja/orm/metaclass.py
@@ -1,16 +1,15 @@
 from typing import no_type_check
 
 from django.db.models import Model as DjangoModel
-from pydantic.main import ModelMetaclass
 
 from ninja.errors import ConfigError
 from ninja.orm.factory import create_schema
-from ninja.schema import Schema
+from ninja.schema import ResolverMetaclass, Schema
 
 _is_modelschema_class_defined = False
 
 
-class ModelSchemaMetaclass(ModelMetaclass):
+class ModelSchemaMetaclass(ResolverMetaclass):
     @no_type_check
     def __new__(
         mcs,

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -128,6 +128,12 @@ class ResolverMetaclass(ModelMetaclass):
         for attr, resolve_func in namespace.items():
             if not attr.startswith("resolve_"):
                 continue
+            if (
+                not callable(resolve_func)
+                # A staticmethod isn't directly callable in Python <=3.9.
+                and not isinstance(resolve_func, staticmethod)
+            ):
+                continue
             resolvers[attr[8:]] = Resolver(resolve_func)
 
         result = super().__new__(cls, name, bases, namespace, **kwargs)

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -1,4 +1,24 @@
-from typing import Any
+"""
+Since "Model" word would be very confusing when used in django context, this
+module basically makes an alias for it named "Schema" and adds extra whistles to
+be able to work with django querysets and managers.
+
+The schema is a bit smarter than a standard pydantic Model because it can handle
+dotted attributes and resolver methods. For example::
+
+
+    class UserSchema(User):
+        name: str
+        initials: str
+        boss: str = Field(None, alias="boss.name")
+
+        @staticmethod
+        def resolve_initials(obj):
+            return "".join(n[:1] for n in obj.name.split())
+
+"""
+from operator import attrgetter
+from typing import Any, Type
 
 import pydantic
 from django.db.models import Manager, QuerySet
@@ -12,15 +32,31 @@ assert pydantic_version >= [1, 6], "Pydantic 1.6+ required"
 __all__ = ["BaseModel", "Field", "validator", "DjangoGetter", "Schema"]
 
 
-# Since "Model" word would be very confusing when used in django context
-# this module basically makes alias for it named "Schema"
-# and ads extra whistles to be able to work with django querysets and managers
-
-
 class DjangoGetter(GetterDict):
-    def get(self, key: Any, default: Any = None) -> Any:
-        result = super().get(key, default)
+    __slots__ = ("_obj", "_cls")
 
+    def __init__(self, obj: Any, cls: "Type[Schema]" = None):
+        self._obj = obj
+        self._cls = cls
+
+    def __getitem__(self, key: str) -> Any:
+        resolve_func = getattr(self._cls, f"resolve_{key}", None) if self._cls else None
+        if resolve_func and callable(resolve_func):
+            item = resolve_func(self._obj)
+        else:
+            try:
+                item = attrgetter(key)(self._obj)
+            except AttributeError as e:
+                raise KeyError(key) from e
+        return self.format_result(item)
+
+    def get(self, key: Any, default: Any = None) -> Any:
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def format_result(self, result: Any) -> Any:
         if isinstance(result, Manager):
             return list(result.all())
 
@@ -39,3 +75,23 @@ class Schema(BaseModel):
     class Config:
         orm_mode = True
         getter_dict = DjangoGetter
+
+    @classmethod
+    def from_orm(cls: Type["Schema"], obj: Any) -> "Schema":
+        # DjangoGetter also needs the class so it can find resolver methods.
+        if not isinstance(obj, GetterDict):
+            getter_dict = cls.__config__.getter_dict
+            obj = (
+                getter_dict(obj, cls)
+                if issubclass(getter_dict, DjangoGetter)
+                else getter_dict(obj)
+            )
+        return super().from_orm(obj)
+
+    @classmethod
+    def _decompose_class(cls, obj: Any) -> GetterDict:
+        # This method has backported logic from Pydantic 1.9 and is no longer
+        # needed once that is the minimum version.
+        if isinstance(obj, GetterDict):
+            return obj
+        return super()._decompose_class(obj)

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -45,9 +45,12 @@ class DjangoGetter(GetterDict):
             item = resolve_func(self._obj)
         else:
             try:
-                item = attrgetter(key)(self._obj)
-            except AttributeError as e:
-                raise KeyError(key) from e
+                item = getattr(self._obj, key)
+            except AttributeError:
+                try:
+                    item = attrgetter(key)(self._obj)
+                except AttributeError as e:
+                    raise KeyError(key) from e
         return self.format_result(item)
 
     def get(self, key: Any, default: Any = None) -> Any:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -43,7 +43,7 @@ class User:
     name = "John Smith"
     group_set = FakeManager([1, 2, 3])
     avatar = ImageFieldFile(None, Mock(), name=None)
-    boss = Boss()
+    boss: Optional[Boss] = Boss()
 
     @property
     def tags(self):
@@ -68,10 +68,14 @@ class UserWithBossSchema(UserSchema):
 
 class UserWithInitialsSchema(UserSchema):
     initials: str
+    has_boss: bool
+
+    def resolve_initials(self, obj):
+        return "".join(n[:1] for n in self.name.split())
 
     @staticmethod
-    def resolve_initials(obj):
-        return "".join(n[:1] for n in obj.name.split())
+    def resolve_has_boss(obj):
+        return bool(obj.boss)
 
 
 def test_schema():
@@ -128,6 +132,7 @@ def test_with_initials_schema():
     assert schema.dict() == {
         "name": "John Smith",
         "initials": "JS",
+        "has_boss": True,
         "groups": [1, 2, 3],
         "tags": [{"id": "1", "title": "foo"}, {"id": "2", "title": "bar"}],
         "avatar": None,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -64,18 +64,18 @@ class UserSchema(Schema):
 
 class UserWithBossSchema(UserSchema):
     boss: Optional[str] = Field(None, alias="boss.name")
-
-
-class UserWithInitialsSchema(UserSchema):
-    initials: str
     has_boss: bool
-
-    def resolve_initials(self, obj):
-        return "".join(n[:1] for n in self.name.split())
 
     @staticmethod
     def resolve_has_boss(obj):
         return bool(obj.boss)
+
+
+class UserWithInitialsSchema(UserWithBossSchema):
+    initials: str
+
+    def resolve_initials(self, obj):
+        return "".join(n[:1] for n in self.name.split())
 
 
 def test_schema():
@@ -109,6 +109,7 @@ def test_with_boss_schema():
     assert schema.dict() == {
         "name": "John Smith",
         "boss": "Jane Jackson",
+        "has_boss": True,
         "groups": [1, 2, 3],
         "tags": [{"id": "1", "title": "foo"}, {"id": "2", "title": "bar"}],
         "avatar": None,
@@ -120,6 +121,7 @@ def test_with_boss_schema():
     assert schema.dict() == {
         "name": "John Smith",
         "boss": None,
+        "has_boss": False,
         "groups": [1, 2, 3],
         "tags": [{"id": "1", "title": "foo"}, {"id": "2", "title": "bar"}],
         "avatar": None,
@@ -132,6 +134,7 @@ def test_with_initials_schema():
     assert schema.dict() == {
         "name": "John Smith",
         "initials": "JS",
+        "boss": "Jane Jackson",
         "has_boss": True,
         "groups": [1, 2, 3],
         "tags": [{"id": "1", "title": "foo"}, {"id": "2", "title": "bar"}],


### PR DESCRIPTION
Fixes #291 (even though it was closed) and fixes #250 and adds in new functionality to allow calculated fields via `resolve_` static methods on the response schema class.

Includes tests and docs.