### PR TITLE
Add support for favicon and a custom redoc x-logo

### DIFF
--- a/docs/docs/guides/api-docs.md
+++ b/docs/docs/guides/api-docs.md
@@ -29,7 +29,7 @@ use a custom favicon_url
 ```Python
 api = NinjaAPI(favicon_url="https://example.com/favicon.ico")
 ```
-use a custom logo for (only supported in redoc)
+use a custom logo (only supported in Redoc)
     
 ```Python
 api = NinjaAPI(x_logo_url="https://example.com/logo.png")

--- a/docs/docs/guides/api-docs.md
+++ b/docs/docs/guides/api-docs.md
@@ -23,6 +23,19 @@ NINJA_DOCS_VIEW = 'redoc'
 
 Then you will see the alternative automatic documentation (provided by <a href="https://github.com/Redocly/redoc" target="_blank">Redoc</a>).
 
+## Customize Docs
+use a custom favicon_url
+    
+```Python
+api = NinjaAPI(favicon_url="https://example.com/favicon.ico")
+```
+use a custom logo for (only supported in redoc)
+    
+```Python
+api = NinjaAPI(x_logo_url="https://example.com/logo.png")
+```
+
+
 ## Hiding docs
 
 In case you do not need to display interactive documetation - set `docs_url` argument to `None`

--- a/ninja/main.py
+++ b/ninja/main.py
@@ -48,6 +48,8 @@ class NinjaAPI:
         title: str = "NinjaAPI",
         version: str = "1.0.0",
         description: str = "",
+        favicon_url: str = "",
+        x_logo_url: str = "",
         openapi_url: Optional[str] = "/openapi.json",
         docs_url: Optional[str] = "/docs",
         servers: Optional[List[Dict[str, Union[str, Any]]]] = None,
@@ -76,6 +78,8 @@ class NinjaAPI:
         self.title = title
         self.version = version
         self.description = description
+        self.favicon_url = favicon_url
+        self.x_logo_url = x_logo_url
         self.openapi_url = openapi_url
         self.docs_url = docs_url
         self.servers = servers

--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -48,6 +48,9 @@ class OpenAPISchema(dict):
         self.schemas: DictStrAny = {}
         self.securitySchemes: DictStrAny = {}
         self.all_operation_ids: Set = set()
+        info_kwargs = {}
+        if api.x_logo_url:
+            info_kwargs["x-logo"] = {"url": api.x_logo_url}
         super().__init__(
             [
                 ("openapi", "3.0.2"),
@@ -57,6 +60,7 @@ class OpenAPISchema(dict):
                         "title": api.title,
                         "version": api.version,
                         "description": api.description,
+                        **info_kwargs
                     },
                 ),
                 ("paths", self.get_paths()),

--- a/ninja/templates/ninja/redoc.html
+++ b/ninja/templates/ninja/redoc.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <link rel="shortcut icon" href="{% static 'ninja/favicon.png' %}">
+    <link rel="shortcut icon" href="{{ api.favicon_url }}">
     <title>{{ api.title }}</title>
 </head>
 <body>

--- a/ninja/templates/ninja/redoc_cdn.html
+++ b/ninja/templates/ninja/redoc_cdn.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <link rel="shortcut icon" href="https://django-ninja.rest-framework.com/img/favicon.png">
+    <link rel="shortcut icon" href="{{ api.favicon_url }}">
     <title>{{ api.title }}</title>
 </head>
 <body>

--- a/ninja/templates/ninja/swagger.html
+++ b/ninja/templates/ninja/swagger.html
@@ -3,7 +3,7 @@
 <html>
 <head>
     <link type="text/css" rel="stylesheet" href="{% static 'ninja/swagger-ui.css' %}">
-    <link rel="shortcut icon" href="{% static 'ninja/favicon.png' %}">
+    <link rel="shortcut icon" href="{{ api.favicon_url }}">
     <title>{{ api.title }}</title>
 </head>
 <body>

--- a/ninja/templates/ninja/swagger_cdn.html
+++ b/ninja/templates/ninja/swagger_cdn.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.15.5/swagger-ui.css">
-    <link rel="shortcut icon" href="https://django-ninja.rest-framework.com/img/favicon.png">
+    <link rel="shortcut icon" href="{{ api.favicon_url }}">
     <title>{{ api.title }}</title>
 </head>
 <body>


### PR DESCRIPTION
I find it hard to add the x-logo support for redoc/easily add a favicon url

Solution:
adding `favicon_url` and `x_logo_url` into `__init__` in `main.py`

and allow more attributes in the schema info section