### PR TITLE
Field alias

### DIFF
--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -151,6 +151,7 @@ class Schema(BaseModel, metaclass=ResolverMetaclass):
     class Config:
         orm_mode = True
         getter_dict = DjangoGetter
+        allow_population_by_field_name = True
 
     @classmethod
     def from_orm(cls: Type[S], obj: Any) -> S:

--- a/tests/demo_project/someapp/api.py
+++ b/tests/demo_project/someapp/api.py
@@ -1,29 +1,36 @@
 from datetime import date
-from typing import List
+from typing import List, Optional
 
 from django.shortcuts import get_object_or_404
-from pydantic import BaseModel
 
-from ninja import Router
+from ninja import Router, Field, Schema
 
-from .models import Event
+from .models import Event, Category
 
 router = Router()
 
 
-class EventSchema(BaseModel):
+class EventSchema(Schema):
     title: str
     start_date: date
     end_date: date
+    category: Optional[str] = Field(None, alias="category.title")
 
     class Config:
         orm_mode = True
 
 
-@router.post("/create", url_name="event-create-url-name")
+@router.post("/create", url_name="event-create-url-name", response=EventSchema)
 def create_event(request, event: EventSchema):
-    Event.objects.create(**event.dict())
-    return event
+    payload = event.dict()
+    category_title = payload.pop('category')
+    
+    if category_title is not None:
+        category, created = Category.objects.get_or_create(title=category_title)
+    else:
+        category = None
+
+    return Event.objects.create(category=category, **payload)
 
 
 @router.get("", response=List[EventSchema])

--- a/tests/test_django_models.py
+++ b/tests/test_django_models.py
@@ -8,7 +8,7 @@ from someapp.models import Event
 def test_with_client(client: Client):
     assert Event.objects.count() == 0
 
-    test_item = {"start_date": "2020-01-01", "end_date": "2020-01-02", "title": "test"}
+    test_item = {"start_date": "2020-01-01", "end_date": "2020-01-02", "title": "test", "category": "test_events"}
 
     response = client.post("/api/events/create", **json_payload(test_item))
     assert response.status_code == 200


### PR DESCRIPTION
This addresses #506 

when a Schema is used as a input payload or query parameter, the schema should be instantiated with the field name and not the alias name...