### PR TITLE
Add support for adding multiple examples in request bodies and path, query, cookie, and header params

### DIFF
--- a/ninja/encoders.py
+++ b/ninja/encoders.py
@@ -1,0 +1,172 @@
+# type: ignore
+import dataclasses
+from collections import defaultdict
+from enum import Enum
+from pathlib import PurePath
+from types import GeneratorType
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+
+from pydantic import BaseModel
+from pydantic.json import ENCODERS_BY_TYPE
+
+SetIntStr = Set[Union[int, str]]
+DictIntStrAny = Dict[Union[int, str], Any]
+
+
+def generate_encoders_by_class_tuples(
+    type_encoder_map: Dict[Any, Callable[[Any], Any]]
+) -> Dict[Callable[[Any], Any], Tuple[Any, ...]]:
+    encoders_by_class_tuples: Dict[Callable[[Any], Any], Tuple[Any, ...]] = defaultdict(
+        tuple
+    )
+    for type_, encoder in type_encoder_map.items():
+        encoders_by_class_tuples[encoder] += (type_,)
+    return encoders_by_class_tuples
+
+
+encoders_by_class_tuples = generate_encoders_by_class_tuples(ENCODERS_BY_TYPE)
+
+
+def jsonable_encoder(
+    obj: Any,
+    include: Optional[Union[SetIntStr, DictIntStrAny]] = None,
+    exclude: Optional[Union[SetIntStr, DictIntStrAny]] = None,
+    by_alias: bool = True,
+    exclude_unset: bool = False,
+    exclude_defaults: bool = False,
+    exclude_none: bool = False,
+    custom_encoder: Optional[Dict[Any, Callable[[Any], Any]]] = None,
+    sqlalchemy_safe: bool = True,
+) -> Any:
+    custom_encoder = custom_encoder or {}
+    if custom_encoder:
+        if type(obj) in custom_encoder:
+            return custom_encoder[type(obj)](obj)
+        else:
+            for encoder_type, encoder_instance in custom_encoder.items():
+                if isinstance(obj, encoder_type):
+                    return encoder_instance(obj)
+    if include is not None and not isinstance(include, (set, dict)):
+        include = set(include)
+    if exclude is not None and not isinstance(exclude, (set, dict)):
+        exclude = set(exclude)
+    if isinstance(obj, BaseModel):
+        encoder = getattr(obj.__config__, "json_encoders", {})
+        if custom_encoder:
+            encoder.update(custom_encoder)
+        obj_dict = obj.dict(
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_none=exclude_none,
+            exclude_defaults=exclude_defaults,
+        )
+        if "__root__" in obj_dict:
+            obj_dict = obj_dict["__root__"]
+        return jsonable_encoder(
+            obj_dict,
+            exclude_none=exclude_none,
+            exclude_defaults=exclude_defaults,
+            custom_encoder=encoder,
+            sqlalchemy_safe=sqlalchemy_safe,
+        )
+    if dataclasses.is_dataclass(obj):
+        obj_dict = dataclasses.asdict(obj)
+        return jsonable_encoder(
+            obj_dict,
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+            custom_encoder=custom_encoder,
+            sqlalchemy_safe=sqlalchemy_safe,
+        )
+    if isinstance(obj, Enum):
+        return obj.value
+    if isinstance(obj, PurePath):
+        return str(obj)
+    if isinstance(obj, (str, int, float, type(None))):
+        return obj
+    if isinstance(obj, dict):
+        encoded_dict = {}
+        allowed_keys = set(obj.keys())
+        if include is not None:
+            allowed_keys &= set(include)
+        if exclude is not None:
+            allowed_keys -= set(exclude)
+        for key, value in obj.items():
+            if (
+                (
+                    not sqlalchemy_safe
+                    or (not isinstance(key, str))
+                    or (not key.startswith("_sa"))
+                )
+                and (value is not None or not exclude_none)
+                and key in allowed_keys
+            ):
+                encoded_key = jsonable_encoder(
+                    key,
+                    by_alias=by_alias,
+                    exclude_unset=exclude_unset,
+                    exclude_none=exclude_none,
+                    custom_encoder=custom_encoder,
+                    sqlalchemy_safe=sqlalchemy_safe,
+                )
+                encoded_value = jsonable_encoder(
+                    value,
+                    by_alias=by_alias,
+                    exclude_unset=exclude_unset,
+                    exclude_none=exclude_none,
+                    custom_encoder=custom_encoder,
+                    sqlalchemy_safe=sqlalchemy_safe,
+                )
+                encoded_dict[encoded_key] = encoded_value
+        return encoded_dict
+    if isinstance(obj, (list, set, frozenset, GeneratorType, tuple)):
+        encoded_list = []
+        for item in obj:
+            encoded_list.append(
+                jsonable_encoder(
+                    item,
+                    include=include,
+                    exclude=exclude,
+                    by_alias=by_alias,
+                    exclude_unset=exclude_unset,
+                    exclude_defaults=exclude_defaults,
+                    exclude_none=exclude_none,
+                    custom_encoder=custom_encoder,
+                    sqlalchemy_safe=sqlalchemy_safe,
+                )
+            )
+        return encoded_list
+
+    if type(obj) in ENCODERS_BY_TYPE:
+        return ENCODERS_BY_TYPE[type(obj)](obj)
+    for encoder, classes_tuple in encoders_by_class_tuples.items():
+        if isinstance(obj, classes_tuple):
+            return encoder(obj)
+
+    try:
+        data = dict(obj)
+    except Exception as e:
+        errors: List[Exception] = []
+        errors.append(e)
+        try:
+            data = vars(obj)
+        except Exception as e:
+            errors.append(e)
+            raise ValueError(errors)
+    return jsonable_encoder(
+        data,
+        include=include,
+        exclude=exclude,
+        by_alias=by_alias,
+        exclude_unset=exclude_unset,
+        exclude_defaults=exclude_defaults,
+        exclude_none=exclude_none,
+        custom_encoder=custom_encoder,
+        sqlalchemy_safe=sqlalchemy_safe,
+    )

