### PR TITLE
Fix params descriptions visualization in swagger ui

### DIFF
--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -151,6 +151,11 @@ class OpenAPISchema(dict):
                     "schema": p_schema,
                     "required": p_required,
                 }
+
+                # copy description from schema description to param description
+                if "description" in p_schema:
+                    param["description"] = p_schema["description"]
+
                 result.append(param)
 
         return result

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -88,6 +88,7 @@ def test_schema():
     assert room_param == {
         "in": "query",
         "name": "room",
+        "description": "An enumeration.",
         "required": True,
         "schema": {
             "title": "RoomEnum",

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -544,6 +544,7 @@ def test_schema_title_description(schema):
         {
             "in": "query",
             "name": "param2",
+            "description": "param 2 desc",
             "required": False,
             "schema": {
                 "default": "A Default",

--- a/tests/test_with_django/schema_fixtures/test-multi-cookie.json
+++ b/tests/test_with_django/schema_fixtures/test-multi-cookie.json
@@ -25,6 +25,7 @@
       {
         "in": "cookie",
         "name": "foo4",
+        "description": "Foo4 Desc",
         "schema": {
           "title": "Foo4 Title",
           "description": "Foo4 Desc",
@@ -65,6 +66,7 @@
       {
         "in": "cookie",
         "name": "foo2",
+        "description": "Foo2 Desc",
         "schema": {
           "title": "Foo2 Title",
           "description": "Foo2 Desc",
@@ -85,6 +87,7 @@
       {
         "in": "cookie",
         "name": "foo3",
+        "description": "Foo3 Desc",
         "schema": {
           "title": "Foo3 Title",
           "description": "Foo3 Desc",

--- a/tests/test_with_django/schema_fixtures/test-multi-header.json
+++ b/tests/test_with_django/schema_fixtures/test-multi-header.json
@@ -25,6 +25,7 @@
       {
         "in": "header",
         "name": "foo4",
+        "description": "Foo4 Desc",
         "schema": {
           "title": "Foo4 Title",
           "description": "Foo4 Desc",
@@ -65,6 +66,7 @@
       {
         "in": "header",
         "name": "foo2",
+        "description": "Foo2 Desc",
         "schema": {
           "title": "Foo2 Title",
           "description": "Foo2 Desc",
@@ -85,6 +87,7 @@
       {
         "in": "header",
         "name": "foo3",
+        "description": "Foo3 Desc",
         "schema": {
           "title": "Foo3 Title",
           "description": "Foo3 Desc",

--- a/tests/test_with_django/schema_fixtures/test-multi-path.json
+++ b/tests/test_with_django/schema_fixtures/test-multi-path.json
@@ -25,6 +25,7 @@
       {
         "in": "path",
         "name": "foo4",
+        "description": "Foo4 Desc",
         "schema": {
           "title": "Foo4 Title",
           "description": "Foo4 Desc",
@@ -65,6 +66,7 @@
       {
         "in": "path",
         "name": "foo2",
+        "description": "Foo2 Desc",
         "schema": {
           "title": "Foo2 Title",
           "description": "Foo2 Desc",
@@ -85,6 +87,7 @@
       {
         "in": "path",
         "name": "foo3",
+        "description": "Foo3 Desc",
         "schema": {
           "title": "Foo3 Title",
           "description": "Foo3 Desc",

--- a/tests/test_with_django/schema_fixtures/test-multi-query.json
+++ b/tests/test_with_django/schema_fixtures/test-multi-query.json
@@ -25,6 +25,7 @@
       {
         "in": "query",
         "name": "foo4",
+        "description": "Foo4 Desc",
         "schema": {
           "title": "Foo4 Title",
           "description": "Foo4 Desc",
@@ -65,6 +66,7 @@
       {
         "in": "query",
         "name": "foo2",
+        "description": "Foo2 Desc",
         "schema": {
           "title": "Foo2 Title",
           "description": "Foo2 Desc",
@@ -85,6 +87,7 @@
       {
         "in": "query",
         "name": "foo3",
+        "description": "Foo3 Desc",
         "schema": {
           "title": "Foo3 Title",
           "description": "Foo3 Desc",


### PR DESCRIPTION
This pull request fixes the visualization of params descriptions in swagger docs #326 #322 

The solution approach was to copy the description obtained from the schema to the top-level param dictionary.