### PR TITLE
[ `Enchancement` ] : Add repository url in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dist-name = "django-ninja"
 author = "Vitaliy Kucheryaviy"
 author-email = "ppr.vitaly@gmail.com"
 home-page = "https://django-ninja.rest-framework.com"
+repository = "https://github.com/vitalik/django-ninja"
 classifiers = [
     "Intended Audience :: Information Technology",
     "Intended Audience :: System Administrators",


### PR DESCRIPTION
Hi there,

It seems that this project doesn't have repository url configured.

This PR aims to solve this issue.

So when this Pull Request is merged we can get a PyPi Github Icon
<details>
<summary>Example Badge ( taken from poetry )</summary>

![image](https://user-images.githubusercontent.com/61817579/189284233-3b312b13-5041-4da9-9bd7-9e1f7432f664.png)


</details>


