### PR TITLE
improve error message in export_openapi_schema

### DIFF
--- a/ninja/management/commands/export_openapi_schema.py
+++ b/ninja/management/commands/export_openapi_schema.py
@@ -27,7 +27,12 @@ class Command(BaseCommand):
 
     def _get_api_instance(self, api_path: Optional[str] = None) -> NinjaAPI:
         if not api_path:
-            return resolve("/api/").func.keywords["api"]  # type: ignore
+            try:
+                return resolve("/api/").func.keywords["api"]  # type: ignore
+            except AttributeError:
+                raise CommandError(
+                    "No NinjaAPI instance found; please specify one with --api"
+                )
 
         try:
             api = import_string(api_path)

--- a/tests/test_export_openapi_schema.py
+++ b/tests/test_export_openapi_schema.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 from io import StringIO
+from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
@@ -45,3 +46,12 @@ def test_export_custom():
 
     call_command(ExportCmd(), api="demo.urls.api_v1")
     call_command(ExportCmd(), api="demo.urls.api_v2")
+
+
+@patch("ninja.management.commands.export_openapi_schema.resolve")
+def test_export_default_without_api_endpoint(mock):
+    mock.side_effect = AttributeError()
+    output = StringIO()
+    with pytest.raises(CommandError) as e:
+        call_command(ExportCmd(), stdout=output)
+    assert str(e.value) == "No NinjaAPI instance found; please specify one with --api"


### PR DESCRIPTION
Closes https://github.com/vitalik/django-ninja/issues/381

Currently, if you don't have a NinjaAPI instance at the URL `/api/`, then the `export_openapi_schema` command will fail with an opaque error message. This PR improves the error message in that scenario, telling the user to pass the path to the API using the `--api` flag.