### PR TITLE
List[Schema] = Body(...) on a multipart/form-data support and minor editor improvement

### DIFF
--- a/ninja/params_models.py
+++ b/ninja/params_models.py
@@ -176,10 +176,10 @@ class _MultiPartBodyModel(BodyModel):
     ) -> Optional[DictStrAny]:
         results: DictStrAny = {}
         list_fields = getattr(cls, "_collection_fields", [])
+        get_request_data = super(_MultiPartBodyModel, cls).get_request_data
 
-        def parse_data(data, annotation=None):
+        def parse_data(data: str, annotation: Any = None) -> Any:
             req = _HttpRequest()
-            get_request_data = super(_MultiPartBodyModel, cls).get_request_data
             if annotation == str and data[0] != '"' and data[-1] != '"':
                 data = f'"{data}"'
             req.body = data.encode()
@@ -197,7 +197,7 @@ class _MultiPartBodyModel(BodyModel):
                     ):
                         data = parse_data(datalist[0], annotation)
                     else:
-                        data = [parse_data(d) for d in request.POST.getlist(name)]
+                        data = [parse_data(d) for d in datalist]
                 else:
                     data = parse_data(request.POST[name], annotation)
                 results[name] = data

--- a/ninja/params_models.py
+++ b/ninja/params_models.py
@@ -166,6 +166,7 @@ class _HttpRequest(HttpRequest):
 
     body: bytes = b""
 
+
 class _MultiPartBodyModel(BodyModel):
     _body_params: DictStrAny
 
@@ -175,6 +176,7 @@ class _MultiPartBodyModel(BodyModel):
     ) -> Optional[DictStrAny]:
         results: DictStrAny = {}
         list_fields = getattr(cls, "_collection_fields", [])
+
         def parse_data(data, annotation=None):
             req = _HttpRequest()
             get_request_data = super(_MultiPartBodyModel, cls).get_request_data
@@ -182,11 +184,13 @@ class _MultiPartBodyModel(BodyModel):
                 data = f'"{data}"'
             req.body = data.encode()
             return get_request_data(req, api, path_params)
-        
+
         for name, annotation in cls._body_params.items():
             if name in request.POST:
                 if name in list_fields:
-                    data = [parse_data(d, annotation) for d in request.POST.getlist(name)]
+                    data = [
+                        parse_data(d, annotation) for d in request.POST.getlist(name)
+                    ]
                 else:
                     data = parse_data(request.POST[name], annotation)
                 results[name] = data

--- a/ninja/params_models.py
+++ b/ninja/params_models.py
@@ -188,9 +188,16 @@ class _MultiPartBodyModel(BodyModel):
         for name, annotation in cls._body_params.items():
             if name in request.POST:
                 if name in list_fields:
