### PR TITLE
Enable exception_handler to handle Pyright's strict mode

### DIFF
--- a/ninja/main.py
+++ b/ninja/main.py
@@ -451,7 +451,7 @@ class NinjaAPI:
         assert issubclass(exc_class, Exception)
         self._exception_handlers[exc_class] = handler
 
-    def exception_handler(self, exc_class: Type[Exception]) -> Callable:
+    def exception_handler(self, exc_class: Type[Exception]) -> Callable[..., Any]:
         def decorator(func: Callable) -> Callable:
             self.add_exception_handler(exc_class, func)
             return func


### PR DESCRIPTION
Without enabling the callable to take any # of inputs and return Any as the type, Pyright will complain with these two errors:
```
Type of "exception_handler" is partially unknown
Type of "exception_handler" is "(exc_class: Type[Exception]) -> ((...) -> Unknown)"Pylance[reportUnknownMemberType](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportUnknownMemberType)
Untyped function decorator obscures type of function; ignoring decoratorPylance[reportUntypedFunctionDecorator](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportUntypedFunctionDecorator)
```
Hence, you need to disable those checks for this line. The typing adjustment I am advocating for fixes that!

```py
@api.exception_handler(  # pyright: ignore [reportUntypedFunctionDecorator, reportUnknownMemberType]
    Exception
)
```

Also, I think the urls property in main.py is typed in a way that does not Django happy. In `urls.py`

`path("api/", api.urls),` results in:

```
Argument of type "Tuple[List[URLResolver | URLPattern], str, str]" cannot be assigned to parameter "view" of type "List[URLResolver | str]" in function "path"
  "Tuple[List[URLResolver | URLPattern], str, str]" is incompatible with "List[URLResolver | str]"Pylance[reportGeneralTypeIssues](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportGeneralTypeIssues)

while `path("api/", api.urls[0])` results in:

Argument of type "List[URLResolver | URLPattern]" cannot be assigned to parameter "view" of type "List[URLResolver | str]" in function "path"
  "List[URLResolver | URLPattern]" is incompatible with "List[URLResolver | str]"
    TypeVar "_T@list" is invariant
      Type "URLResolver | URLPattern" cannot be assigned to type "URLResolver | str"
        Type "URLPattern" cannot be assigned to type "URLResolver | str"
          "URLPattern" is incompatible with "URLResolver"

```
I thought worth bringing to your attention!