### PR TITLE
Set correct media type in docs for custom renderer

### DIFF
--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -252,7 +252,9 @@ class OpenAPISchema(dict):
                 schema = self._create_schema_from_model(
                     model, by_alias=operation.by_alias
                 )[0]
-                details[status]["content"] = {"application/json": {"schema": schema}}
+                details[status]["content"] = {
+                    self.api.renderer.media_type: {"schema": schema}
+                }
             result.update(details)
 
         return result


### PR DESCRIPTION
When specifying a renderer with a custom media type, the generated schema docs don't reflect the media type header.
It always returns application/json.

This patch uses the media_type from the custom renderer to render the response schema media type