### PR TITLE
First key derivation optimization

### DIFF
--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -161,7 +161,7 @@ class Operation:
 
         status: int = 200
         if len(self.response_models) == 1:
-            status = list(self.response_models.keys())[0]
+            status = next(iter(self.response_models))
 
         if isinstance(result, tuple) and len(result) == 2:
             status = result[0]


### PR DESCRIPTION
Hi. 

This is a small change to get the first key faster.

```python
import timeit


print(timeit.timeit('next(iter(response_models))', setup='response_models = {200: "blabla"}'))
# 0.095
print(timeit.timeit('list(response_models.keys())[0]', setup='response_models = {200: "blabla"}'))
# 0.216
```