### PR TITLE
Implement PlainTextRenderer

### DIFF
--- a/ninja/renderers.py
+++ b/ninja/renderers.py
@@ -23,3 +23,11 @@ class JSONRenderer(BaseRenderer):
 
     def render(self, request: HttpRequest, data: Any, *, response_status: int) -> Any:
         return json.dumps(data, cls=self.encoder_class, **self.json_dumps_params)
+
+
+class PlainTextRenderer(BaseRenderer):
+    media_type: str = "text/plain"
+    charset: str = "utf-8"
+
+    def render(self, request: HttpRequest, data: Any, *, response_status: int) -> Any:
+        return str(data)

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1,0 +1,43 @@
+import pytest
+
+from ninja.renderers import JSONRenderer, PlainTextRenderer
+from ninja import NinjaAPI
+from ninja.testing import TestClient
+
+
+@pytest.mark.parametrize(
+    "renderer,expected_content_type",
+    [
+        (JSONRenderer, "application/json; charset=utf-8"),
+        (PlainTextRenderer, "text/plain; charset=utf-8"),
+    ],
+)
+def test_renderer_media_type(renderer, expected_content_type):
+    api = NinjaAPI(renderer=renderer())
+
+    @api.get("/1")
+    def same_name(request):
+        return None
+
+    client = TestClient(api)
+    response = client.get("/1")
+    assert response.headers == {"Content-Type": expected_content_type}
+
+
+@pytest.mark.parametrize(
+    "renderer,expected_response",
+    [
+        (JSONRenderer, b"""{"key": "value"}"""),
+        (PlainTextRenderer, b"""{'key': 'value'}"""),
+    ],
+)
+def test_renderer_text(renderer, expected_response):
+    api = NinjaAPI(renderer=renderer())
+
+    @api.get("/1")
+    def same_name(request):
+        return {"key": "value"}
+
+    client = TestClient(api)
+    response = client.get("/1")
+    assert response.content == expected_response


### PR DESCRIPTION
Having a `PlainTextRenderer` is useful; mostly to hook up a [prometheus_client](https://github.com/prometheus/client_python).

This PR is not particularly useful by itself, but it will make writing useful tests for #754 easier/better.