### PR TITLE
Place pre-commit `ruff` before `black` because of its `autofix`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,13 +11,13 @@ repos:
       - id: mypy
         additional_dependencies: ["django-stubs", "pydantic"]
         exclude: (tests|docs)/
-  - repo: https://github.com/psf/black
-    rev: "23.1.0"
-    hooks:
-      - id: black
-        exclude: docs/src/
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.282
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+  - repo: https://github.com/psf/black
+    rev: "23.1.0"
+    hooks:
+      - id: black
+        exclude: docs/src/


### PR DESCRIPTION
Continuation of https://github.com/vitalik/django-ninja/pull/805 :

> Ruff's pre-commit hook should be placed after other formatting tools, such as Black and isort, unless you enable autofix, in which case, Ruff's pre-commit hook should run before Black, isort, and other formatting tools, as Ruff's autofix behavior can output code changes that require reformatting.

From https://github.com/astral-sh/ruff-pre-commit .
