### PR TITLE
Add a test for list query params

### DIFF
--- a/tests/main.py
+++ b/tests/main.py
@@ -208,6 +208,11 @@ def get_query_type_optional_10(request, query: int = 10):
     return f"foo bar {query}"
 
 
+@router.get("/query/list")
+def get_query_list(request, query: list[str] = Query(...)):
+    return ",".join(query)
+
+
 @router.get("/query/param")
 def get_query_param(request, query=Query(None)):
     if query is None:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -57,6 +57,7 @@ client = TestClient(router)
         ("/query/int/default", 200, "foo bar 10"),
         ("/query/int/default?query=50", 200, "foo bar 50"),
         ("/query/int/default?query=foo", 422, response_not_valid_int),
+        ("/query/list?query=a&query=b&query=c", 200, "a,b,c"),
         ("/query/param", 200, "foo bar"),
         ("/query/param?query=50", 200, "foo bar 50"),
         ("/query/param-required", 422, response_missing),


### PR DESCRIPTION
I had a bit of trouble figuring out list query parameters - possibly they could be a bit better documented in terms of needing to set them up with `Query(...)`?

While working this out I implemented a quick test for django-ninja's handling of list params, hopefully this is useful.