### PR TITLE
Allow Renderer charset to be None

### DIFF
--- a/ninja/main.py
+++ b/ninja/main.py
@@ -411,7 +411,11 @@ class NinjaAPI:
         return HttpResponse("", content_type=self.get_content_type())
 
     def get_content_type(self) -> str:
-        return "{}; charset={}".format(self.renderer.media_type, self.renderer.charset)
+        if self.renderer.charset is not None:
+            return "{}; charset={}".format(
+                self.renderer.media_type, self.renderer.charset
+            )
+        return self.renderer.media_type
 
     def get_openapi_schema(self, path_prefix: Optional[str] = None) -> OpenAPISchema:
         if path_prefix is None:

--- a/ninja/renderers.py
+++ b/ninja/renderers.py
@@ -9,7 +9,7 @@ __all__ = ["BaseRenderer", "JSONRenderer"]
 
 
 class BaseRenderer:
-    media_type: Optional[str] = None
+    media_type: str = "text/plain"
     charset: Optional[str] = "utf-8"
 
     def render(self, request: HttpRequest, data: Any, *, response_status: int) -> Any:

--- a/ninja/renderers.py
+++ b/ninja/renderers.py
@@ -10,7 +10,7 @@ __all__ = ["BaseRenderer", "JSONRenderer"]
 
 class BaseRenderer:
     media_type: Optional[str] = None
-    charset: str = "utf-8"
+    charset: Optional[str] = "utf-8"
 
     def render(self, request: HttpRequest, data: Any, *, response_status: int) -> Any:
         raise NotImplementedError("Please implement .render() method")

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -102,13 +102,14 @@ def test_implment_render():
     with pytest.raises(NotImplementedError):
         renderer.render(None, None, response_status=200)
 
+
 def test_none_charset():
     class FooRenderer(BaseRenderer):
         media_type = "custom-type"
         charset = None
 
         def render(self, *args, **kwargs):
-            return ''
+            return ""
 
     api = NinjaAPI(renderer=FooRenderer())
     api.get("/test")(operation)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -101,3 +101,19 @@ def test_implment_render():
     renderer = FooRenderer()
     with pytest.raises(NotImplementedError):
         renderer.render(None, None, response_status=200)
+
+def test_none_charset():
+    class FooRenderer(BaseRenderer):
+        media_type = "custom-type"
+        charset = None
+
+        def render(self, *args, **kwargs):
+            return ''
+
+    api = NinjaAPI(renderer=FooRenderer())
+    api.get("/test")(operation)
+    client = TestClient(api)
+
+    response = client.get("/test")
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "custom-type"


### PR DESCRIPTION
We have an especially strict client for an API which demands the content-type be exactly what was entered, which is also strictly defined. When defining a renderer, you previously also had to specify a charset which was then appended to the content-type on response.

* Make charset optional when defining a renderer
* Only append the charset to the content type if it's not None
* Fix a type on the media_type prop which was incorrectly set as optional

Hope this isn't too controversial?