### PR TITLE
Add exception `MethodNotAllowedError` and handler for it

### DIFF
--- a/docs/docs/guides/errors.md
+++ b/docs/docs/guides/errors.md
@@ -67,7 +67,7 @@ Raised when request data does not validate
 
 Used to throw http error with status code from any place of the code
 
-#### `ninja.errors.MethodNotAllowed`
+#### `ninja.errors.MethodNotAllowedError`
 
 Raised when request method not allowed
 

--- a/docs/docs/guides/errors.md
+++ b/docs/docs/guides/errors.md
@@ -67,6 +67,10 @@ Raised when request data does not validate
 
 Used to throw http error with status code from any place of the code
 
+#### `ninja.errors.MethodNotAllowed`
+
+Raised when request method not allowed
+
 #### `django.http.Http404`
  
  Django's default 404 exception (can be returned f.e. with `get_object_or_404`)

--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -18,8 +18,12 @@ from django.http import HttpRequest, HttpResponse
 from django.http.response import HttpResponseBase
 
 from ninja.constants import NOT_SET
-from ninja.errors import AuthenticationError, ConfigError, ValidationError
-from ninja.errors import ConfigError, MethodNotAllowed, ValidationError
+from ninja.errors import (
+    AuthenticationError,
+    ConfigError,
+    MethodNotAllowedError,
+    ValidationError,
+)
 from ninja.params_models import TModels
 from ninja.schema import Schema
 from ninja.signature import ViewSignature, is_async
@@ -361,7 +365,7 @@ class PathView:
         allowed_methods = set()
         for op in self.operations:
             allowed_methods.update(op.methods)
-        return self.api.on_exception(request, MethodNotAllowed(allowed_methods))
+        return self.api.on_exception(request, MethodNotAllowedError(allowed_methods))
 
 
 class ResponseObject:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -86,7 +86,7 @@ def file_response(request):
         ("delete", "/delete", 200, "this is DELETE", False),
         ("get",    "/multi",  200, "this is GET", False),
         ("post",   "/multi",  200, "this is POST", False),
-        ("patch",  "/multi",  405, b"Method not allowed", False),
+        ("patch",  "/multi",  405, {'detail': 'Method not allowed'}, False),
         ("get",    "/html",   200, b"html", False),
         ("get",    "/file",   200, b"this is a file", True),
     ],

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -51,9 +51,13 @@ def test_default_handler(settings):
         "detail": "Cannot parse request body (Expecting value: line 1 column 1 (char 0))",
     }
 
+    response = client.put("/error/custom")
+    assert response.status_code == 405
+    assert response.json() == {"detail": "Method not allowed. Allowed Methods: POST"}
+
     settings.DEBUG = False
     with pytest.raises(RuntimeError):
-        response = client.post("/error/base")
+        client.post("/error/base")
 
     response = client.post("/error/custom", body="invalid_json")
     assert response.status_code == 400


### PR DESCRIPTION
Instead of a direct answer from the b"Method not allowed", I propose to process the resulting exception, like other exceptions.
Added a `MethodNotAllowedError` error, as well as a handler for this error.