--- a/ninja/params.py
+++ b/ninja/params.py
@@ -1,6 +1,6 @@
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
-from pydantic.fields import FieldInfo, ModelField
+from pydantic.fields import FieldInfo, ModelField, Undefined
 
 from ninja import params_models
 
@@ -22,12 +22,16 @@ class Param(FieldInfo):
         min_length: int = None,
         max_length: int = None,
         regex: str = None,
+        example: Any = Undefined,
+        examples: Optional[Dict[str, Any]] = None,
         deprecated: bool = None,
         # param_name: str = None,
         # param_type: Any = None,
         **extra: Any,
     ):
         self.deprecated = deprecated
+        self.example = example
+        self.examples = examples
         # self.param_name: str = None
         # self.param_type: Any = None
         self.model_field: Optional[ModelField] = None

--- a/ninja/params_functions.py
+++ b/ninja/params_functions.py
@@ -3,7 +3,9 @@
 # what it basically does makes function XXX that create instance of params.XXX
 # and annotates function with result = Any
 # idea from https://github.com/tiangolo/fastapi/blob/master/fastapi/param_functions.py
-from typing import Any, Optional
+from typing import Any, Dict, Optional
+
+from pydantic.fields import Undefined
 
 from ninja import params
 
@@ -21,6 +23,8 @@ def Path(  # noqa: N802
     min_length: Optional[int] = None,
     max_length: Optional[int] = None,
     regex: Optional[str] = None,
+    example: Any = Undefined,
+    examples: Optional[Dict[str, Any]] = None,
     deprecated: Optional[bool] = None,
     **extra: Any,
 ) -> Any:
@@ -36,6 +40,8 @@ def Path(  # noqa: N802
         min_length=min_length,
         max_length=max_length,
         regex=regex,
+        example=example,
+        examples=examples,
         deprecated=deprecated,
         **extra,
     )
@@ -54,6 +60,8 @@ def Query(  # noqa: N802
     min_length: Optional[int] = None,
     max_length: Optional[int] = None,
     regex: Optional[str] = None,
+    example: Any = Undefined,
+    examples: Optional[Dict[str, Any]] = None,
     deprecated: Optional[bool] = None,
     **extra: Any,
 ) -> Any:
@@ -69,6 +77,8 @@ def Query(  # noqa: N802
         min_length=min_length,
         max_length=max_length,
         regex=regex,
+        example=example,
+        examples=examples,
         deprecated=deprecated,
         **extra,
     )
@@ -87,6 +97,8 @@ def Header(  # noqa: N802
     min_length: Optional[int] = None,
     max_length: Optional[int] = None,
     regex: Optional[str] = None,
+    example: Any = Undefined,
+    examples: Optional[Dict[str, Any]] = None,
     deprecated: Optional[bool] = None,
     **extra: Any,
 ) -> Any:
@@ -102,6 +114,8 @@ def Header(  # noqa: N802
         min_length=min_length,
         max_length=max_length,
         regex=regex,
+        example=example,
+        examples=examples,
         deprecated=deprecated,
         **extra,
     )
