### PR TITLE
Refactor pagination to not overwrite _ninja_contribute_to_operation

### DIFF
--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -92,7 +92,8 @@ class Operation:
 
         if hasattr(view_func, "_ninja_contribute_to_operation"):
             # Allow 3rd party code to contribute to the operation behaviour
-            view_func._ninja_contribute_to_operation(self)  # type: ignore
+            for func in view_func._ninja_contribute_to_operation:  # type: ignore[attr-defined]
+                func(self)
 
     def run(self, request: HttpRequest, **kw: Any) -> HttpResponseBase:
         error = self._run_checks(request)

--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -13,6 +13,7 @@ from ninja.constants import NOT_SET
 from ninja.errors import ConfigError
 from ninja.operation import Operation
 from ninja.signature.details import is_collection_type
+from ninja.signature.utils import contribute_to_operation
 
 
 class PaginationBase(ABC):
@@ -160,8 +161,8 @@ def _inject_pagination(
     #     make_response_paginated(schema, paginator, op)
 
     if paginator.Output:
-        view_with_pagination._ninja_contribute_to_operation = partial(  # type: ignore
-            make_response_paginated, paginator
+        contribute_to_operation(
+            view_with_pagination, partial(make_response_paginated, paginator)
         )
 
     return view_with_pagination

--- a/ninja/signature/utils.py
+++ b/ninja/signature/utils.py
@@ -1,13 +1,16 @@
 import asyncio
 import inspect
 import re
-from typing import Any, Callable, Set
+from typing import TYPE_CHECKING, Any, Callable, Set, Union
 
 from django.urls import register_converter
 from django.urls.converters import UUIDConverter
 from pydantic.typing import ForwardRef, evaluate_forwardref  # type: ignore
 
 from ninja.types import DictStrAny
+
+if TYPE_CHECKING:
+    from ninja.operation import Operation
 
 __all__ = [
     "get_typed_signature",
@@ -54,6 +57,14 @@ def get_path_param_names(path: str) -> Set[str]:
 
 def is_async(callable: Callable) -> bool:
     return asyncio.iscoroutinefunction(callable)
+
+
+def contribute_to_operation(
+    operation: Union[Callable, "Operation"], contribution: Callable[["Operation"], None]
+) -> None:
+    if not hasattr(operation, "_ninja_contribute_to_operation"):
+        operation._ninja_contribute_to_operation = []  # type: ignore[union-attr]
+    operation._ninja_contribute_to_operation.append(contribution)  # type: ignore[union-attr]
 
 
 class NinjaUUIDConverter:


### PR DESCRIPTION
Solves #777, using a similar solution to my other PR #604 

- Creates a function called inject_contribute_args that will add new args without overwriting existing ones
- Updates the _inject_pagination function to use the new function

No tests written yet, as #604 reorganises the relevant test structure. Leaving as draft until #604 is merged.