### PR TITLE
Added a section detailing how to reverse a url for the api docs page.

### DIFF
--- a/docs/docs/guides/api-docs.md
+++ b/docs/docs/guides/api-docs.md
@@ -9,7 +9,7 @@ You will see the automatic, interactive API documentation (provided by the <a hr
 
 ## CDN vs staticfiles
 
-You are not required to put django ninja to `INSTALLED_APPS`. In that case the interactive UI is hosted by CDN. 
+You are not required to put django ninja to `INSTALLED_APPS`. In that case the interactive UI is hosted by CDN.
 
 To host docs (Js/css) from your own server - just put "ninja" to INSTALLED_APPS - in that case standard django staticfiles mechanics will host it.
 
@@ -39,4 +39,24 @@ To protect docs with authentication (or decorate for some other use case) use `d
 from django.contrib.admin.views.decorators import staff_member_required
 
 api = NinjaAPI(docs_decorator=staff_member_required)
+```
+
+## Resolving the doc's url
+
+The url for the api's documentation view can be reversed by referencing the view's name `openapi-view`.
+
+In Python code, for example:
+```Python
+from django.urls import reverse
+
+reverse('api-1.0.0:openapi-view')
+
+>>> '/api/docs'
+```
+
+In a Django template, for example:
+```Html
+<a href="{% url 'api-1.0.0:openapi-view' %}">API Docs</a>
+
+>>> <a href="/api/docs">API Docs</a>
 ```


### PR DESCRIPTION
I've added a section titled **Resolving the doc's url** to the **API Docs** page, detailing how to reverse a url for the api documentation view. This has been created in response to [issue 712](https://github.com/vitalik/django-ninja/issues/712). I was unable to find any reference to a name for the api docs view to use with Django's reverse feature.
[vitalik](https://github.com/vitalik) has pointed out that the view's name is _openapi-view_.