-                    data = [
-                        parse_data(d, annotation) for d in request.POST.getlist(name)
-                    ]
+                    datalist = request.POST.getlist(name)
+                    if (
+                        len(datalist) == 1
+                        and datalist[0] != ""
+                        and datalist[0][0] == "["
+                        and datalist[0][-1] == "]"
+                    ):
+                        data = parse_data(datalist[0], annotation)
+                    else:
+                        data = [parse_data(d) for d in request.POST.getlist(name)]
                 else:
                     data = parse_data(request.POST[name], annotation)
                 results[name] = data

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -21,15 +21,16 @@ dotted attributes and resolver methods. For example::
 
 """
 from typing import Any, Callable, Dict, Type, TypeVar, Union, no_type_check
+from typing_extensions import dataclass_transform
 
 import pydantic
 from django.db.models import Manager, QuerySet
 from django.db.models.fields.files import FieldFile
 from django.template import Variable, VariableDoesNotExist
 from pydantic import BaseModel, Field, validator
-from pydantic.main import ModelMetaclass, __dataclass_transform__
+from pydantic.main import ModelMetaclass
 from pydantic.utils import GetterDict
-from pydantic.fields import Field, FieldInfo
+from pydantic.fields import Field as Field_, FieldInfo
 
 pydantic_version = list(map(int, pydantic.VERSION.split(".")[:2]))
 assert pydantic_version >= [1, 6], "Pydantic 1.6+ required"
@@ -120,7 +121,7 @@ class Resolver:
 
         return PartialSchema()
 
-@__dataclass_transform__(kw_only_default=True, field_descriptors=(Field, FieldInfo))
+@dataclass_transform(kw_only_default=True, field_descriptors=(Field_, FieldInfo))
 class ResolverMetaclass(ModelMetaclass):
     _ninja_resolvers: Dict[str, Resolver]
 

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -30,7 +30,7 @@ from pydantic import BaseModel, Field, validator
 from pydantic.fields import FieldInfo
 from pydantic.main import ModelMetaclass
 from pydantic.utils import GetterDict
-from typing_extensions import dataclass_transform
+from typing_extensions import dataclass_transform  # type: ignore
 
 pydantic_version = list(map(int, pydantic.VERSION.split(".")[:2]))
 assert pydantic_version >= [1, 6], "Pydantic 1.6+ required"

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -27,7 +27,7 @@ from django.db.models import Manager, QuerySet
 from django.db.models.fields.files import FieldFile
 from django.template import Variable, VariableDoesNotExist
 from pydantic import BaseModel, Field, validator
-from pydantic.fields import Field as Field_, FieldInfo
+from pydantic.fields import FieldInfo
 from pydantic.main import ModelMetaclass
 from pydantic.utils import GetterDict
 from typing_extensions import dataclass_transform
@@ -122,7 +122,7 @@ class Resolver:
         return PartialSchema()
 
 
-@dataclass_transform(kw_only_default=True, field_descriptors=(Field_, FieldInfo))
+@dataclass_transform(kw_only_default=True, field_descriptors=(Field, FieldInfo))
 class ResolverMetaclass(ModelMetaclass):
     _ninja_resolvers: Dict[str, Resolver]
 

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -27,8 +27,9 @@ from django.db.models import Manager, QuerySet
 from django.db.models.fields.files import FieldFile
 from django.template import Variable, VariableDoesNotExist
 from pydantic import BaseModel, Field, validator
-from pydantic.main import ModelMetaclass
+from pydantic.main import ModelMetaclass, __dataclass_transform__
 from pydantic.utils import GetterDict
+from pydantic.fields import Field, FieldInfo
 
 pydantic_version = list(map(int, pydantic.VERSION.split(".")[:2]))
 assert pydantic_version >= [1, 6], "Pydantic 1.6+ required"
@@ -119,7 +120,7 @@ class Resolver:
 
         return PartialSchema()
 
-
+@__dataclass_transform__(kw_only_default=True, field_descriptors=(Field, FieldInfo))
 class ResolverMetaclass(ModelMetaclass):
     _ninja_resolvers: Dict[str, Resolver]
 

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -21,16 +21,16 @@ dotted attributes and resolver methods. For example::
 
 """
 from typing import Any, Callable, Dict, Type, TypeVar, Union, no_type_check
-from typing_extensions import dataclass_transform
 
 import pydantic
 from django.db.models import Manager, QuerySet
 from django.db.models.fields.files import FieldFile
 from django.template import Variable, VariableDoesNotExist
 from pydantic import BaseModel, Field, validator
+from pydantic.fields import Field as Field_, FieldInfo
 from pydantic.main import ModelMetaclass
 from pydantic.utils import GetterDict
-from pydantic.fields import Field as Field_, FieldInfo
+from typing_extensions import dataclass_transform
 
 pydantic_version = list(map(int, pydantic.VERSION.split(".")[:2]))
 assert pydantic_version >= [1, 6], "Pydantic 1.6+ required"
@@ -120,6 +120,7 @@ class Resolver:
                 return value
 
         return PartialSchema()
