### PR TITLE
Add `docs_context` to pass additional parameters to Swagger and Redoc

### DIFF
--- a/docs/docs/guides/api-docs.md
+++ b/docs/docs/guides/api-docs.md
@@ -41,6 +41,15 @@ from django.contrib.admin.views.decorators import staff_member_required
 api = NinjaAPI(docs_decorator=staff_member_required)
 ```
 
+## Extending your docs engine configuration
+
+To provide some advanced configuration for your documentation engine, like setting [`persistAuthorization`](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#persistAuthorization) in Swagger, use the `docs_context` argument with `swagger` and / or `redoc` key matching your `NINJA_DOCS_VIEW`:
+
+```Python
+api = NinjaAPI(docs_context={'swagger': {'persistAuthorization': True}}}
+```
+
+
 ## Extending OpenAPI Spec with custom attributes
 
 You can extend OpenAPI spec with custom attributes, for example to add `termsOfService`

--- a/docs/docs/guides/api-docs.md
+++ b/docs/docs/guides/api-docs.md
@@ -46,7 +46,7 @@ api = NinjaAPI(docs_decorator=staff_member_required)
 To provide some advanced configuration for your documentation engine, like setting [`persistAuthorization`](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#persistAuthorization) in Swagger, use the `docs_context` argument with `swagger` and / or `redoc` key matching your `NINJA_DOCS_VIEW`:
 
 ```Python
-api = NinjaAPI(docs_context={'swagger': {'persistAuthorization': True}}}
+api = NinjaAPI(docs_context={"swagger": {"persistAuthorization": True}})
 ```
 
 

--- a/docs/docs/guides/api-docs.md
+++ b/docs/docs/guides/api-docs.md
@@ -41,9 +41,9 @@ from django.contrib.admin.views.decorators import staff_member_required
 api = NinjaAPI(docs_decorator=staff_member_required)
 ```
 
-## Extending your docs engine configuration
+## Extending your docs renderer configuration
 