@@ -120,6 +134,8 @@ def Cookie(  # noqa: N802
     min_length: Optional[int] = None,
     max_length: Optional[int] = None,
     regex: Optional[str] = None,
+    example: Any = Undefined,
+    examples: Optional[Dict[str, Any]] = None,
     deprecated: Optional[bool] = None,
     **extra: Any,
 ) -> Any:
@@ -135,6 +151,8 @@ def Cookie(  # noqa: N802
         min_length=min_length,
         max_length=max_length,
         regex=regex,
+        example=example,
+        examples=examples,
         deprecated=deprecated,
         **extra,
     )
@@ -153,6 +171,8 @@ def Body(  # noqa: N802
     min_length: Optional[int] = None,
     max_length: Optional[int] = None,
     regex: Optional[str] = None,
+    example: Any = Undefined,
+    examples: Optional[Dict[str, Any]] = None,
     deprecated: Optional[bool] = None,
     **extra: Any,
 ) -> Any:
@@ -168,6 +188,8 @@ def Body(  # noqa: N802
         min_length=min_length,
         max_length=max_length,
         regex=regex,
+        example=example,
+        examples=examples,
         deprecated=deprecated,
         **extra,
     )
@@ -186,6 +208,8 @@ def Form(  # noqa: N802
     min_length: Optional[int] = None,
     max_length: Optional[int] = None,
     regex: Optional[str] = None,
+    example: Any = Undefined,
+    examples: Optional[Dict[str, Any]] = None,
     deprecated: Optional[bool] = None,
     **extra: Any,
 ) -> Any:
@@ -201,6 +225,8 @@ def Form(  # noqa: N802
         min_length=min_length,
         max_length=max_length,
         regex=regex,
+        example=example,
+        examples=examples,
         deprecated=deprecated,
         **extra,
     )
@@ -219,6 +245,8 @@ def File(  # noqa: N802
     min_length: Optional[int] = None,
     max_length: Optional[int] = None,
     regex: Optional[str] = None,
+    example: Any = Undefined,
+    examples: Optional[Dict[str, Any]] = None,
     deprecated: Optional[bool] = None,
     **extra: Any,
 ) -> Any:
@@ -234,6 +262,8 @@ def File(  # noqa: N802
         min_length=min_length,
         max_length=max_length,
         regex=regex,
+        example=example,
+        examples=examples,
         deprecated=deprecated,
         **extra,
     )

--- a/tests/test_openapi_params.py
+++ b/tests/test_openapi_params.py
@@ -27,17 +27,6 @@ def operation4(request):
     return {"tags": True}
 
 
-@api.get(
-    "/operation5",
-    examples={
-        "example1": {"summary": "summary1", "value": {}},
-        "example2": {"summary": "summary2", "value": {}},
-    },
-)
-def operation5(request):
-    return {}
-
-
 @api.get("/not-included", include_in_schema=False)
 def not_included(request):
     return True
@@ -51,19 +40,16 @@ def test_schema():
     op2 = schema["paths"]["/api/operation2"]["get"]
     op3 = schema["paths"]["/api/operation3"]["get"]
     op4 = schema["paths"]["/api/operation4"]["get"]
-    op5 = schema["paths"]["/api/operation5"]["get"]
 
     assert op1["operationId"] == "my_id"
     assert op2["operationId"] == "test_openapi_params_operation2"
     assert op3["operationId"] == "test_openapi_params_operation3"
     assert op4["operationId"] == "test_openapi_params_operation4"
-    assert op4["operationId"] == "test_openapi_params_operation5"
 
     assert op1["summary"] == "Operation 1"
     assert op2["summary"] == "Operation2"
     assert op3["summary"] == "Summary from argument"
     assert op4["summary"] == "Operation4"
-    assert op4["summary"] == "Operation5"
 
     assert op1["description"] == "This will be in description"
 
@@ -73,11 +59,6 @@ def test_schema():
     assert op3["description"] == "description arg"
 
     assert op4["tags"] == ["tag1", "tag2"]
-
-    assert op5["examples"] == {
-        "example1": {"summary": "summary1", "value": {}},
-        "example2": {"summary": "summary2", "value": {}},
-    }
 
 
 def test_not_included():

--- a/tests/test_openapi_params.py
+++ b/tests/test_openapi_params.py
@@ -27,6 +27,17 @@ def operation4(request):
     return {"tags": True}
 
 
+@api.get(
+    "/operation5",
+    examples={
+        "example1": {"summary": "summary1", "value": {}},
+        "example2": {"summary": "summary2", "value": {}},
+    },
+)
+def operation5(request):
+    return {}
+
+
 @api.get("/not-included", include_in_schema=False)
 def not_included(request):
     return True
