### PR TITLE
add --sorted flag to export_openapi_schema

### DIFF
--- a/ninja/management/commands/export_openapi_schema.py
+++ b/ninja/management/commands/export_openapi_schema.py
@@ -57,6 +57,9 @@ class Command(BaseCommand):
         parser.add_argument(
             "--indent", dest="indent", default=None, type=int, help="JSON indent"
         )
+        parser.add_argument(
+            "--sorted", dest="sort_keys", default=False, action='store_true', help="Sort Json keys"
+        )
 
     def handle(self, *args: Any, **options: Any) -> None:
         api = self._get_api_instance(options["api"])

--- a/ninja/management/commands/export_openapi_schema.py
+++ b/ninja/management/commands/export_openapi_schema.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
     def handle(self, *args: Any, **options: Any) -> None:
         api = self._get_api_instance(options["api"])
         schema = api.get_openapi_schema()
-        result = json.dumps(schema, cls=NinjaJSONEncoder, indent=options["indent"])
+        result = json.dumps(schema, cls=NinjaJSONEncoder, indent=options["indent"], sort_keys=options["sort_keys"])
 
         if options["output"]:
             with open(options["output"], "wb") as f:

--- a/ninja/management/commands/export_openapi_schema.py
+++ b/ninja/management/commands/export_openapi_schema.py
@@ -58,13 +58,22 @@ class Command(BaseCommand):
             "--indent", dest="indent", default=None, type=int, help="JSON indent"
         )
         parser.add_argument(
-            "--sorted", dest="sort_keys", default=False, action='store_true', help="Sort Json keys"
+            "--sorted",
+            dest="sort_keys",
+            default=False,
+            action="store_true",
+            help="Sort Json keys",
         )
 
     def handle(self, *args: Any, **options: Any) -> None:
         api = self._get_api_instance(options["api"])
         schema = api.get_openapi_schema()
-        result = json.dumps(schema, cls=NinjaJSONEncoder, indent=options["indent"], sort_keys=options["sort_keys"])
+        result = json.dumps(
+            schema,
+            cls=NinjaJSONEncoder,
+            indent=options["indent"],
+            sort_keys=options["sort_keys"],
+        )
 
         if options["output"]:
             with open(options["output"], "wb") as f:


### PR DESCRIPTION
openapi generation shuffles the keys around from time to time. 
When the schema is in VCS, on every generation a huge changeset is created.
This pr adds a `--sorted` flag to sort the object keys on json export