### PR TITLE
Allow exception handlers to annotate return as `NoReturn`

### DIFF
--- a/ninja/main.py
+++ b/ninja/main.py
@@ -5,6 +5,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    NoReturn,
     Optional,
     Sequence,
     Tuple,
@@ -32,7 +33,9 @@ if TYPE_CHECKING:
 __all__ = ["NinjaAPI"]
 
 Exc = Union[Exception, Type[Exception]]
-ExcHandler = Callable[[HttpRequest, Exc], HttpResponse]
+ExcHandler = Union[
+    Callable[[HttpRequest, Exc], HttpResponse], Callable[[HttpRequest, Exc], NoReturn]
+]
 
 
 class NinjaAPI:


### PR DESCRIPTION
Allows for intercepting a propagated exception and either reraise or raise a different error. All while allowing type checkers to follow on that.