### PR TITLE
Added VectroField support

### DIFF
--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -71,6 +71,7 @@ TYPES = {
     "CIEmailField": str,
     "CITextField": str,
     "HStoreField": Dict,
+    "VectorField": List,
 }
 
 TModel = TypeVar("TModel")


### PR DESCRIPTION
Fixed the error related to the new field "VectroField "

python_type = TYPES[internal_type]
KeyError: 'VectorField'