### PR TITLE
ConfigError: ModelSchema classes requires a 'Config' subclass

### DIFF
--- a/ninja/orm/metaclass.py
+++ b/ninja/orm/metaclass.py
@@ -24,7 +24,12 @@ class ModelSchemaMetaclass(ResolverMetaclass):
                 and issubclass(base, ModelSchema)
                 and base == ModelSchema
             ):
-                config = namespace["Config"]
+                try:
+                    config = namespace["Config"]
+                except KeyError:
+                    raise ConfigError(
+                        f"ModelSchema class '{name}' requires a 'Config' subclass"
+                    )
 
                 assert issubclass(config.model, DjangoModel)
 

--- a/tests/test_orm_metaclass.py
+++ b/tests/test_orm_metaclass.py
@@ -121,3 +121,13 @@ def test_model_fields_all():
         },
         "required": ["field1"],
     }
+
+
+def test_model_schema_without_config():
+    with pytest.raises(
+        ConfigError,
+        match="ModelSchema class 'NoConfigSchema' requires a 'Config' subclass",
+    ):
+
+        class NoConfigSchema(ModelSchema):
+            pass


### PR DESCRIPTION
Makes it a bit easier for newbies like me.

Signed-off-by: Sebastian Wagner <sebastian@inter.link>