### PR TITLE
"Django's cache framework" added.

### DIFF
--- a/ninja/constants.py
+++ b/ninja/constants.py
@@ -15,3 +15,6 @@ class NOT_SET_TYPE:
 
 
 NOT_SET = NOT_SET_TYPE()
+
+# 1 second
+CACHE_TIMEOUT = 1

--- a/ninja/main.py
+++ b/ninja/main.py
@@ -15,7 +15,7 @@ from typing import (
 from django.http import HttpRequest, HttpResponse
 from django.urls import URLPattern, URLResolver, reverse
 
-from ninja.constants import NOT_SET, NOT_SET_TYPE
+from ninja.constants import NOT_SET, NOT_SET_TYPE, CACHE_TIMEOUT
 from ninja.errors import ConfigError, set_default_exc_handlers
 from ninja.openapi import get_schema
 from ninja.openapi.schema import OpenAPISchema
@@ -58,6 +58,8 @@ class NinjaAPI:
         renderer: Optional[BaseRenderer] = None,
         parser: Optional[Parser] = None,
         default_router: Optional[Router] = None,
+        cache_timeout: Optional[int] = None,
+        cache: bool = False,
     ):
         """
         Args:
@@ -90,6 +92,9 @@ class NinjaAPI:
 
         self.auth: Optional[Union[Sequence[Callable], NOT_SET_TYPE]]
 
+        self.cache_timeout = cache_timeout if cache_timeout else CACHE_TIMEOUT
+        self.cache = cache
+
         if callable(auth):
             self.auth = [auth]
         else:
@@ -117,6 +122,8 @@ class NinjaAPI:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        cache_timeout: Optional[int] = None,
+        cache: bool = False,
     ) -> Callable[[TCallable], TCallable]:
         """
         `GET` operation. See <a href="../operations-parameters">operations
@@ -138,6 +145,8 @@ class NinjaAPI:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            cache_timeout=cache_timeout,
+            cache=cache,
         )
 
     def post(
@@ -158,6 +167,8 @@ class NinjaAPI:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        cache_timeout: Optional[int] = None,
+        cache: bool = False,
     ) -> Callable[[TCallable], TCallable]:
         """
         `POST` operation. See <a href="../operations-parameters">operations
@@ -179,6 +190,8 @@ class NinjaAPI:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            cache_timeout=cache_timeout,
+            cache=cache,
         )
 
     def delete(
@@ -199,6 +212,8 @@ class NinjaAPI:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        cache_timeout: Optional[int] = None,
+        cache: bool = False,
     ) -> Callable[[TCallable], TCallable]:
         """
         `DELETE` operation. See <a href="../operations-parameters">operations
@@ -220,6 +235,8 @@ class NinjaAPI:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            cache_timeout=cache_timeout,
+            cache=cache,
         )
 
     def patch(
@@ -240,6 +257,8 @@ class NinjaAPI:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        cache_timeout: Optional[int] = None,
+        cache: bool = False,
     ) -> Callable[[TCallable], TCallable]:
         """
         `PATCH` operation. See <a href="../operations-parameters">operations
@@ -261,6 +280,8 @@ class NinjaAPI:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            cache_timeout=cache_timeout,
+            cache=cache,
         )
 
     def put(
@@ -281,6 +302,8 @@ class NinjaAPI:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        cache_timeout: Optional[int] = None,
+        cache: bool = False,
     ) -> Callable[[TCallable], TCallable]:
         """
         `PUT` operation. See <a href="../operations-parameters">operations
@@ -302,6 +325,8 @@ class NinjaAPI:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            cache_timeout=cache_timeout,
+            cache=cache,
         )
 
     def api_operation(
@@ -323,6 +348,8 @@ class NinjaAPI:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        cache_timeout: Optional[int] = None,
+        cache: bool = False,
     ) -> Callable[[TCallable], TCallable]:
         return self.default_router.api_operation(
             methods,
@@ -341,6 +368,8 @@ class NinjaAPI:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            cache_timeout=cache_timeout,
+            cache=cache,
         )
 
     def add_router(

--- a/ninja/router.py
+++ b/ninja/router.py
@@ -43,6 +43,8 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        cache_timeout: Optional[int] = None,
+        cache: bool = False,
     ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["GET"],
@@ -61,6 +63,8 @@ class Router:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            cache_timeout=cache_timeout,
+            cache=cache,
         )
 
     def post(
@@ -81,6 +85,8 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        cache_timeout: Optional[int] = None,
+        cache: bool = False,
     ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["POST"],
@@ -99,6 +105,8 @@ class Router:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            cache_timeout=cache_timeout,
+            cache=cache,
         )
 
     def delete(
@@ -119,6 +127,8 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        cache_timeout: Optional[int] = None,
+        cache: bool = False,
     ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["DELETE"],
@@ -137,6 +147,8 @@ class Router:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            cache_timeout=cache_timeout,
+            cache=cache,
         )
 
     def patch(
@@ -157,6 +169,8 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        cache_timeout: Optional[int] = None,
+        cache: bool = False,
     ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["PATCH"],
@@ -175,6 +189,8 @@ class Router:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            cache_timeout=cache_timeout,
+            cache=cache,
         )
 
     def put(
@@ -195,6 +211,8 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        cache_timeout: Optional[int] = None,
+        cache: bool = False,
     ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["PUT"],
@@ -213,6 +231,8 @@ class Router:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            cache_timeout=cache_timeout,
+            cache=cache,
         )
 
     def api_operation(
@@ -234,6 +254,8 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        cache_timeout: Optional[int] = None,
+        cache: bool = False,
     ) -> Callable[[TCallable], TCallable]:
         def decorator(view_func: TCallable) -> TCallable:
             self.add_api_operation(
@@ -254,6 +276,8 @@ class Router:
                 url_name=url_name,
                 include_in_schema=include_in_schema,
                 openapi_extra=openapi_extra,
+                cache_timeout=cache_timeout,
+                cache=cache,
             )
             return view_func
 
