### PR TITLE
remove context from inspect.stack

### DIFF
--- a/ninja/utils.py
+++ b/ninja/utils.py
@@ -31,5 +31,5 @@ def is_debug_server() -> bool:
     """Check if running under the Django Debug Server"""
     return settings.DEBUG and any(
         s.filename.endswith("runserver.py") and s.function == "run"
-        for s in inspect.stack()[1:]
+        for s in inspect.stack(0)[1:]
     )


### PR DESCRIPTION
This is a quick take on #623 

https://docs.python.org/3/library/inspect.html#inspect.stack

inspect.stack(context=1) adds context lines to the stackframe.
using context=0 file loads can be avoided and might bring an improved startup time already