### PR TITLE
Refactor serialization of pydantic response object data and move it to a NinjaAPI method for easier overriding

### DIFF
--- a/ninja/main.py
+++ b/ninja/main.py
@@ -20,6 +20,7 @@ from ninja.errors import ConfigError, set_default_exc_handlers
 from ninja.openapi import get_schema
 from ninja.openapi.schema import OpenAPISchema
 from ninja.openapi.urls import get_openapi_urls, get_root_url
+from ninja.operation import ResponseObject
 from ninja.parser import Parser
 from ninja.renderers import BaseRenderer, JSONRenderer
 from ninja.router import Router
@@ -28,6 +29,7 @@ from ninja.utils import is_debug_server, normalize_path
 
 if TYPE_CHECKING:
     from .operation import Operation  # pragma: no cover
+    from .schema import Schema
 
 __all__ = ["NinjaAPI"]
 
@@ -385,6 +387,26 @@ class NinjaAPI:
     def root_path(self) -> str:
         name = f"{self.urls_namespace}:api-root"
         return reverse(name)
+
+    def serialize_response_model_data(
+        self,
+        request: HttpRequest,
+        response_model: "Schema",
+        response_data: Any,
+        by_alias: bool = False,
+        exclude_unset: bool = False,
+        exclude_defaults: bool = False,
+        exclude_none: bool = False,
+    ) -> Any:
+        resp_object = ResponseObject(response_data)
+        # ^ we need object because getter_dict seems work only with from_orm
+        result = response_model.from_orm(resp_object).dict(
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+        )["response"]
+        return result
 
     def create_response(
         self,

--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -191,14 +191,16 @@ class Operation:
             # Empty response.
             return temporal_response
 
-        resp_object = ResponseObject(result)
-        # ^ we need object because getter_dict seems work only with from_orm
-        result = response_model.from_orm(resp_object).dict(
-            by_alias=self.by_alias,
-            exclude_unset=self.exclude_unset,
-            exclude_defaults=self.exclude_defaults,
-            exclude_none=self.exclude_none,
-        )["response"]
+        result = self.api.serialize_response_model_data(
+            request,
+            response_model,
+            result,
+            self.by_alias,
+            self.exclude_unset,
+            self.exclude_defaults,
+            self.exclude_none,
+        )
+
         return self.api.create_response(
             request, result, temporal_response=temporal_response
         )


### PR DESCRIPTION
This change takes the logic for converting a pydantic response object to a dict (pre-json conversion) and refactors it into a method on NinjaAPI.  The actual functionality and logic does not change, just the location.

The purpose of this is to make this logic easier to override by subclassing the NinjaAPI object.  If this is not the best way to organize this logic step, I am happy to do it some other way.  The main thing is to have the ability to override/replace this step with custom logic.

Why have this ability?  Sometimes you need more control over the conversion of the response object to a dict.  For example, pydantic's `dict` method supports `include` and `exclude` parameters with which you can implement output field filtering.  Alternatively, there are more complex and featureful methods of serializing a pydantic model that may be desirable.   In any case, this move allows one to modify the pydantic `dict` arguments as needed, or replace the `dict` call with something else entirely, if wanted.
