### PR TITLE
remove python 3.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
       - name: Install Flit
         run: pip install flit
       - name: Install Dependencies

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         django-version: ['<2.2', '<3.0', '<3.1', '<3.2', '<3.3', '<4.1']
 
     steps:

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         django-version: ['<2.2', '<3.0', '<3.1', '<3.2', '<3.3', '<4.1']
 
     steps:


### PR DESCRIPTION
python 3.6 isn't available anymore on gh-actions.

- removes version 3.6
- adds version 3.11