### PR TITLE
Allow reversing URLs with multiple operations.

### DIFF
--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -50,12 +50,16 @@ class Operation:
         exclude_defaults: bool = False,
         exclude_none: bool = False,
         include_in_schema: bool = True,
+        url_name: str = None,
     ) -> None:
         self.is_async = False
         self.path: str = path
         self.methods: List[str] = methods
         self.view_func: Callable = view_func
         self.api: "NinjaAPI" = cast("NinjaAPI", None)
+        self.url_name = url_name if url_name is not None else ""
+        if url_name is not None:
+            self.url_name = url_name
 
         self.auth_param: Optional[Union[Sequence[Callable], Callable, object]] = auth
         self.auth_callbacks: Sequence[Callable] = []
@@ -177,7 +181,8 @@ class Operation:
             response_model = self.response_models[Ellipsis]
         else:
             raise ConfigError(
-                f"Schema for status {status} is not set in response {self.response_models.keys()}"
+                f"Schema for status {status} is not set in response"
+                f" {self.response_models.keys()}"
             )
 
         temporal_response.status_code = status
@@ -312,6 +317,7 @@ class PathView:
             exclude_defaults=exclude_defaults,
             exclude_none=exclude_none,
             include_in_schema=include_in_schema,
+            url_name=url_name,
         )
 
         self.operations.append(operation)

--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -57,7 +57,6 @@ class Operation:
         self.methods: List[str] = methods
         self.view_func: Callable = view_func
         self.api: "NinjaAPI" = cast("NinjaAPI", None)
-        self.url_name = url_name if url_name is not None else ""
         if url_name is not None:
             self.url_name = url_name
 

--- a/tests/demo_project/demo/urls.py
+++ b/tests/demo_project/demo/urls.py
@@ -31,6 +31,16 @@ def foobar(request):
     return "foobar"
 
 
+@api_v3.post("foobar")
+def post_foobar(request):
+    return "foobar"
+
+
+@api_v3.put("foobar", url_name="foobar_put")
+def put_foobar(request):
+    return "foobar"
+
+
 api_multi_param = NinjaAPI(version="1.0.1")
 api_multi_param.add_router("", multi_param)
 

--- a/tests/test_reverse.py
+++ b/tests/test_reverse.py
@@ -1,0 +1,14 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.parametrize(
+    "view_name, path",
+    [
+        ("foobar", "/api/v3/foobar"),
+        ("post_foobar", "/api/v3/foobar"),
+        ("foobar_put", "/api/v3/foobar"),
+    ],
+)
+def test_reverse(view_name, path):
+    assert reverse(f"api-3.0.0:{view_name}") == path


### PR DESCRIPTION
A pretty glaring shortcoming is that it is impossible to reverse URLs that have been registered with same path, but different operations.

Using the same path for different operations is a pretty common pattern. It is even used throughout Ninja's documentation.

    @router.get("/{identifier}")
    def detail(request, identifier: str):
        return "ok"

    @router.put("/{identifier}")
    def update(request, identifier: str, data: Policy):
        return "ok"

The above is perfectly valid, but reversing `update` using `django.urls.reverse()` will result in a `NoReverseMatch` error.

This commit is an attempt at solving the issue. N.B. I am not familiar with the internals of Ninja. This is just an experiment.