### PR TITLE
Replace pre-commit `flake8` and `isort` with `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: flake8
         exclude: (docs/src|tests/demo_project)/
   - repo: https://github.com/PyCQA/isort
-    rev: "5.10.1"
+    rev: "5.11.5"
     hooks:
       - id: isort
         exclude: docs/src

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,13 +16,8 @@ repos:
     hooks:
       - id: black
         exclude: docs/src/
-  - repo: https://github.com/PyCQA/flake8
-    rev: "4.0.1"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.282
     hooks:
-      - id: flake8
-        exclude: (docs/src|tests/demo_project)/
-  - repo: https://github.com/PyCQA/isort
-    rev: "5.11.5"
-    hooks:
-      - id: isort
-        exclude: docs/src
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]


### PR DESCRIPTION
Currently, when trying to run any pre-commit hooks in Python 3.10, `poetry` crashes with the following log:
```bash
[INFO] Installing environment for https://github.com/PyCQA/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/home/alxd/.cache/pre-commit/repords8_k88/py_env-python3/bin/python', '-mpip', 'install', '.')
return code: 1
stdout:
    Processing /home/alxd/.cache/pre-commit/repords8_k88
      Installing build dependencies: started
      Installing build dependencies: finished with status 'done'
      Getting requirements to build wheel: started
      Getting requirements to build wheel: finished with status 'done'
      Preparing metadata (pyproject.toml): started
      Preparing metadata (pyproject.toml): finished with status 'error'
stderr:
      error: subprocess-exited-with-error
      
      × Preparing metadata (pyproject.toml) did not run successfully.
      │ exit code: 1
      ╰─> [14 lines of output]
          Traceback (most recent call last):
            File "/home/alxd/.cache/pre-commit/repords8_k88/py_env-python3/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
              main()
            File "/home/alxd/.cache/pre-commit/repords8_k88/py_env-python3/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
              json_out['return_val'] = hook(**hook_input['kwargs'])
            File "/home/alxd/.cache/pre-commit/repords8_k88/py_env-python3/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
              return hook(metadata_directory, config_settings)
            File "/tmp/pip-build-env-wd0r5k17/overlay/lib/python3.10/site-packages/poetry/core/masonry/api.py", line 41, in prepare_metadata_for_build_wheel
              poetry = Factory().create_poetry(Path(".").resolve(), with_groups=False)
            File "/tmp/pip-build-env-wd0r5k17/overlay/lib/python3.10/site-packages/poetry/core/factory.py", line 58, in create_poetry
              raise RuntimeError("The Poetry configuration is invalid:\n" + message)
          RuntimeError: The Poetry configuration is invalid:
            - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
          
          [end of output]
      
      note: This error originates from a subprocess, and is likely not a problem with pip.
    error: metadata-generation-failed
    
    × Encountered error while generating package metadata.
    ╰─> See above for output.
    
    note: This is an issue with the package mentioned above, not pip.
    hint: See above for details.
Check the log at /home/alxd/.cache/pre-commit/pre-commit.log
```

This is a known bug of `isort`, fixed by [the 5.15.5 release](https://github.com/PyCQA/isort/releases/tag/5.11.5). It [shouldn't](https://github.com/home-assistant/core/issues/86892) break compatibility with Python 3.7.