### PR TITLE
add tests to #597 (make enums show up in schema)

### DIFF
--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -310,6 +310,11 @@ def flatten_properties(
         definition = definitions[def_name]
         yield from flatten_properties(prop_name, definition, prop_required, definitions)
 
+    elif "items" in prop_details and "$ref" in prop_details["items"]:
+        def_name = prop_details["items"]["$ref"].split("/")[-1]
+        definition = definitions[def_name]
+        yield from flatten_properties(prop_name, definition, prop_required, definitions)
+
     elif "properties" in prop_details:
         required = set(prop_details.get("required", []))
         for k, v in prop_details["properties"].items():

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -1,5 +1,6 @@
 from typing import List, Union
 from unittest.mock import Mock
+import enum
 
 import pytest
 from django.contrib.admin.views.decorators import staff_member_required
@@ -17,8 +18,13 @@ class Payload(Schema):
     f: float
 
 
+class ATypeEnum(str, enum.Enum):
+    x = "X"
+    y = "Y"
+
 class TypeA(Schema):
     a: str
+    a_type: ATypeEnum
 
 
 class TypeB(Schema):
@@ -188,8 +194,9 @@ def test_schema(schema):
         "TypeA": {
             "properties": {
                 "a": {"title": "A", "type": "string"},
+                "a_type": {'$ref': '#/components/schemas/ATypeEnum'}
             },
-            "required": ["a"],
+            "required": ["a", "a_type"],
             "title": "TypeA",
             "type": "object",
         },
@@ -201,6 +208,12 @@ def test_schema(schema):
             "title": "TypeB",
             "type": "object",
         },
+        "ATypeEnum": {
+            "description": "An enumeration.",
+            "enum": ["X", "Y"],
+            "title": "ATypeEnum",
+            "type": "string"
+        }
     }
 
 
@@ -291,8 +304,9 @@ def test_schema_list(schema):
         "TypeA": {
             "properties": {
                 "a": {"title": "A", "type": "string"},
+                "a_type": {"$ref": "#/components/schemas/ATypeEnum"}
             },
-            "required": ["a"],
+            "required": ["a", "a_type"],
             "title": "TypeA",
             "type": "object",
         },
@@ -303,6 +317,12 @@ def test_schema_list(schema):
             "required": ["b"],
             "title": "TypeB",
             "type": "object",
+        },
+        "ATypeEnum": {
+            "description": "An enumeration.",
+            "enum": ["X", "Y"],
+            "title": "ATypeEnum",
+            "type": "string"
         },
         "Response": {
             "properties": {


### PR DESCRIPTION
this is a follow-up to #597 and adds the relevant tests to openapi-schema