### PR TITLE
Support both new and old style Union/Optional

### DIFF
--- a/ninja/signature/details.py
+++ b/ninja/signature/details.py
@@ -24,6 +24,13 @@ FuncParam = namedtuple(
     "FuncParam", ["name", "alias", "source", "annotation", "is_collection"]
 )
 
+try:
+    from types import UnionType
+
+    UNION_TYPES = (Union, UnionType)
+except ImportError:
+    UNION_TYPES = (Union,)
+
 
 class ViewSignature:
     FLATTEN_PATH_SEP = (
@@ -247,7 +254,7 @@ class ViewSignature:
 
 def is_pydantic_model(cls: Any) -> bool:
     try:
-        if get_collection_origin(cls) == Union:
+        if get_collection_origin(cls) in UNION_TYPES:
             return any(issubclass(arg, pydantic.BaseModel) for arg in get_args(cls))
         return issubclass(cls, pydantic.BaseModel)
     except TypeError:

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -111,13 +111,9 @@ def method_union_payload_and_simple(request, data: Union[int, TypeB]):
 if sys.version_info >= (3, 10):
     # This requires Python 3.10 or higher (PEP 604), so we're using eval to
     # conditionally make it available
-    exec(
-        """
-@api.post("/test-new-union-type", response=Response)
-def method_new_union_payload(request, data: TypeA | TypeB):
-    return dict(i=data.i, f=data.f)
-"""
-    )
+    @api.post("/test-new-union-type", response=Response)
+    def method_new_union_payload(request, data: "TypeA | TypeB"):
+        return dict(i=data.i, f=data.f)
 
 
 @api.post(


### PR DESCRIPTION
The Python 3.10+ syntax of creating a union or optional type (with `str | int`), results in a different type than using the pre-Python 3.10 syntax (`Union[str, int]`).

```pycon
>>> from typing import Optional, Union, get_origin
>>> get_origin(Union[int, str])
typing.Union
>>> get_origin(int | str)
<class 'types.UnionType'>
>>> get_origin(Optional[int])
typing.Union
>>> get_origin(int | None)
<class 'types.UnionType'>
```

I'm curious about how to update the test so that it works on both Python 3.9 and Python 3.10.
If you can point me in the right direction, I'll gladly update it.

This would fix #685.
