### PR TITLE
Include Enum to NinjaJSONEncoder

### DIFF
--- a/ninja/responses.py
+++ b/ninja/responses.py
@@ -1,5 +1,6 @@
 from ipaddress import IPv4Address, IPv6Address
 from typing import Any, FrozenSet
+from enum import Enum
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import JsonResponse
@@ -21,6 +22,8 @@ class NinjaJSONEncoder(DjangoJSONEncoder):
         if isinstance(o, BaseModel):
             return o.model_dump()
         if isinstance(o, (IPv4Address, IPv6Address)):
+            return str(o)
+        if isinstance(o, Enum):
             return str(o)
         return super().default(o)
 

--- a/ninja/responses.py
+++ b/ninja/responses.py
@@ -1,6 +1,6 @@
+from enum import Enum
 from ipaddress import IPv4Address, IPv6Address
 from typing import Any, FrozenSet
-from enum import Enum
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import JsonResponse

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,4 +1,5 @@
 import json
+from enum import Enum
 from ipaddress import IPv4Address, IPv6Address
 from typing import List, Union
 
@@ -28,6 +29,11 @@ class User:
         self.id = id
         self.user_name = user_name
         self.password = password
+
+
+class MyEnum(Enum):
+    first = "first"
+    second = "second"
 
 
 def to_camel(string: str) -> str:
@@ -157,3 +163,10 @@ def test_ipv6address_encoding():
     response = Response(data)
     response_data = json.loads(response.content)
     assert response_data["ipv6"] == str(data["ipv6"])
+
+
+def test_enum_encoding():
+    data = {"enum": MyEnum.first}
+    response = Response(data)
+    response_data = json.loads(response.content)
+    assert response_data["enum"] == str(data["enum"])


### PR DESCRIPTION
This would allow proper usage of enums in path parameters
Currently if you want to have an enum in the path, you would do this.
```
enum_value: SomeEnumClass = Path(...),
```
Which works fine until the request path includes an enum value that does not exist.
ie.
```
class SomeEnumClass(enum.Enum):
    first: "first"
    second: "second"

requests.get("some_path/third/other")
```

This would return a 500 instead of an expected 422 due to crashing in the JSONEncoder.
Returning and error
```
TypeError: Object of type SomeEnumClass is not JSON serializable"
```