-To provide some advanced configuration for your documentation engine, like setting [`persistAuthorization`](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#persistAuthorization) in Swagger, use the `docs_context` argument with `swagger` and / or `redoc` key matching your `NINJA_DOCS_VIEW`:
+To provide some advanced configuration for your documentation engine, like setting [`persistAuthorization`](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#persistAuthorization) in Swagger, use the `docs_context` argument with [`swagger`](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/) and / or [`redoc`](https://redocly.com/docs/api-reference-docs/configuration/functionality/) key matching your `NINJA_DOCS_VIEW`:
 
 ```Python
 api = NinjaAPI(docs_context={"swagger": {"persistAuthorization": True}})

--- a/ninja/main.py
+++ b/ninja/main.py
@@ -50,8 +50,9 @@ class NinjaAPI:
         description: str = "",
         openapi_url: Optional[str] = "/openapi.json",
         docs_url: Optional[str] = "/docs",
-        servers: Optional[List[Dict[str, Union[str, Any]]]] = None,
         docs_decorator: Optional[Callable[[TCallable], TCallable]] = None,
+        docs_context: Optional[Dict[str, Dict[str, Union[str, Any]]]] = None,
+        servers: Optional[List[Dict[str, Union[str, Any]]]] = None,
         urls_namespace: Optional[str] = None,
         csrf: bool = False,
         auth: Optional[Union[Sequence[Callable], Callable, NOT_SET_TYPE]] = NOT_SET,
@@ -69,6 +70,8 @@ class NinjaAPI:
             openapi_url: The relative URL to serve the openAPI spec.
             openapi_extra: Additional attributes for the openAPI spec.
             docs_url: The relative URL to serve the API docs.
+            docs_decorator: The authentication decorator to protect the access to the API docs with.
+            docs_context: The miscellaneous options passed to respective API docs engines.
             servers: List of target hosts used in openAPI spec.
             csrf: Require a CSRF token for unsafe request types. See <a href="../csrf">CSRF</a> docs.
             auth (Callable | Sequence[Callable] | NOT_SET | None): Authentication class
@@ -80,8 +83,9 @@ class NinjaAPI:
         self.description = description
         self.openapi_url = openapi_url
         self.docs_url = docs_url
-        self.servers = servers
         self.docs_decorator = docs_decorator
+        self.docs_context = docs_context
+        self.servers = servers
         self.urls_namespace = urls_namespace or f"api-{self.version}"
         self.csrf = csrf
         self.renderer = renderer or JSONRenderer()

--- a/ninja/openapi/views.py
+++ b/ninja/openapi/views.py
@@ -53,10 +53,11 @@ def openapi_view(request: HttpRequest, api: "NinjaAPI") -> HttpResponse:
     }
 
     docs_context = api.docs_context
-    docs_renderer = ninja_settings.DOCS_VIEW
-    applicable_docs_context = getattr(docs_context, docs_renderer, None)
-    if applicable_docs_context:
-        context.update({"extended_settings": applicable_docs_context})
+    if docs_context:
+        docs_renderer = ninja_settings.DOCS_VIEW
+        applicable_docs_context = docs_context.get(docs_renderer)
+        if applicable_docs_context:
+            context.update({"extended_settings": applicable_docs_context})
 
     if "ninja" in settings.INSTALLED_APPS:
         return render(request, view_tpl, context)

--- a/ninja/openapi/views.py
+++ b/ninja/openapi/views.py
@@ -51,6 +51,13 @@ def openapi_view(request: HttpRequest, api: "NinjaAPI") -> HttpResponse:
         "add_csrf": add_csrf,
         "openapi_json_url": reverse(f"{api.urls_namespace}:openapi-json"),
     }
+
+    docs_context = api.docs_context
+    docs_renderer = ninja_settings.DOCS_VIEW
+    applicable_docs_context = getattr(docs_context, docs_renderer, None)
+    if applicable_docs_context:
+        context.update({"extended_settings": applicable_docs_context})
+
     if "ninja" in settings.INSTALLED_APPS:
         return render(request, view_tpl, context)
     else:

--- a/ninja/static/ninja/swagger-ui-init.js
+++ b/ninja/static/ninja/swagger-ui-init.js
@@ -1,7 +1,6 @@
 /**JS file for handling the SwaggerUIBundle and avoid inline script */
 const swaggerUi = document.querySelector("body")
-
-console.log(swaggerUi)
+const extendedSettings = JSON.parse(document.getElementById('extendedSettings').textContent);
 
 SwaggerUIBundle({
     url: swaggerUi.dataset.openapiUrl,
@@ -18,5 +17,5 @@ SwaggerUIBundle({
         return req;
     },
     deepLinking: true,
-    ...swaggerUi.dataset.extendedSettings
+    ...extendedSettings
 })

--- a/ninja/static/ninja/swagger-ui-init.js
+++ b/ninja/static/ninja/swagger-ui-init.js
@@ -1,6 +1,7 @@
 /**JS file for handling the SwaggerUIBundle and avoid inline script */
 const swaggerUi = document.querySelector("body")
-const extendedSettings = JSON.parse(document.getElementById('extendedSettings').textContent);
+const extendedSettingsElement = document.getElementById('extendedSettings')
+const extendedSettings = extendedSettingsElement ? JSON.parse(extendedSettingsElement.textContent) : {};
 
 SwaggerUIBundle({
     url: swaggerUi.dataset.openapiUrl,

--- a/ninja/static/ninja/swagger-ui-init.js
+++ b/ninja/static/ninja/swagger-ui-init.js
@@ -1,6 +1,8 @@
 /**JS file for handling the SwaggerUIBundle and avoid inline script */
 const swaggerUi = document.querySelector("body")
 
+console.log(swaggerUi)
+
 SwaggerUIBundle({
     url: swaggerUi.dataset.openapiUrl,
     dom_id: '#swagger-ui',
@@ -15,5 +17,6 @@ SwaggerUIBundle({
         }
         return req;
     },
-    deepLinking: true
+    deepLinking: true,
+    ...swaggerUi.dataset.extendedSettings
 })

--- a/ninja/templates/ninja/redoc.html
+++ b/ninja/templates/ninja/redoc.html
@@ -6,7 +6,15 @@
     <title>{{ api.title }}</title>
 </head>
 <body>
-    <redoc spec-url='{{ openapi_json_url }}'></redoc>
+    {% if extended_settings %}{{ extended_settings|json_script:"extendedSettings" }}{% endif %}
+    <div id="redoc-ui"></div>
     <script src="{% static 'ninja/redoc.standalone.js' %}"></script>
+    <script>
+        const extendedSettingsElement = document.getElementById('extendedSettings')
+        const extendedSettings = extendedSettingsElement ? JSON.parse(extendedSettingsElement.textContent) : {};
+        const specUrl = "{{ openapi_json_url }}";
+        const element = document.getElementById('redoc-ui');
+        Redoc.init(specUrl, extendedSettings, element);
+    </script>
 </body>
 </html>

--- a/ninja/templates/ninja/redoc_cdn.html
+++ b/ninja/templates/ninja/redoc_cdn.html
@@ -5,7 +5,15 @@
     <title>{{ api.title }}</title>
 </head>
 <body>
-    <redoc spec-url='{{ openapi_json_url }}'></redoc>
+    {% if extended_settings %}{{ extended_settings|json_script:"extendedSettings" }}{% endif %}
+    <div id="redoc-ui"></div>
     <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0/bundles/redoc.standalone.js"></script>
+    <script>
+        const extendedSettingsElement = document.getElementById('extendedSettings')
+        const extendedSettings = extendedSettingsElement ? JSON.parse(extendedSettingsElement.textContent) : {};
+        const specUrl = "{{ openapi_json_url }}";
+        const element = document.getElementById('redoc-ui');
+        Redoc.init(specUrl, extendedSettings, element);
+    </script>
 </body>
 </html>

--- a/ninja/templates/ninja/swagger.html
+++ b/ninja/templates/ninja/swagger.html
@@ -9,9 +9,8 @@
 <body
     data-openapi-url="{{ openapi_json_url }}"
     data-csrf-token="{% if add_csrf %}{{ csrf_token }}{% endif %}"
-    data-api-csrf="{% if add_csrf %}true{% endif %}"
-    data-extended-settings="{% if extended_settings %}{{ extended_settings }}{% endif %}"
-    >
+    data-api-csrf="{% if add_csrf %}true{% endif %}">
+    {% if extended_settings %}{{ extended_settings|json_script:"extendedSettings" }}{% endif %}
     
     <div id="swagger-ui"></div>
 

--- a/ninja/templates/ninja/swagger.html
+++ b/ninja/templates/ninja/swagger.html
@@ -9,7 +9,9 @@
 <body
     data-openapi-url="{{ openapi_json_url }}"
     data-csrf-token="{% if add_csrf %}{{ csrf_token }}{% endif %}"
-    data-api-csrf="{% if add_csrf %}true{% endif %}">
+    data-api-csrf="{% if add_csrf %}true{% endif %}"
+    data-extended-settings="{% if extended_settings %}{{ extended_settings }}{% endif %}"
+    >
     
     <div id="swagger-ui"></div>
 

--- a/ninja/templates/ninja/swagger_cdn.html
+++ b/ninja/templates/ninja/swagger_cdn.html
@@ -11,6 +11,9 @@
 
     <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.15.5/swagger-ui-bundle.js"></script>
     <script>
+        {% if extended_settings %}
+        const extendedSettings = {{ extended_settings }}
+        {% endif %}
         const ui = SwaggerUIBundle({
             url: '{{ openapi_json_url }}',
             dom_id: '#swagger-ui',
@@ -25,7 +28,10 @@
 				return req;
 			},
         {% endif %}
-            deepLinking: true
+            deepLinking: true,
+        {% if extended_settings %}
+            ...extendedSettings
+        {% endif %}
         })
     </script>
 </body>

--- a/ninja/templates/ninja/swagger_cdn.html
+++ b/ninja/templates/ninja/swagger_cdn.html
@@ -9,11 +9,10 @@
     <div id="swagger-ui">
     </div>
 
+    {% if extended_settings %}{{ extended_settings|json_script:"extendedSettings" }}{% endif %}
     <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.15.5/swagger-ui-bundle.js"></script>
     <script>
-        {% if extended_settings %}
-        const extendedSettings = {{ extended_settings }}
-        {% endif %}
+        const extendedSettings = JSON.parse(document.getElementById('extendedSettings').textContent);
         const ui = SwaggerUIBundle({
             url: '{{ openapi_json_url }}',
             dom_id: '#swagger-ui',
@@ -29,9 +28,7 @@
 			},
         {% endif %}
             deepLinking: true,
-        {% if extended_settings %}
             ...extendedSettings
-        {% endif %}
         })
     </script>
 </body>

--- a/ninja/templates/ninja/swagger_cdn.html
+++ b/ninja/templates/ninja/swagger_cdn.html
@@ -12,7 +12,8 @@
     {% if extended_settings %}{{ extended_settings|json_script:"extendedSettings" }}{% endif %}
     <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.15.5/swagger-ui-bundle.js"></script>
     <script>
-        const extendedSettings = JSON.parse(document.getElementById('extendedSettings').textContent);
+        const extendedSettingsElement = document.getElementById('extendedSettings')
+        const extendedSettings = extendedSettingsElement ? JSON.parse(extendedSettingsElement.textContent) : {};
         const ui = SwaggerUIBundle({
             url: '{{ openapi_json_url }}',
             dom_id: '#swagger-ui',

--- a/tests/test_openapi_docs_context.py
+++ b/tests/test_openapi_docs_context.py
@@ -1,0 +1,35 @@
+from unittest.mock import Mock
+
+from django.test import override_settings
+
+from ninja import NinjaAPI
+from ninja.openapi.urls import get_openapi_urls
+
+# TODO: Test passing the doc_context for Redoc
+# TODO: Test passing the doc_context to cdn templates
+
+
+def test_openapi_docs_context_swagger():
+    "Test providing docs_context to Swagger"
+    api = NinjaAPI(docs_context={"swagger": {"filter": True}})
+
+    paths = get_openapi_urls(api)
+    assert len(paths) == 2
+    doc_path = paths[1]
+
+    response = doc_path.callback(Mock())
+    assert response.status_code == 200
+    assert b'{"filter": true}' in response.content
+
+
+def test_openapi_docs_context_swagger_misconfigured():
+    "Test providing docs_context to Redoc when Swagger is configured"
+    api = NinjaAPI(docs_context={"redoc": {"filter": True}})
+
+    paths = get_openapi_urls(api)
+    assert len(paths) == 2
+    doc_path = paths[1]
+
+    response = doc_path.callback(Mock())
+    assert response.status_code == 200
+    assert b'{"filter": true}' not in response.content


### PR DESCRIPTION
Created a PR implementing https://github.com/vitalik/django-ninja/issues/782 .

- Added `docs_context` optional parameter to NinjaAPI, which passes additional parameters straight to Swagger or Redoc templates
- Implemented and tested (by hand) successful parameter consumption by Swagger, Swagger CDN, Redoc and Redoc CDN versions.
  - Also tested passing wrong configuration (Swagger to Redoc, Redoc to Swagger) and empty configuration.
  - In order to pass additional `options` to Redoc, we cannot use the simple `<redoc />` HTML shorthand, as per [this document](https://redocly.com/docs/redoc/deployment/html/).
  - Used Django's [`json_script`](https://docs.djangoproject.com/en/4.2/ref/templates/builtins/#json-script) to safely pass multiple options to the template.
- Created simple tests for coverage.
- More tests could be useful, but I'm not sure how to properly instantiate NinjaAPI and Django, needing to modify both the `api` object and override `NINJA_DOCS_VIEW`.
- Added documentation for the feature in `api-docs.md`.
- Ran all the linters and formatters.
- More renderers / engines / plugins can be easily added, as `extended_settings` now exists in the OpenAPI View Template.

If you'd like to test the changes locally, the best set of settings should be:
```Python
api = NinjaAPI(docs_context={"swagger": {"filter": "SthToFilter"}})
api = NinjaAPI(docs_context={"redoc": {"disableSearch": True}})
```
This way the changes will be visible immediately after loading the page, no need to debug it in the console.