### PR TITLE
Attribute `description` declared has type `str` but is used as type None

### DIFF
--- a/docs/src/tutorial/body/code01.py
+++ b/docs/src/tutorial/body/code01.py
@@ -3,7 +3,7 @@ from ninja import Schema
 
 class Item(Schema):
     name: str
-    description: str = None
+    description: str = ""
     price: float
     quantity: int
 

--- a/docs/src/tutorial/body/code01.py
+++ b/docs/src/tutorial/body/code01.py
@@ -3,7 +3,7 @@ from ninja import Schema
 
 class Item(Schema):
     name: str
-    description: str = ""
+    description: Optional[str] = None
     price: float
     quantity: int
 


### PR DESCRIPTION
**"filename"**: "docs/src/tutorial/body/code01.py"
**"warning_type"**: "Incompatible attribute type [8]"
**"warning_message"**: " Attribute `description` declared in class `Item` has type `str` but is used as type `None`.",
**"warning_line"**: 6
**"fix"**: "" instead of None