### PR TITLE
Implement rudimentary support for async auth

### DIFF
--- a/docs/docs/guides/authentication.md
+++ b/docs/docs/guides/authentication.md
@@ -34,7 +34,7 @@ Now, when you click the **Authorize** button, you will get a prompt to input you
 When you do test calls, the Authorization header will be passed for every request.
 
 
-## Global authentication 
+## Global authentication
 
 In case you need to secure **all** methods of your API, you can pass the `auth` argument to the `NinjaAPI` constructor:
 
@@ -173,5 +173,21 @@ the same way an operation would:
 ```Python hl_lines="1 4"
 {!./src/tutorial/authentication/bearer02.py!}
 ```
+
+
+## Async authentication
+
+**Django Ninja** has basic support for asynchronous authentication. While the default authentication classes are not async-compatible, you can still define your custom asynchronous authentication callables and pass them in using `auth`.
+
+```python
+async def async_auth(request):
+    ...
+
+
+@api.get("/pets", auth=async_auth)
+def pets(request):
+    ...
+```
+
 
 See [Handling errors](errors.md) for more information.

--- a/ninja/utils.py
+++ b/ninja/utils.py
@@ -33,3 +33,9 @@ def is_debug_server() -> bool:
         s.filename.endswith("runserver.py") and s.function == "run"
         for s in inspect.stack(0)[1:]
     )
+
+
+def is_async_callable(f: Callable) -> bool:
+    return inspect.iscoroutinefunction(f) or inspect.iscoroutinefunction(
+        getattr(f, "__call__", None)
+    )

--- a/tests/test_auth_async.py
+++ b/tests/test_auth_async.py
@@ -1,0 +1,114 @@
+import asyncio
+
+import django
+import pytest
+
+from ninja import NinjaAPI
+from ninja.testing import TestAsyncClient
+
+
+@pytest.mark.skipif(django.VERSION < (3, 1), reason="requires django 3.1 or higher")
+@pytest.mark.asyncio
+async def test_async_view_handles_async_auth_func():
+    api = NinjaAPI()
+
+    async def auth(request):
+        key = request.GET.get("key")
+        if key == "secret":
+            return key
+
+    @api.get("/async", auth=auth)
+    async def view(request):
+        await asyncio.sleep(0)
+        return {"key": request.auth}
+
+    client = TestAsyncClient(api)
+
+    # Actual tests --------------------------------------------------
+
+    # without auth:
+    res = await client.get("/async")
+    assert res.status_code == 401
+
+    # async successful
+    res = await client.get("/async?key=secret")
+    assert res.json() == {"key": "secret"}
+
+
+@pytest.mark.skipif(django.VERSION < (3, 1), reason="requires django 3.1 or higher")
+@pytest.mark.asyncio
+async def test_async_view_handles_async_auth_cls():
+    api = NinjaAPI()
+
+    class Auth:
+        async def __call__(self, request):
+            key = request.GET.get("key")
+            if key == "secret":
+                return key
+
+    @api.get("/async", auth=Auth())
+    async def view(request):
+        await asyncio.sleep(0)
+        return {"key": request.auth}
+
+    client = TestAsyncClient(api)
+
+    # Actual tests --------------------------------------------------
+
+    # without auth:
+    res = await client.get("/async")
+    assert res.status_code == 401
+
+    # async successful
+    res = await client.get("/async?key=secret")
+    assert res.json() == {"key": "secret"}
+
+
+@pytest.mark.skipif(django.VERSION < (3, 1), reason="requires django 3.1 or higher")
+@pytest.mark.asyncio
+async def test_async_view_handles_multi_auth():
+    api = NinjaAPI()
+
+    def auth_1(request):
+        return None
+
+    async def auth_2(request):
+        return None
+
+    async def auth_3(request):
+        key = request.GET.get("key")
+        if key == "secret":
+            return key
+
+    @api.get("/async", auth=[auth_1, auth_2, auth_3])
+    async def view(request):
+        await asyncio.sleep(0)
+        return {"key": request.auth}
+
+    client = TestAsyncClient(api)
+
+    res = await client.get("/async?key=secret")
+    assert res.json() == {"key": "secret"}
+
+
+@pytest.mark.skipif(django.VERSION < (3, 1), reason="requires django 3.1 or higher")
+@pytest.mark.asyncio
+async def test_async_view_handles_auth_errors():
+    api = NinjaAPI()
+
+    async def auth(request):
+        raise Exception("boom")
+
+    @api.get("/async", auth=auth)
+    async def view(request):
+        await asyncio.sleep(0)
+        return {"key": request.auth}
+
+    @api.exception_handler(Exception)
+    def on_custom_error(request, exc):
+        return api.create_response(request, {"custom": True}, status=401)
+
+    client = TestAsyncClient(api)
+
+    res = await client.get("/async?key=secret")
+    assert res.json() == {"custom": True}

--- a/tests/test_csrf_async.py
+++ b/tests/test_csrf_async.py
@@ -17,20 +17,6 @@ class TestAsyncClient(BaseTestAsyncClient):
         return request
 
 
