### PR TITLE
Don't run CI tests for `Django<2.2`.

### DIFF
--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        django-version: ['<2.2', '<3.0', '<3.1', '<3.2', '<3.3', '<4.1']
+        django-version: ['<3.0', '<3.1', '<3.2', '<3.3', '<4.1']
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3 :: Only",
     "Framework :: Django",
-    "Framework :: Django :: 2.1",
     "Framework :: Django :: 2.2",
     "Framework :: Django :: 3.0",
     "Framework :: Django :: 3.1",


### PR DESCRIPTION
- `install_requires` declares `Django>=2.2`

Perhaps we should also drop support for `Django < 3.2`? To align with officially supported versions by Django (https://www.djangoproject.com/download/)