### PR TITLE
Make optional field of UploadedFile optional

### DIFF
--- a/ninja/files.py
+++ b/ninja/files.py
@@ -19,6 +19,6 @@ class UploadedFile(DjangoUploadedFile):
 
     @classmethod
     def __modify_schema__(
-        cls, field_schema: Dict[str, Any], field: Optional[ModelField]
+        cls, field_schema: Dict[str, Any], field: Optional[ModelField] = None
     ) -> None:
         field_schema.update(type="string", format="binary")


### PR DESCRIPTION
`UploadedFile.__modify_schema__` has a `field` parameter that is not used in the method body, is typed as `Optional`, but still requires a value. Schema generation fails because of the value for this parameter not being provided.