### PR TITLE
Fix Django-Ninja PUT/PATCH request with UploadedFile

### DIFF
--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -40,6 +40,7 @@ def load_request(request: HttpRequest):
     making the ParamModel look up at request.POST and request.FILES
     """
     if request.method in ("PUT", "PATCH") and request.content_type != "application/json":
+        original_method = request.method
         if hasattr(request, '_post'):
             del request._post
             del request._files
@@ -47,8 +48,8 @@ def load_request(request: HttpRequest):
             request.method = "POST"
             request.META['REQUEST_METHOD'] = 'POST'
             request._load_post_and_files()
-            request.META['REQUEST_METHOD'] = 'PUT'
-            request.method = "PUT"
+            request.META['REQUEST_METHOD'] = original_method
+            request.method = original_method
         except Exception:
             pass
 


### PR DESCRIPTION
Request PUT or PATCH raises an error for endpoints that receives UploadedFile. This happens because:
1. Since we receive a File within the request, the content-type can not be application/json anymore, forcing to be multipart/form-data (and the `ParamModel` to be `_MultiPartBodyModel`);
2. Django does not handle the request like he does for POST requests, not loading the multipart/form-data from request body into request.POST and request.FILES. 

This crashes in Django Ninja while processing the request (`Operation.run()`) for `ParamModel` `_MultiPartBodyModel` and `FileModel` since it tries to retrieve data from request.POST and request.FILES.

Possible solutions I reached:
1. Add some logic into `_MultiPartBodyModel`  and `FileModel` to load the request body data like the Django does for POST request (essencially, replicate Django logic)
2. Ask "nicely" to Django load the data for us, making he think he is loading a POST request.

I've choose the second approach.