@@ -279,6 +303,8 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        cache_timeout: Optional[int] = None,
+        cache: bool = False,
     ) -> None:
         if path not in self.path_operations:
             path_view = PathView()
@@ -303,6 +329,8 @@ class Router:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            cache_timeout=cache_timeout,
+            cache=cache,
         )
         if self.api:
             path_view.set_api_instance(self.api, self)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,60 @@
+import time
+from time import sleep
+
+import pytest
+from pydantic import BaseModel
+
+from ninja import Router, NinjaAPI
+from ninja.testing import TestClient
+
+api = NinjaAPI(
+    cache=True,
+    cache_timeout=3,
+)
+
+
+class User(BaseModel):
+    username: str
+    email: str
+
+
+user = User(
+    username="ninjadev",
+    email="ninja@ninja.dev",
+)
+
+
+@api.get("/user", response=User, cache=True)
+def get_user(request):
+    return user
+
+
+@api.get("/change-user", response=User)
+def change_user(request):
+    user.username += "_changed"
+    return user
+
+
+@api.get("/sleep", response=str)
+def sleep(request):
+    time.sleep(4)
+    return "done"
+
+
+client = TestClient(api)
+
+
+@pytest.mark.parametrize(
+    "path,expected_result",
+    [
+        ("/user", {"username": "ninjadev", "email": "ninja@ninja.dev"}),
+        ("/change-user", {"username": "ninjadev_changed", "email": "ninja@ninja.dev"}),
+        ("/user", {"username": "ninjadev", "email": "ninja@ninja.dev"}),
+        ("/sleep", "done"),
+        ("/user", {"username": "ninjadev_changed", "email": "ninja@ninja.dev"}),
+    ]
+)
+def test_cache_responses(path, expected_result):
+    response = client.get(path)
+    assert response.status_code == 200, response.content
+    assert response.json() == expected_result

--- a/tests/test_cache_async.py
+++ b/tests/test_cache_async.py
@@ -1,0 +1,62 @@
+import asyncio
+import time
+from time import sleep
+
+import pytest
+from pydantic import BaseModel
+
+from ninja import Router, NinjaAPI
+from ninja.testing import TestClient, TestAsyncClient
+
+api = NinjaAPI(
+    cache=True,
+    cache_timeout=3,
+)
+
+
+class User(BaseModel):
+    username: str
+    email: str
+
+
+user = User(
+    username="ninjadev",
+    email="ninja@ninja.dev",
+)
+
+
+@api.get("/user", response=User, cache=True)
+async def get_user(request):
+    return user
+
+
+@api.get("/change-user", response=User)
+async def change_user(request):
+    user.username += "_changed"
+    return user
+
+
+@api.get("/sleep", response=str)
+async def sleep(request):
+    await asyncio.sleep(4)
+    return "done"
+
+
+client = TestAsyncClient(api)
+
+
+@pytest.mark.parametrize(
+    "path,expected_result",
+    [
+        ("/user", {"username": "ninjadev", "email": "ninja@ninja.dev"}),
+        ("/change-user", {"username": "ninjadev_changed", "email": "ninja@ninja.dev"}),
+        ("/user", {"username": "ninjadev", "email": "ninja@ninja.dev"}),
+        ("/sleep", "done"),
+        ("/user", {"username": "ninjadev_changed", "email": "ninja@ninja.dev"}),
+    ]
+)
+@pytest.mark.asyncio
+async def test_cache_responses(path, expected_result):
+    response = await client.get(path)
+    assert response.status_code == 200, response.content
+    assert response.json() == expected_result


### PR DESCRIPTION
"caching" can be enabled by global NinjaAPI's "cache" parameter. Each HTTP method(GET, PUT, POST... or routes) has its own "cache" and "cache_timeout" parameters.

Constants:

CACHE_TIMEOUT: 1 second