### PR TITLE
Access to test response attributes

### DIFF
--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -168,3 +168,6 @@ class NinjaResponse:
 
     def __getitem__(self, key: str) -> Any:
         return self._response[key]
+
+    def __getattr__(self, attr: str) -> Any:
+        return getattr(self._response, attr)

--- a/tests/test_response_cookies.py
+++ b/tests/test_response_cookies.py
@@ -1,0 +1,26 @@
+from django.http import HttpResponse
+
+from ninja import NinjaAPI
+from ninja.testing import TestClient
+
+api = NinjaAPI()
+
+
+@api.get("/test-no-cookies")
+def op_no_cookies(request):
+    return {}
+
+
+@api.get("/test-set-cookie")
+def op_set_cookie(request):
+    response = HttpResponse()
+    response.set_cookie(key="sessionid", value="sessionvalue")
+    return response
+
+
+client = TestClient(api)
+
+
+def test_cookies():
+    assert bool(client.get("/test-no-cookies").cookies) is False
+    assert "sessionid" in client.get("/test-set-cookie").cookies


### PR DESCRIPTION
Give an access to the attributes of the Django response wrapped inside the test response of Ninja by providing a `__getattr__` method that it called when an attribute lookup has not found the attribute of the test response.