+
 
 @dataclass_transform(kw_only_default=True, field_descriptors=(Field_, FieldInfo))
 class ResolverMetaclass(ModelMetaclass):

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 import pytest
 from django.http import QueryDict  # noqa
@@ -99,7 +99,7 @@ def listview6(
 
 
 @router.post("/list7")
-def listview7(request, body: List[BodyModel], file: UploadedFile | None = File(None)):
+def listview7(request, body: List[BodyModel], file: Union[UploadedFile, None] = File(None)):
     return {
         "body": body,
     }

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -169,6 +169,16 @@ client = TestClient(router)
             dict(data=QueryDict('body={"x":1,"y":1}&body={"x":1,"y":1}')),
             {"body": [{"x": 1, "y": 1}, {"x": 1, "y": 1}]},
         ),
+        (
+            "/list7",
+            dict(data=QueryDict('body={"x":1,"y":1}')),
+            {"body": [{"x": 1, "y": 1}]},
+        ),
+        (
+            "/list7",
+            dict(data=QueryDict('body=[{"x":1,"y":1},{"x":1,"y":1}]')),
+            {"body": [{"x": 1, "y": 1}, {"x": 1, "y": 1}]},
+        ),
     ]
     # fmt: on
 )

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -4,8 +4,9 @@ import pytest
 from django.http import QueryDict  # noqa
 from pydantic import BaseModel, Field, conlist
 
-from ninja import Form, Query, Router, Schema
+from ninja import File, Form, Query, Router, Schema
 from ninja.testing import TestClient
+from ninja.files import UploadedFile
 
 router = Router()
 
@@ -97,6 +98,13 @@ def listview6(
     return {"query": object_id}
 
 
+@router.post("/list7")
+def listview7(request, body: List[BodyModel], file: UploadedFile | None = File(None)):
+    return {
+        "body": body,
+    }
+
+
 client = TestClient(router)
 
 
@@ -153,6 +161,11 @@ client = TestClient(router)
             "/list6?id=1&id=2",
             {},
             {"query": [1, 2]},
+        ),
+        (
+            "/list7",
+            dict(data=QueryDict('body={"x":1,"y":1}&body={"x":1,"y":1}')),
+            {"body": [{"x": 1, "y": 1}, {"x": 1, "y": 1}]},
         ),
     ]
     # fmt: on

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -5,8 +5,8 @@ from django.http import QueryDict  # noqa
 from pydantic import BaseModel, Field, conlist
 
 from ninja import File, Form, Query, Router, Schema
-from ninja.testing import TestClient
 from ninja.files import UploadedFile
+from ninja.testing import TestClient
 
 router = Router()
 
@@ -99,7 +99,9 @@ def listview6(
 
 
 @router.post("/list7")
-def listview7(request, body: List[BodyModel], file: Union[UploadedFile, None] = File(None)):
+def listview7(
+    request, body: List[BodyModel], file: Union[UploadedFile, None] = File(None)
+):
     return {
         "body": body,
     }


### PR DESCRIPTION
When you have a view that includes a file and a list of a Schema, instead of getting a list of items, you get the last item. Because _MultiPartBodyModel class only uses request.POST[name] which only gets the last item instead of a list of all items.

[django docs on QueryDict](https://docs.djangoproject.com/en/4.1/ref/request-response/#django.http.QueryDict.__getitem__)

Now, you can get a list of items while using multipart/form-data.

Also added better editor support using typing_extensions.dataclass_transform(same thing pydantic uses). 

![image](https://user-images.githubusercontent.com/29009961/202715298-698c7321-bf9d-439c-bef5-d8fc03e3aa5d.png)

instead of **data

![image](https://user-images.githubusercontent.com/29009961/202717631-5a5104ae-710e-46e4-9dab-25d1e1e118c6.png)


I'm not sure if it is necessary to make two separate pull requests for these two.
