### PR TITLE
[feat] add superuser session authentication only

### DIFF
--- a/ninja/security/__init__.py
+++ b/ninja/security/__init__.py
@@ -1,6 +1,6 @@
 from ninja.security.apikey import APIKeyCookie, APIKeyHeader, APIKeyQuery
 from ninja.security.http import HttpBasicAuth, HttpBearer
-from ninja.security.session import SessionAuth
+from ninja.security.session import SessionAuth, SessionAuthSuperUser
 
 __all__ = [
     "APIKeyCookie",
@@ -9,7 +9,9 @@ __all__ = [
     "HttpBasicAuth",
     "HttpBearer",
     "SessionAuth",
+    "SessionAuthSuperUser",
     "django_auth",
 ]
 
 django_auth = SessionAuth()
+django_auth_superuser = SessionAuthSuperUser()

--- a/ninja/security/session.py
+++ b/ninja/security/session.py
@@ -24,7 +24,7 @@ class SessionAuthSuperUser(APIKeyCookie):
     param_name: str = settings.SESSION_COOKIE_NAME
 
     def authenticate(self, request: HttpRequest, key: Optional[str]) -> Optional[Any]:
-        if request.user.is_authenticated and request.user.is_superuser:
+        if request.user.is_authenticated and getattr(request.user, 'is_superuser', None):
             return request.user
 
         return None

--- a/ninja/security/session.py
+++ b/ninja/security/session.py
@@ -24,7 +24,8 @@ class SessionAuthSuperUser(APIKeyCookie):
     param_name: str = settings.SESSION_COOKIE_NAME
 
     def authenticate(self, request: HttpRequest, key: Optional[str]) -> Optional[Any]:
-        if request.user.is_authenticated and getattr(request.user, 'is_superuser', None):
+        is_superuser = getattr(request.user, "is_superuser", None)
+        if request.user.is_authenticated and is_superuser:
             return request.user
 
         return None

--- a/ninja/security/session.py
+++ b/ninja/security/session.py
@@ -5,7 +5,7 @@ from django.http import HttpRequest
 
 from ninja.security.apikey import APIKeyCookie
 
-__all__ = ["SessionAuth"]
+__all__ = ["SessionAuth", "SessionAuthSuperUser"]
 
 
 class SessionAuth(APIKeyCookie):
@@ -14,6 +14,17 @@ class SessionAuth(APIKeyCookie):
 
     def authenticate(self, request: HttpRequest, key: Optional[str]) -> Optional[Any]:
         if request.user.is_authenticated:
+            return request.user
+
+        return None
+
+
+class SessionAuthSuperUser(APIKeyCookie):
+    "Reusing Django session authentication & verify that the user is a super user"
+    param_name: str = settings.SESSION_COOKIE_NAME
+
+    def authenticate(self, request: HttpRequest, key: Optional[str]) -> Optional[Any]:
+        if request.user.is_authenticated and request.user.is_superuser:
             return request.user
 
         return None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -112,7 +112,7 @@ BODY_UNAUTHORIZED_DEFAULT = dict(detail="Unauthorized")
         ("/django_auth_superuser", {}, 401, BODY_UNAUTHORIZED_DEFAULT),
         (
             "/django_auth_superuser",
-            dict(user=MockSuperUser("admin")),
+            dict(user=MockUser("admin")),
             401,
             BODY_UNAUTHORIZED_DEFAULT,
         ),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -11,6 +11,7 @@ from ninja.security import (
     HttpBasicAuth,
     HttpBearer,
     django_auth,
+    django_auth_superuser
 )
 from ninja.security.base import AuthBase
 from ninja.testing import TestClient
@@ -75,6 +76,7 @@ def on_custom_error(request, exc):
 
 for path, auth in [
     ("django_auth", django_auth),
+    ("django_auth_superuser", django_auth_superuser),
     ("callable", callable_auth),
     ("apikeyquery", KeyQuery()),
     ("apikeyheader", KeyHeader()),
@@ -91,6 +93,12 @@ client = TestClient(api)
 
 class MockUser(str):
     is_authenticated = True
+    is_superuser = False
+
+
+class MockSuperUser(str):
+    is_authenticated = True
+    is_superuser = True
 
 
 BODY_UNAUTHORIZED_DEFAULT = dict(detail="Unauthorized")
@@ -101,6 +109,9 @@ BODY_UNAUTHORIZED_DEFAULT = dict(detail="Unauthorized")
     [
         ("/django_auth", {}, 401, BODY_UNAUTHORIZED_DEFAULT),
         ("/django_auth", dict(user=MockUser("admin")), 200, dict(auth="admin")),
+        ("/django_auth_superuser", {}, 401, BODY_UNAUTHORIZED_DEFAULT),
+        ("/django_auth_superuser", dict(user=MockUser("admin")), 401, BODY_UNAUTHORIZED_DEFAULT),
+        ("/django_auth_superuser", dict(user=MockSuperUser("admin")), 200, dict(auth="admin")),
         ("/callable", {}, 401, BODY_UNAUTHORIZED_DEFAULT),
         ("/callable?auth=demo", {}, 200, dict(auth="demo")),
         ("/apikeyquery", {}, 401, BODY_UNAUTHORIZED_DEFAULT),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -11,7 +11,7 @@ from ninja.security import (
     HttpBasicAuth,
     HttpBearer,
     django_auth,
-    django_auth_superuser
+    django_auth_superuser,
 )
 from ninja.security.base import AuthBase
 from ninja.testing import TestClient
@@ -110,8 +110,18 @@ BODY_UNAUTHORIZED_DEFAULT = dict(detail="Unauthorized")
         ("/django_auth", {}, 401, BODY_UNAUTHORIZED_DEFAULT),
         ("/django_auth", dict(user=MockUser("admin")), 200, dict(auth="admin")),
         ("/django_auth_superuser", {}, 401, BODY_UNAUTHORIZED_DEFAULT),
-        ("/django_auth_superuser", dict(user=MockUser("admin")), 401, BODY_UNAUTHORIZED_DEFAULT),
-        ("/django_auth_superuser", dict(user=MockSuperUser("admin")), 200, dict(auth="admin")),
+        (
+            "/django_auth_superuser",
+            dict(user=MockUser("admin")),
+            401,
+            BODY_UNAUTHORIZED_DEFAULT,
+        ),
+        (
+            "/django_auth_superuser",
+            dict(user=MockSuperUser("admin")),
+            200,
+            dict(auth="admin"),
+        ),
         ("/callable", {}, 401, BODY_UNAUTHORIZED_DEFAULT),
         ("/callable?auth=demo", {}, 200, dict(auth="demo")),
         ("/apikeyquery", {}, 401, BODY_UNAUTHORIZED_DEFAULT),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -195,6 +195,7 @@ def test_schema():
         "KeyHeaderCustomException": {"in": "header", "name": "key", "type": "apiKey"},
         "KeyQuery": {"in": "query", "name": "key", "type": "apiKey"},
         "SessionAuth": {"in": "cookie", "name": "sessionid", "type": "apiKey"},
+        "SessionAuthSuperUser": {"in": "cookie", "name": "sessionid", "type": "apiKey"},
     }
     # TODO: Samename for schema check
     # TODO: check operation security attributes

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -112,7 +112,7 @@ BODY_UNAUTHORIZED_DEFAULT = dict(detail="Unauthorized")
         ("/django_auth_superuser", {}, 401, BODY_UNAUTHORIZED_DEFAULT),
         (
             "/django_auth_superuser",
-            dict(user=MockUser("admin")),
+            dict(user=MockSuperUser("admin")),
             401,
             BODY_UNAUTHORIZED_DEFAULT,
         ),


### PR DESCRIPTION
I have some use cases where some APIs are only for some privileged root user and it quite helpful to have an helper to add this extra security.

Let me know