### PR TITLE
Provide a way to inject pagination to multiple response schema.

### DIFF
--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -145,9 +145,7 @@ def _inject_pagination(
         result = paginator.paginate_queryset(
             items, pagination=pagination_params, **kwargs
         )
-        if paginator.Output:
-            result["items"] = list(result["items"])
-        # ^ forcing queryset evaluation #TODO: check why pydantic did not do it here
+
         return result
 
     view_with_pagination._ninja_contribute_args = [  # type: ignore

--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -139,6 +139,8 @@ def _inject_pagination(
             kwargs[paginator.pass_parameter] = pagination_params
 
         items = func(*args, **kwargs)
+        if isinstance(items, tuple) and len(items) == 2:
+            items = items[1]
 
         result = paginator.paginate_queryset(
             items, pagination=pagination_params, **kwargs

--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -176,9 +176,13 @@ class RouterPaginated(Router):
     def add_api_operation(
         self, path: str, methods: List[str], view_func: Callable, **kwargs: Any
     ) -> None:
-        response = kwargs["response"]
-        if is_collection_type(response):
-            view_func = _inject_pagination(view_func, self.pagination_class)
+        if methods[0] == 'GET':
+            response = kwargs["response"]
+            if isinstance(response, dict):
+                status: int = 200
+                response = response[status]
+            if is_collection_type(response):
+                view_func = _inject_pagination(view_func, self.pagination_class)
         return super().add_api_operation(path, methods, view_func, **kwargs)
 
 

--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -180,7 +180,7 @@ class RouterPaginated(Router):
             response = kwargs["response"]
             if isinstance(response, dict):
                 status: int = 200
-                response = response[status]
+                response = response.get(status, None)
             if is_collection_type(response):
                 view_func = _inject_pagination(view_func, self.pagination_class)
         return super().add_api_operation(path, methods, view_func, **kwargs)

--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -176,13 +176,12 @@ class RouterPaginated(Router):
     def add_api_operation(
         self, path: str, methods: List[str], view_func: Callable, **kwargs: Any
     ) -> None:
-        if methods[0] == 'GET':
-            response = kwargs["response"]
-            if isinstance(response, dict):
-                status: int = 200
-                response = response.get(status, None)
-            if is_collection_type(response):
-                view_func = _inject_pagination(view_func, self.pagination_class)
+        response = kwargs["response"]
+        if isinstance(response, dict):
+            status: int = 200
+            response = response.get(status, None)
+        if is_collection_type(response):
+            view_func = _inject_pagination(view_func, self.pagination_class)
         return super().add_api_operation(path, methods, view_func, **kwargs)
 
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -87,6 +87,12 @@ def items_7(request):
     return [7] * 7
 
 
+@api.get("/items_8", response={101: int, 200: List[int]})
+@paginate()
+def items_8(request, **kwargs):
+    return 200, ITEMS  # tuple type of return followed by multiple response schema
+
+
 client = TestClient(api)
 
 
@@ -252,6 +258,38 @@ def test_case7():
         "type": "array",
         "items": {"type": "integer"},
     }
+
+
+def test_case8_tuple_type_return():
+    response = client.get("/items_8?limit=10").json()
+    assert response == {"items": ITEMS[:10], "count": 100}
+
+    schema = api.get_openapi_schema()["paths"]["/api/items_8"]["get"]
+    print(schema["parameters"])
+    assert schema["parameters"] == [
+        {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+                "title": "Limit",
+                "default": 100,
+                "exclusiveMinimum": 0,
+                "type": "integer",
+            },
+            "required": False,
+        },
+        {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+                "title": "Offset",
+                "default": 0,
+                "exclusiveMinimum": -1,
+                "type": "integer",
+            },
+            "required": False,
+        },
+    ]
 
 
 def test_config_error_None():

--- a/tests/test_pagination_router.py
+++ b/tests/test_pagination_router.py
@@ -21,6 +21,11 @@ def items_nolist(request):
     return {"id": 1}
 
 
+@api.get("/items_multiple_response_schema", response={200: List[ItemSchema], 500: str})
+def items_multiple_response_schema(request):
+    return 200, [{"id": i} for i in range(1, 51)]
+
+
 client = TestClient(api)
 
 
@@ -62,3 +67,35 @@ def test_for_NON_list_reponse():
     ]
     print(parameters)
     assert parameters == []
+
+
+def test_for_list_reponse_muliple_response_schema():
+    parameters = api.get_openapi_schema()["paths"]["/api/items_multiple_response_schema"]["get"]["parameters"]
+    assert parameters == [
+        {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+                "title": "Limit",
+                "default": 100,
+                "exclusiveMinimum": 0,
+                "type": "integer",
+            },
+            "required": False,
+        },
+        {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+                "title": "Offset",
+                "default": 0,
+                "exclusiveMinimum": -1,
+                "type": "integer",
+            },
+            "required": False,
+        },
+    ]
+
+    response = client.get("/items?offset=5&limit=1").json()
+    print(response)
+    assert response == {"items": [{"id": 6}], "count": 50}


### PR DESCRIPTION
Hi @vitalik 
I found some issues in pagination feature when using multiple response schemas.

### Motivation
- The type of multiple response schemas is different with the single schema. 
    - Input of response schema
        - single : type == Schema or List of Schema
       `@api.get("/tasks", response=List[TaskSchema])`
        - multiple : type == dict 
       `@api.post('/login', response={200: Token, 401: Message, 402: Message})`
    
    - Output of response schema
        - single : type == queryset or list
        `return Task.objects.all()`
        - multiple : type == tuple
        `return 200, Task.objects.all()`

- The difference in type of Input reponse occurs an error when using a builtin router class(`RouterPaginated`)
- The difference in type of Output reponse occurs an error when injecting pagination to result(response).
     
### Modifications & Checkpoints
- Add method check & response type check in `RouterPaginated` class.
    - I assume only GET method needs to be injected to pagination.
    - Also, status code 200 should be required if someone want to use multiple response schemas.
- Add result(response) type check in `_inject_pagination` function.
    - `paginator.paginate_queryset` can not handle items which type is tuple.
    - No need to force queryset evaluation to result['items'] since `from_orm` will take care of the rest of the process.


I must say django ninja is amazing. It makes my coding experience happy. 
Thank you very much. 
