### PR TITLE
fix List[enum] in query params

### DIFF
--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -304,6 +304,12 @@ def flatten_properties(
             for item in prop_details["allOf"]:
                 yield from flatten_properties("", item, True, definitions)
 
+    elif "items" in prop_details and "$ref" in prop_details["items"]:
+        def_name = prop_details["items"]["$ref"].rsplit("/", 1)[-1]
+        prop_details["items"].update(definitions[def_name])
+        del prop_details["items"]["$ref"]
+        yield prop_name, prop_details, prop_required
+
     elif "$ref" in prop_details:
         def_name = prop_details["$ref"].split("/")[-1]
         definition = definitions[def_name]

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,6 +1,5 @@
 from datetime import date
 from enum import Enum
-from pprint import pprint
 from typing import List, Optional
 
 from pydantic import BaseModel


### PR DESCRIPTION
For #152 

At the moment the schema-to-openai converter doesn't correctly resolve a List[enum]. It assumes it's in the definitions - but is never added to the definitions unless it is used in a response schema.

I've fixed this by resolving the 'items' using the definitions in the schema: https://json-schema.org/understanding-json-schema/reference/array.html#items

Though I think a better way would be to just add the enum to the schema definitions but it didn't look like that's how you had done it before with the other enums so I emulated your method.