### PR TITLE
Fix OpenAPI spec example in api-docs.md

### DIFF
--- a/docs/docs/guides/api-docs.md
+++ b/docs/docs/guides/api-docs.md
@@ -48,11 +48,9 @@ You can extend OpenAPI spec with custom attributes, for example to add `termsOfS
 ```Python
 api = NinjaAPI(
    openapi_extra={
-            "info": {
-                "termsOfService": "https://example.com/terms/",
-            }
-        }
-       
+       "info": {
+           "termsOfService": "https://example.com/terms/",
+       }
    },
    title="Demo API",
    description="This is a demo API with dynamic OpenAPI info section"


### PR DESCRIPTION
Removes redundant curly bracket which makes it invalid.