### PR TITLE
Fix #674: Allow overriding renderer per endpoint

### DIFF
--- a/ninja/router.py
+++ b/ninja/router.py
@@ -5,6 +5,7 @@ from django.urls import URLPattern, path as django_path
 from ninja.constants import NOT_SET
 from ninja.errors import ConfigError
 from ninja.operation import PathView
+from ninja.renderers import BaseRenderer
 from ninja.types import TCallable
 from ninja.utils import normalize_path, replace_path_param_notation
 
@@ -43,6 +44,7 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        renderer: Optional[BaseRenderer] = None,
     ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["GET"],
@@ -61,6 +63,7 @@ class Router:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            renderer=renderer,
         )
 
     def post(
@@ -234,6 +237,7 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        renderer: Optional[BaseRenderer] = None,
     ) -> Callable[[TCallable], TCallable]:
         def decorator(view_func: TCallable) -> TCallable:
             self.add_api_operation(
@@ -254,6 +258,7 @@ class Router:
                 url_name=url_name,
                 include_in_schema=include_in_schema,
                 openapi_extra=openapi_extra,
+                renderer=renderer,
             )
             return view_func
 
@@ -279,6 +284,7 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        renderer: Optional[BaseRenderer] = None,
     ) -> None:
         if path not in self.path_operations:
             path_view = PathView()
@@ -303,6 +309,7 @@ class Router:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            renderer=renderer,
         )
         if self.api:
             path_view.set_api_instance(self.api, self)


### PR DESCRIPTION
This PR aims to address #674 and #627.
This is a minimum implementation that allowed me to validate the mechanism; before implementing further I'd like your opinion (@vitalik ?) on whether this feature would be OK to merge and whether this is the correct way to do so.

If you confirm, I'll add support for this feature on the other paths (patch/put/post/..) and will add some tests.

This PR allows for the following snippet to execute as expected:

```python
class PlainTextRenderer:
    media_type: str = "text/plain"
    charset: str = "utf-8"

    def render(self, request: HttpRequest, data: Any, *, response_status: int) -> Any:
        return str(data)

@api.get("/sub", renderer=PlainTextRenderer())
def sub(request, a: int, b: int):
    return f"some cool text; {a - b}\n"


@api.get("/add")
def add(request, a: int, b: int):
    return {"result": a + b}
```