### PR TITLE
UploadedFile inherit from Django's UploadedFile

### DIFF
--- a/ninja/files.py
+++ b/ninja/files.py
@@ -18,5 +18,5 @@ class UploadedFile(DjangoUploadedFile):
         return v
 
     @classmethod
-    def __modify_schema__(cls, field_schema: Dict[str, Any], field: Optional[ModelField]):
+    def __modify_schema__(cls, field_schema: Dict[str, Any], field: Optional[ModelField]) -> None:
         field_schema.update(type="string", format="binary")

--- a/ninja/files.py
+++ b/ninja/files.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Iterable, Optional, Type
+from typing import Any, Callable, Dict, Iterable, Optional, Type
 
 from django.core.files.uploadedfile import UploadedFile as DjangoUploadedFile
 from pydantic.fields import ModelField
@@ -18,5 +18,5 @@ class UploadedFile(DjangoUploadedFile):
         return v
 
     @classmethod
-    def __modify_schema__(cls, field_schema, field: Optional[ModelField]):
+    def __modify_schema__(cls, field_schema: Dict[str, Any], field: Optional[ModelField]):
         field_schema.update(type="string", format="binary")

--- a/ninja/files.py
+++ b/ninja/files.py
@@ -1,11 +1,12 @@
-from typing import Any, Callable, Iterable, Type
+from typing import Any, Callable, Iterable, Optional, Type
 
 from django.core.files.uploadedfile import UploadedFile as DjangoUploadedFile
+from pydantic.fields import ModelField
 
 __all__ = ["UploadedFile"]
 
 
-class UploadedFile(bytes):
+class UploadedFile(DjangoUploadedFile):
     @classmethod
     def __get_validators__(cls: Type["UploadedFile"]) -> Iterable[Callable[..., Any]]:
         yield cls._validate
@@ -15,3 +16,7 @@ class UploadedFile(bytes):
         if not isinstance(v, DjangoUploadedFile):
             raise ValueError(f"Expected UploadFile, received: {type(v)}")
         return v
+
+    @classmethod
+    def __modify_schema__(cls, field_schema, field: Optional[ModelField]):
+        field_schema.update(type="string", format="binary")

--- a/ninja/files.py
+++ b/ninja/files.py
@@ -18,5 +18,7 @@ class UploadedFile(DjangoUploadedFile):
         return v
 
     @classmethod
-    def __modify_schema__(cls, field_schema: Dict[str, Any], field: Optional[ModelField]) -> None:
+    def __modify_schema__(
+        cls, field_schema: Dict[str, Any], field: Optional[ModelField]
+    ) -> None:
         field_schema.update(type="string", format="binary")


### PR DESCRIPTION
Having uploaded file inherit from bytes causes inaccurate typing.

This PR fixes the typing issues by:
- having UploadedFile inherit from Django's UploadedFile instead of bytes
- adding a __modify_schema__ class method so that it appears the same way as a `bytes` type would in schemas.