### PR TITLE
pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-yaml
+      # - id: end-of-file-fixer
+      # - id: trailing-whitespace
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.931
+    hooks:
+      - id: mypy
+        additional_dependencies: ["django-stubs", "pydantic"]
+        exclude: (tests|docs)/
+  - repo: https://github.com/psf/black
+    rev: "22.1.0"
+    hooks:
+      - id: black
+        exclude: docs/src/
+  - repo: https://github.com/PyCQA/flake8
+    rev: "4.0.1"
+    hooks:
+      - id: flake8
+        exclude: (docs/src|tests/demo_project)/
+  - repo: https://github.com/PyCQA/isort
+    rev: "5.10.1"
+    hooks:
+      - id: isort
+        exclude: docs/src

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,9 @@ make test-cov
 
 Django Ninja uses `black`, `isort` and `flake8` for style check
 
-Before your commit please check your code with:
+Run `pre-commit install` to create a git hook to fix your styles before you commit.
+
+Alternatively, manually check your code with:
 
 ```
 black --check ninja tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,11 +60,14 @@ test = [
     "black",
     "isort",
     "flake8",
-    "mypy==0.930",
+    "mypy==0.931",
     "django-stubs",
 ]
 doc = [
     "mkdocs",
     "mkdocs-material",
     "markdown-include"
+]
+dev = [
+    "pre-commit",
 ]


### PR DESCRIPTION
Add a pre-commit config to allow contributors to create a git hook that will check their code _before_ committing, avoiding the common cycle of: push, fix styles, push, fix types, push...