### PR TITLE
Fix #666: Support auth inheritance for routers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         additional_dependencies: ["django-stubs", "pydantic"]
         exclude: (tests|docs)/
   - repo: https://github.com/psf/black
-    rev: "22.3.0"
+    rev: "23.1.0"
     hooks:
       - id: black
         exclude: docs/src/

--- a/ninja/main.py
+++ b/ninja/main.py
@@ -353,7 +353,7 @@ class NinjaAPI:
             prefix = normalize_path("/".join((parent_prefix, prefix))).lstrip("/")
 
         self._routers.extend(router.build_routers(prefix))
-        router.set_api_instance(self)
+        router.set_api_instance(self, parent_router)
 
     @property
     def urls(self) -> Tuple[List[Union[URLResolver, URLPattern]], str, str]:

--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -179,7 +179,6 @@ class OpenAPISchema(dict):
         by_alias: bool = True,
         remove_level: bool = True,
     ) -> Tuple[DictStrAny, bool]:
-
         if hasattr(model, "_flatten_map"):
             schema = self._flatten_schema(model)
         else:
@@ -242,7 +241,6 @@ class OpenAPISchema(dict):
 
         result = {}
         for status, model in operation.response_models.items():
-
             if status == Ellipsis:
                 continue  # it's not yet clear what it means if user wants to output any other code
 

--- a/ninja/params_models.py
+++ b/ninja/params_models.py
@@ -163,7 +163,6 @@ class FileModel(ParamModel):
 
 
 class _HttpRequest(HttpRequest):
-
     body: bytes = b""
 
 

--- a/ninja/router.py
+++ b/ninja/router.py
@@ -299,6 +299,8 @@ class Router:
         self, api: "NinjaAPI", parent_router: Optional["Router"] = None
     ) -> None:
         # TODO: check - parent_router seems not used
+        if self.auth is NOT_SET and parent_router and parent_router.auth:
+            self.auth = parent_router.auth
         self.api = api
         for path_view in self.path_operations.values():
             path_view.set_api_instance(self.api, self)

--- a/ninja/security/http.py
+++ b/ninja/security/http.py
@@ -83,5 +83,7 @@ class HttpBasicAuth(HttpAuthBase, ABC):  # TODO: maybe HttpBasicAuthBase
         try:
             username, password = b64decode(user_pass_encoded).decode().split(":", 1)
             return unquote(username), unquote(password)
-        except Exception as e:  # dear contributors please do not change to valueerror - here can be multiple exceptions
+        except (
+            Exception
+        ) as e:  # dear contributors please do not change to valueerror - here can be multiple exceptions
             raise DecodeError("Invalid Authorization header") from e

--- a/tests/test_auth_inheritance_routers.py
+++ b/tests/test_auth_inheritance_routers.py
@@ -1,8 +1,8 @@
 import pytest
-from ninja.testing import TestClient
 
 from ninja import NinjaAPI, Router
 from ninja.security import APIKeyQuery
+from ninja.testing import TestClient
 
 
 class Auth(APIKeyQuery):

--- a/tests/test_auth_inheritance_routers.py
+++ b/tests/test_auth_inheritance_routers.py
@@ -1,0 +1,76 @@
+import pytest
+from ninja.testing import TestClient
+
+from ninja import NinjaAPI, Router
+from ninja.security import APIKeyQuery
+
+
+class Auth(APIKeyQuery):
+    def __init__(self, secret):
+        self.secret = secret
+        super().__init__()
+
+    def authenticate(self, request, key):
+        if key == self.secret:
+            return key
+
+
+api = NinjaAPI()
+
+r1 = Router()
+r2 = Router()
+r3 = Router()
+r4 = Router()
+
+api.add_router("/r1", r1, auth=Auth("r1_auth"))
+r1.add_router("/r2", r2)
+r2.add_router("/r3", r3)
+r3.add_router("/r4", r4, auth=Auth("r4_auth"))
+
+client = TestClient(api)
+
+
+@r1.get("/")
+def op1(request):
+    return request.auth
+
+
+@r2.get("/")
+def op2(request):
+    return request.auth
+
+
+@r3.get("/")
+def op3(request):
+    return request.auth
+
+
+@r4.get("/")
+def op4(request):
+    return request.auth
+
+
+@r3.get("/op5", auth=Auth("op5_auth"))
+def op5(request):
+    return request.auth
+
+
+@pytest.mark.parametrize(
+    "route, status_code",
+    [
+        ("/r1/", 401),
+        ("/r1/r2/", 401),
+        ("/r1/r2/r3/", 401),
+        ("/r1/r2/r3/r4/", 401),
+        ("/r1/r2/r3/op5", 401),
+        ("/r1/?key=r1_auth", 200),
+        ("/r1/r2/?key=r1_auth", 200),
+        ("/r1/r2/r3/?key=r1_auth", 200),
+        ("/r1/r2/r3/r4/?key=r4_auth", 200),
+        ("/r1/r2/r3/op5?key=op5_auth", 200),
+        ("/r1/r2/r3/r4/?key=r1_auth", 401),
+        ("/r1/r2/r3/op5?key=r1_auth", 401),
+    ],
+)
+def test_router_inheritance_auth(route, status_code):
+    assert client.get(route).status_code == status_code

--- a/tests/test_docs/test_body.py
+++ b/tests/test_docs/test_body.py
@@ -5,7 +5,6 @@ from ninja.testing import TestClient
 
 
 def test_examples():
-
     api = NinjaAPI()
 
     with patch("builtins.api", api, create=True):

--- a/tests/test_docs/test_form.py
+++ b/tests/test_docs/test_form.py
@@ -5,7 +5,6 @@ from ninja.testing import TestClient
 
 
 def test_examples():
-
     api = NinjaAPI()
 
     with patch("builtins.api", api, create=True):

--- a/tests/test_docs/test_path.py
+++ b/tests/test_docs/test_path.py
@@ -5,7 +5,6 @@ from ninja.testing import TestClient
 
 
 def test_examples():
-
     api = NinjaAPI()
 
     with patch("builtins.api", api, create=True):

--- a/tests/test_docs/test_query.py
+++ b/tests/test_docs/test_query.py
@@ -5,7 +5,6 @@ from ninja.testing import TestClient
 
 
 def test_examples():
-
     api = NinjaAPI()
 
     with patch("builtins.api", api, create=True):

--- a/tests/test_export_openapi_schema.py
+++ b/tests/test_export_openapi_schema.py
@@ -11,7 +11,6 @@ from ninja.management.commands.export_openapi_schema import Command as ExportCmd
 
 
 def test_export_default():
-
     output = StringIO()
     call_command(ExportCmd(), stdout=output)
     json.loads(output.getvalue())  # if no exception, then OK

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -660,7 +660,6 @@ def test_union_payload_simple(schema):
 
 
 def test_get_openapi_urls():
-
     api = NinjaAPI(openapi_url=None)
     paths = get_openapi_urls(api)
     assert len(paths) == 0
@@ -677,7 +676,6 @@ def test_get_openapi_urls():
 
 
 def test_unique_operation_ids():
-
     api = NinjaAPI()
 
     @api.get("/1")

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -67,7 +67,6 @@ def test_django_2_2_plus_headers(version, has_headers):
 
 
 class ClientTestSchema(Schema):
-
     time: datetime
 
 


### PR DESCRIPTION
This PR fixes #666 and adds support to the inheritance of auth in routers.