### PR TITLE
fix: allow default example to be included in pagination output in generated API docs.

### DIFF
--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -209,7 +209,6 @@ def make_response_paginated(paginator: PaginationBase, op: Operation) -> None:
         (paginator.Output,),
         {
             "__annotations__": {paginator.items_attribute: List[item_schema]},  # type: ignore
-            paginator.items_attribute: [],
         },
     )  # typing: ignore
 


### PR DESCRIPTION
ref: #502