### PR TITLE
Improves authentication validation to throw an exception

### DIFF
--- a/docs/docs/tutorial/errors.md
+++ b/docs/docs/tutorial/errors.md
@@ -55,6 +55,10 @@ function must return http response
 By default, **Django Ninja** initialized the following exception handlers:
 
 
+#### `ninja.errors.AuthenticationError`
+
+Raised when authentication data is not valid
+
 #### `ninja.errors.ValidationError`
 
 Raised when request data does not validate

--- a/ninja/errors.py
+++ b/ninja/errors.py
@@ -21,6 +21,10 @@ class ConfigError(Exception):
     pass
 
 
+class AuthenticationError(Exception):
+    pass
+
+
 class ValidationError(Exception):
     """
     This exception raised when operation params do not validate
@@ -56,6 +60,10 @@ def set_default_exc_handlers(api: "NinjaAPI") -> None:
         ValidationError,
         partial(_default_validation_error, api=api),
     )
+    api.add_exception_handler(
+        AuthenticationError,
+        partial(_default_authentication_error, api=api),
+    )
 
 
 def _default_404(request: HttpRequest, exc: Exception, api: "NinjaAPI") -> HttpResponse:
@@ -75,6 +83,12 @@ def _default_validation_error(
     request: HttpRequest, exc: ValidationError, api: "NinjaAPI"
 ) -> HttpResponse:
     return api.create_response(request, {"detail": exc.errors}, status=422)
+
+
+def _default_authentication_error(
+    request: HttpRequest, exc: AuthenticationError, api: "NinjaAPI"
+) -> HttpResponse:
+    return api.create_response(request, {"detail": "Unauthorized"}, status=401)
 
 
 def _default_exception(

--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -18,7 +18,7 @@ from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed
 from django.http.response import HttpResponseBase
 
 from ninja.constants import NOT_SET
-from ninja.errors import ConfigError, ValidationError
+from ninja.errors import AuthenticationError, ConfigError, ValidationError
 from ninja.params_models import TModels
 from ninja.schema import Schema
 from ninja.signature import ViewSignature, is_async
@@ -149,7 +149,7 @@ class Operation:
             if result:
                 request.auth = result  # type: ignore
                 return None
-        return self.api.create_response(request, {"detail": "Unauthorized"}, status=401)
+        return self.api.on_exception(request, AuthenticationError())
 
     def _result_to_response(
         self, request: HttpRequest, result: Any, temporal_response: HttpResponse


### PR DESCRIPTION
This PR adjusts authentication validation to throw an exception when authentication fails, particularly when using multiple authenticators. With this, developers will have greater flexibility to work with different returns.

When working with multiple authenticators `auth=[BasicAuth(), ApiKey()]` it was not possible to change the return, which by default is `{"detail": "Unauthorized"}`. Now through the [Handling errors](https://django-ninja.rest-framework.com/tutorial/errors/) I can override the default exception handlers.