-csrf_OFF = NinjaAPI(urls_namespace="csrf_OFF")
-csrf_ON = NinjaAPI(urls_namespace="csrf_ON", csrf=True)
-
-
-@csrf_OFF.post("/post")
-async def post_off(request):
-    return {"success": True}
-
-
-@csrf_ON.post("/post")
-async def post_on(request):
-    return {"success": True}
-
-
 TOKEN = "1bcdefghij2bcdefghij3bcdefghij4bcdefghij5bcdefghij6bcdefghijABCD"
 COOKIES = {settings.CSRF_COOKIE_NAME: TOKEN}
 
@@ -38,6 +24,12 @@ COOKIES = {settings.CSRF_COOKIE_NAME: TOKEN}
 @pytest.mark.skipif(django.VERSION < (3, 1), reason="requires django 3.1 or higher")
 @pytest.mark.asyncio
 async def test_csrf_off():
+    csrf_OFF = NinjaAPI(urls_namespace="csrf_OFF")
+
+    @csrf_OFF.post("/post")
+    async def post_off(request):
+        return {"success": True}
+
     client = TestAsyncClient(csrf_OFF)
     response = await client.post("/post", COOKIES=COOKIES)
     assert response.status_code == 200
@@ -46,6 +38,12 @@ async def test_csrf_off():
 @pytest.mark.skipif(django.VERSION < (3, 1), reason="requires django 3.1 or higher")
 @pytest.mark.asyncio
 async def test_csrf_on():
+    csrf_ON = NinjaAPI(urls_namespace="csrf_ON", csrf=True)
+
+    @csrf_ON.post("/post")
+    async def post_on(request):
+        return {"success": True}
+
     client = TestAsyncClient(csrf_ON)
 
     response = await client.post("/post", COOKIES=COOKIES)

--- a/tests/test_csrf_async.py
+++ b/tests/test_csrf_async.py
@@ -1,0 +1,103 @@
+from unittest import mock
+
+import django
+import pytest
+from django.conf import settings
+
+from ninja import NinjaAPI
+from ninja.errors import ConfigError
+from ninja.security import APIKeyCookie
+from ninja.testing import TestAsyncClient as BaseTestAsyncClient
+
+
+class TestAsyncClient(BaseTestAsyncClient):
+    def _build_request(self, *args, **kwargs):
+        request = super()._build_request(*args, **kwargs)
+        request._dont_enforce_csrf_checks = False
+        return request
+
+
+csrf_OFF = NinjaAPI(urls_namespace="csrf_OFF")
+csrf_ON = NinjaAPI(urls_namespace="csrf_ON", csrf=True)
+
+
+@csrf_OFF.post("/post")
+async def post_off(request):
+    return {"success": True}
+
+
+@csrf_ON.post("/post")
+async def post_on(request):
+    return {"success": True}
+
+
+TOKEN = "1bcdefghij2bcdefghij3bcdefghij4bcdefghij5bcdefghij6bcdefghijABCD"
+COOKIES = {settings.CSRF_COOKIE_NAME: TOKEN}
+
+
+@pytest.mark.skipif(django.VERSION < (3, 1), reason="requires django 3.1 or higher")
+@pytest.mark.asyncio
+async def test_csrf_off():
+    client = TestAsyncClient(csrf_OFF)
+    response = await client.post("/post", COOKIES=COOKIES)
+    assert response.status_code == 200
+
+
+@pytest.mark.skipif(django.VERSION < (3, 1), reason="requires django 3.1 or higher")
+@pytest.mark.asyncio
+async def test_csrf_on():
+    client = TestAsyncClient(csrf_ON)
+
+    response = await client.post("/post", COOKIES=COOKIES)
+    assert response.status_code == 403
+
+    # check with token in formdata
+    response = await client.post(
+        "/post", {"csrfmiddlewaretoken": TOKEN}, COOKIES=COOKIES
+    )
+    assert response.status_code == 200
+
+    # check with headers
+    response = await client.post(
+        "/post", COOKIES=COOKIES, headers={"X-CSRFTOKEN": TOKEN}
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.skipif(django.VERSION < (3, 1), reason="requires django 3.1 or higher")
+@pytest.mark.asyncio
+async def test_raises_on_cookie_auth():
+    "It should raise if user picked Cookie based auth and csrf=False"
+
+    class Auth(APIKeyCookie):
+        def authenticate(self, request, key):
+            return request.COOKIES[key] == "foo"
+
+    api = NinjaAPI(auth=Auth(), csrf=False)
+
+    @api.get("/some")
+    async def some_method(request):
+        pass
+
+    with pytest.raises(ConfigError):
+        api._validate()
+
+    try:
+        import os
+
+        os.environ["NINJA_SKIP_REGISTRY"] = ""
+
+        # Check for wrong error reported
+        match = "Looks like you created multiple NinjaAPIs"
+        with pytest.raises(ConfigError, match=match):
+            api.urls
+
+        # django debug server can attempt to import the urls twice when errors exist
+        # verify we get the correct error reported
+        match = "Cookie Authentication must be used with CSRF"
+        with pytest.raises(ConfigError, match=match):
+            with mock.patch("ninja.main._imported_while_running_in_debug_server", True):
+                api.urls
+
+    finally:
+        os.environ["NINJA_SKIP_REGISTRY"] = "yes"


### PR DESCRIPTION
This PR introduces initial support for asynchronous authentication by allowing users to pass in async callables through the `auth` kwarg. The built-in authentication classes provided by this project remain synchronous-only.

Doesn't fully solve https://github.com/vitalik/django-ninja/issues/44, but it might be a good first step towards full async auth support.