### PR TITLE
Allow arbitrary Pagination Output

### DIFF
--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -208,10 +208,7 @@ def make_response_paginated(paginator: PaginationBase, op: Operation) -> None:
     new_schema = type(
         new_name,
         (paginator.Output,),
-        {
-            "__annotations__": {"items": List[item_schema]},  # type: ignore
-            "items": [],
-        },
+        {},
     )  # typing: ignore
 
     response = op._create_response_model(new_schema)

--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -63,8 +63,11 @@ class LimitOffsetPagination(PaginationBase):
     ) -> Any:
         offset = pagination.offset
         limit: int = pagination.limit
+        _items = queryset[offset : offset + limit]
+        items = list(_items)
+        # ^ forcing queryset evaluation #TODO: check why pydantic did not do it here
         return {
-            "items": queryset[offset : offset + limit],
+            "items": items,
             "count": self._items_count(queryset),
         }  # noqa: E203
 
@@ -86,8 +89,11 @@ class PageNumberPagination(PaginationBase):
         **params: DictStrAny,
     ) -> Any:
         offset = (pagination.page - 1) * self.page_size
+        _items = queryset[offset : offset + self.page_size]
+        items = list(_items)
+        # ^ forcing queryset evaluation #TODO: check why pydantic did not do it here
         return {
-            "items": queryset[offset : offset + self.page_size],
+            "items": items,
             "count": self._items_count(queryset),
         }  # noqa: E203
 
@@ -143,9 +149,6 @@ def _inject_pagination(
         result = paginator.paginate_queryset(
             items, pagination=pagination_params, **kwargs
         )
-        if paginator.Output:
-            result["items"] = list(result["items"])
-        # ^ forcing queryset evaluation #TODO: check why pydantic did not do it here
         return result
 
     view_with_pagination._ninja_contribute_args = [  # type: ignore

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -44,6 +44,24 @@ class NoOutputPagination(PaginationBase):
         return items[skip : skip + 5]
 
 
+class ResultsPaginator(PaginationBase):
+    class Input(Schema):
+        skip: int
+
+    class Output(Schema):
+        results: List[int]
+        count: int
+        skip: int
+
+    def paginate_queryset(self, items, pagination: Input, **params):
+        skip = pagination.skip
+        return {
+            "results": items[skip : skip + 5],
+            "count": self._items_count(items),
+            "skip": skip,
+        }
+
+
 @api.get("/items_1", response=List[int])
 @paginate  # WITHOUT brackets (should use default pagination)
 def items_1(request, **kwargs):
@@ -85,6 +103,12 @@ def items_6(request, **kwargs):
 @paginate(NoOutputPagination)
 def items_7(request):
     return [7] * 7
+
+
+@api.get("/items_8", response=List[int])
+@paginate(ResultsPaginator)
+def items_8(request):
+    return list(range(1000))
 
 
 client = TestClient(api)
@@ -252,6 +276,12 @@ def test_case7():
         "type": "array",
         "items": {"type": "integer"},
     }
+
+
+def test_case8():
+
+    response = client.get("/items_8?skip=5").json()
+    assert response == dict(results=[5, 6, 7, 8, 9], count=1000, skip=5)
 
 
 def test_config_error_None():


### PR DESCRIPTION
Currently, the schema of a paginator output MUST contain the field "items".
The scope of this PR is to eliminate this restriction.

I ran into this problem while trying to replicate a DRF [paginator](https://www.django-rest-framework.org/api-guide/pagination/#limitoffsetpagination). There we need a field named "results". Besides that, we need access to the request object during pagination to compose the fields "next" and "previous". I would like to add this functionality as well in the next PR. 
Please let me know if it is more appropriate to include it in this PR instead.

BTW, thanks @vitalik . This project rocks. 