### PR TITLE
Add TestClient note to multiple APIs warning

### DIFF
--- a/ninja/main.py
+++ b/ninja/main.py
@@ -393,7 +393,7 @@ class NinjaAPI:
             and not debug_server_url_reimport()
         ):
             msg = [
-                "Looks like you created multiple NinjaAPIs",
+                "Looks like you created multiple NinjaAPIs or TestClients",
                 "To let ninja distinguish them you need to set either unique version or url_namespace",
                 " - NinjaAPI(..., version='2.0.0')",
                 " - NinjaAPI(..., urls_namespace='otherapi')",


### PR DESCRIPTION
Hi, this error was appearing when I had `client = TestClient(api)` (imported api) in 2 tests. Fixing it by creating only one shared test client.

It took me a while to guess that making a TestClient implicitly creates a NinjaAPI, so I hope this clarification to the error message will be helpful.

It would be nice to get a stack trace here too as this is all I see

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ninja.main.NinjaAPI object at 0x137ef20d0>

    def _validate(self) -> None:
        from ninja.security import APIKeyCookie
    
        # 1) urls namespacing validation
        skip_registry = os.environ.get("NINJA_SKIP_REGISTRY", False)
        if (
            not skip_registry
            and self.urls_namespace in NinjaAPI._registry
            and not debug_server_url_reimport()
        ):
            msg = [
                "Looks like you created multiple NinjaAPIs",
                "To let ninja distinguish them you need to set either unique version or url_namespace",
                " - NinjaAPI(..., version='2.0.0')",
                " - NinjaAPI(..., urls_namespace='otherapi')",
                f"Already registered: {NinjaAPI._registry}",
            ]
>           raise ConfigError("\n".join(msg))
E           ninja.errors.ConfigError: Looks like you created multiple NinjaAPIs
E           To let ninja distinguish them you need to set either unique version or url_namespace
E            - NinjaAPI(..., version='2.0.0')
E            - NinjaAPI(..., urls_namespace='otherapi')
E           Already registered: ['spapi-proxy']

../../.local/share/virtualenvs/foo-bar-Wa38ICUZ/lib/python3.9/site-packages/ninja/main.py:403: ConfigError
```