### PR TITLE
[Docs] remove broken link

### DIFF
--- a/docs/docs/proposals/index.md
+++ b/docs/docs/proposals/index.md
@@ -7,4 +7,3 @@ You can create a proposal by making a pull request with a new page under [`docs/
 Please see the current proposals:
 
  - [Class Based Operations](cbv)
- - [Schemas from Django models](models)


### PR DESCRIPTION
The [proposals section](https://django-ninja.rest-framework.com/proposals/) in the docs references [Schemas from Django models](https://django-ninja.rest-framework.com/proposals/models), which seems to have been implemented already. 

This PR removes the broken link. 