### PR TITLE
Also pass the router to `get_operation_url_name`

### DIFF
--- a/docs/docs/tutorial/urls.md
+++ b/docs/docs/tutorial/urls.md
@@ -41,7 +41,7 @@ You can also override implicit url naming by overwriting the `get_operation_url_
 
 ```Python
 class MyAPI(NinjaAPI):
-    def get_operation_url_name(self, operation):
+    def get_operation_url_name(self, operation, router):
         return operation.view_func.__name__ + '_my_extra_suffix'
 
 api = MyAPI()

--- a/ninja/main.py
+++ b/ninja/main.py
@@ -374,7 +374,11 @@ class NinjaAPI:
         module = operation.view_func.__module__
         return (module + "_" + name).replace(".", "_")
 
-    def get_operation_url_name(self, operation: "Operation") -> str:
+    def get_operation_url_name(self, operation: "Operation", router: Router) -> str:
+        """
+        Get the default URL name to use for an operation if it wasn't
+        explicitly provided.
+        """
         return operation.view_func.__name__
 
     def add_exception_handler(

--- a/ninja/router.py
+++ b/ninja/router.py
@@ -314,10 +314,11 @@ class Router:
             route = normalize_path(route)
             route = route.lstrip("/")
 
-            if not path_view.url_name:
-                url_name = self.api.get_operation_url_name(path_view.operations[0])  # type: ignore
-            else:
-                url_name = path_view.url_name
+            url_name = path_view.url_name or ""
+            if not url_name and self.api:
+                url_name = self.api.get_operation_url_name(
+                    path_view.operations[0], router=self
+                )
 
             yield django_path(route, path_view.get_view(), name=url_name)
 


### PR DESCRIPTION
Seems like having access to the router could also be useful when you fall back to configuring the url_name (building the url name by tags, or whatever)