### PR TITLE
Declare the AuthenticationError exception class in __all__

### DIFF
--- a/ninja/errors.py
+++ b/ninja/errors.py
@@ -11,7 +11,13 @@ from ninja.types import DictStrAny
 if TYPE_CHECKING:
     from ninja import NinjaAPI  # pragma: no cover
 
-__all__ = ["ConfigError", "ValidationError", "HttpError", "set_default_exc_handlers"]
+__all__ = [
+    "ConfigError",
+    "AuthenticationError",
+    "ValidationError",
+    "HttpError",
+    "set_default_exc_handlers",
+]
 
 
 logger = logging.getLogger("django")


### PR DESCRIPTION
This pull request is pretty simple, it just adds the AuthenticationError exception class to __all__ so it can be imported into projects. I'm sorry I didn't do this in pull request #454.