### PR TITLE
ModelSchema: allow model_fields = []

### DIFF
--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -44,7 +44,7 @@ class SchemaFactory:
     ) -> Type[Schema]:
         name = name or model.__name__
 
-        if fields and exclude:
+        if fields is not None and exclude is not None:
             raise ConfigError("Only one of 'fields' or 'exclude' should be set.")
 
         key = self.get_key(model, name, depth, fields, exclude, custom_fields)
@@ -105,7 +105,7 @@ class SchemaFactory:
         "Returns iterator for model fields based on `exclude` or `fields` arguments"
         all_fields = {f.name: f for f in self._model_fields(model)}
 
-        if not fields and not exclude:
+        if fields is None and exclude is None:
             for f in all_fields.values():
                 yield f
 
@@ -113,10 +113,10 @@ class SchemaFactory:
         if invalid_fields:
             raise ConfigError(f"Field(s) {invalid_fields} are not in model {model}")
 
-        if fields:
+        if fields is not None:
             for name in fields:
                 yield all_fields[name]
-        if exclude:
+        if exclude is not None:
             for f in all_fields.values():
                 if f.name not in exclude:
                     yield f

--- a/ninja/orm/metaclass.py
+++ b/ninja/orm/metaclass.py
@@ -36,7 +36,7 @@ class ModelSchemaMetaclass(ResolverMetaclass):
                 fields = getattr(config, "model_fields", None)
                 exclude = getattr(config, "model_exclude", None)
 
-                if not fields and not exclude:
+                if fields is None and exclude is None:
                     raise ConfigError(
                         "Creating a ModelSchema without either the 'model_fields' attribute"
                         " or the 'model_exclude' attribute is prohibited"

--- a/tests/test_orm_metaclass.py
+++ b/tests/test_orm_metaclass.py
@@ -50,6 +50,33 @@ def test_simple():
         "required": ["firstname"],
     }
 
+    class SampleSchema3(ModelSchema):
+        class Config:
+            model = User
+            model_fields = []
+
+    assert SampleSchema3.schema() == {
+        "title": "SampleSchema3",
+        "type": "object",
+        "properties": {},
+    }
+
+    class SampleSchema4(ModelSchema):
+        class Config:
+            model = User
+            model_exclude = []
+
+    assert SampleSchema4.schema() == {
+        "title": "SampleSchema4",
+        "type": "object",
+        "properties": {
+            "id": {"title": "Id", "type": "integer"},
+            "firstname": {"title": "Firstname", "type": "string"},
+            "lastname": {"title": "Lastname", "type": "string"},
+        },
+        "required": ["firstname"],
+    }
+
 
 def test_custom():
     class CustomModel(models.Model):


### PR DESCRIPTION
This PR tests model_fields and model_exclude against None, so the following two ModelSchemes are valid:

``` python
class SampleSchema3(ModelSchema):
    class Config:
        model = User
        model_fields  = []


class SampleSchema4(ModelSchema):
    class Config:
        model = User
        model_exclude  = [] # equivalent to model_fields = "__all__"
```