@@ -40,16 +51,19 @@ def test_schema():
     op2 = schema["paths"]["/api/operation2"]["get"]
     op3 = schema["paths"]["/api/operation3"]["get"]
     op4 = schema["paths"]["/api/operation4"]["get"]
+    op5 = schema["paths"]["/api/operation5"]["get"]
 
     assert op1["operationId"] == "my_id"
     assert op2["operationId"] == "test_openapi_params_operation2"
     assert op3["operationId"] == "test_openapi_params_operation3"
     assert op4["operationId"] == "test_openapi_params_operation4"
+    assert op4["operationId"] == "test_openapi_params_operation5"
 
     assert op1["summary"] == "Operation 1"
     assert op2["summary"] == "Operation2"
     assert op3["summary"] == "Summary from argument"
     assert op4["summary"] == "Operation4"
+    assert op4["summary"] == "Operation5"
 
     assert op1["description"] == "This will be in description"
 
@@ -59,6 +73,11 @@ def test_schema():
     assert op3["description"] == "description arg"
 
     assert op4["tags"] == ["tag1", "tag2"]
+
+    assert op5["examples"] == {
+        "example1": {"summary": "summary1", "value": {}},
+        "example2": {"summary": "summary2", "value": {}},
+    }
 
 
 def test_not_included():

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -202,7 +202,11 @@ def test_schema(schema):
             "type": "object",
             "properties": {
                 "i": {"title": "I", "type": "integer"},
-                "f": {"description": "f desc", "title": "f title", "type": "number"},
+                "f": {
+                    "title": "f title",
+                    "description": "f desc",
+                    "type": "number",
+                },
             },
             "required": ["i", "f"],
         },
@@ -216,20 +220,29 @@ def test_schema(schema):
             "required": ["i", "f"],
         },
         "TypeA": {
-            "properties": {
-                "a": {"title": "A", "type": "string"},
-            },
-            "required": ["a"],
             "title": "TypeA",
             "type": "object",
+            "properties": {"a": {"title": "A", "type": "string"}},
+            "required": ["a"],
         },
         "TypeB": {
-            "properties": {
-                "b": {"title": "B", "type": "string"},
-            },
-            "required": ["b"],
             "title": "TypeB",
             "type": "object",
+            "properties": {"b": {"title": "B", "type": "string"}},
+            "required": ["b"],
+        },
+        "ExamplesResponse": {
+            "title": "ExamplesResponse",
+            "type": "object",
+            "properties": {
+                "i": {"title": "I", "type": "integer"},
+                "f": {
+                    "title": "f title",
+                    "description": "f desc",
+                    "type": "number",
+                },
+            },
+            "required": ["i", "f"],
         },
     }
 
@@ -241,23 +254,25 @@ def test_schema_examples(schema):
         "content": {
             "application/json": {
                 "schema": {
-                    "$ref": "#/components/schemas/Payload",
-                    "examples": {
-                        "example1": {
-                            "summary": "example1",
-                            "value": {"i": 123, "f": 0.5},
-                        }
-                    },
-                }
+                    "title": "Data",
+                    "anyOf": [
+                        {"type": "integer"},
+                        {"$ref": "#/components/schemas/TypeB"},
+                    ],
+                },
+                "examples": {
+                    "example1": {"summary": "example1", "value": {"i": 123, "f": 0.5}}
+                },
             }
         },
         "required": True,
     }
     assert method["responses"] == {
         200: {
+            "description": "OK",
             "content": {
                 "application/json": {
-                    "schema": {"$ref": "#/components/schemas/Response"},
+                    "schema": {"$ref": "#/components/schemas/ExamplesResponse"},
                     "examples": {
                         "example1": {
                             "summary": "example1",
@@ -266,7 +281,6 @@ def test_schema_examples(schema):
                     },
                 }
             },
-            "description": "OK",
         }
     }
 
@@ -379,6 +393,19 @@ def test_schema_list(schema):
             "required": ["i", "f"],
             "title": "Response",
             "type": "object",
+        },
+        "ExamplesResponse": {
+            "title": "ExamplesResponse",
+            "type": "object",
+            "properties": {
+                "i": {"title": "I", "type": "integer"},
+                "f": {
+                    "title": "f title",
+                    "description": "f desc",
+                    "type": "number",
+                },
+            },
+            "required": ["i", "f"],
         },
     }
 


### PR DESCRIPTION
#586 

It was developed based on the fastapi method.
I used type ignore to pass pre-commit , but I need some help.
