### PR TITLE
Fix Paginated Schema default(example value)

### DIFF
--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -209,7 +209,6 @@ def make_response_paginated(paginator: PaginationBase, op: Operation) -> None:
         (paginator.Output,),
         {
             "__annotations__": {paginator.items_attribute: List[item_schema]},  # type: ignore
-            paginator.items_attribute: [],
         },
     )  # typing: ignore
 


### PR DESCRIPTION
This PR resolves Issue https://github.com/vitalik/django-ninja/issues/560
* Setting default value for `paginator.items_attribute` makes `items` schemas' example value not visible
* Removed default value of Output Schema

### Before
<img width="400" alt="image" src="https://user-images.githubusercontent.com/37990664/189021468-c61b34d4-0278-43c3-9d8b-16948a9605cd.png"></td>  </tr> </table> 


### After
<img width="600" alt="image" src="https://user-images.githubusercontent.com/37990664/189022419-063c6200-1f9b-4d04-b863-56935f56f5cf.png">