### PR TITLE
#822 "ValidationError" and "HttpError" are not unpicklable

### DIFF
--- a/ninja/errors.py
+++ b/ninja/errors.py
@@ -39,14 +39,18 @@ class ValidationError(Exception):
     """
 
     def __init__(self, errors: List[DictStrAny]) -> None:
-        super().__init__()
         self.errors = errors
+        super().__init__(errors)
 
 
 class HttpError(Exception):
     def __init__(self, status_code: int, message: str) -> None:
         self.status_code = status_code
-        super().__init__(message)
+        self.message = message
+        super().__init__(status_code, message)
+
+    def __str__(self) -> str:
+        return self.message
 
 
 def set_default_exc_handlers(api: "NinjaAPI") -> None:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,26 @@
+import pickle
+
+from ninja.errors import HttpError, ValidationError
+
+
+def test_validation_error_is_picklable_and_unpicklable():
+    error_to_serialize = ValidationError([{"testkey": "testvalue"}])
+
+    serialized = pickle.dumps(error_to_serialize)
+    assert serialized  # Not empty
+
+    deserialized = pickle.loads(serialized)
+    assert isinstance(deserialized, ValidationError)
+    assert deserialized.errors == error_to_serialize.errors
+
+
+def test_http_error_is_picklable_and_unpicklable():
+    error_to_serialize = HttpError(500, "Test error")
+
+    serialized = pickle.dumps(error_to_serialize)
+    assert serialized  # Not empty
+
+    deserialized = pickle.loads(serialized)
+    assert isinstance(deserialized, HttpError)
+    assert deserialized.status_code == error_to_serialize.status_code
+    assert deserialized.message == error_to_serialize.message


### PR DESCRIPTION
I'm using[ `loguru` ](https://github.com/Delgan/loguru) for logging and had hard time debugging `TypeError: ValidationError.__init__() missing 1 required positional argument: 'errors'` while calling `logger.exception` in Ninja `api.on_exception`. This is addressing the issue.

Fixes #822 