### PR TITLE
Fix bugs when using resolvers with dictionaries

### DIFF
--- a/docs/docs/guides/response/index.md
+++ b/docs/docs/guides/response/index.md
@@ -205,6 +205,28 @@ You can as well pass your own context:
 data = Data.model_validate({'some': 1}, context={'request': MyRequest()})
 ```
 
+### Skipping Resolvers
+
+By default, resolvers are called regardless of how the data is passed to the schema.
+
+If you only want to run the resolvers when the schema is passed an object (e.g. a Django model), but not when it is passed a dictionary (e.g. a request body), you can add `always_resolve = False` to the Schema config.
+
+Note that the data passed to a resolver is always in object form, regardless of the input format.
+
+```Python hl_lines="4-5"
+class Data(Schema):
+    a: int
+    path: str = ""
+
+    class Config:
+        always_resolve = False
+
+    @staticmethod
+    def resolve_path(obj, context):
+        request = context["request"]
+        return request.path
+```
+
 ## Returning querysets
 
 In the previous example we specifically converted a queryset into a list (and executed the SQL query during evaluation).

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -6,7 +6,7 @@ from django.db.models import Manager, QuerySet
 from django.db.models.fields.files import ImageFieldFile
 
 from ninja import Schema
-from ninja.schema import Field
+from ninja.schema import Field, _DictToObjectWrapper
 
 
 class FakeManager(Manager):
@@ -183,3 +183,12 @@ def test_with_attr_that_has_resolve():
         resolve_attr = "2"
 
     assert ResolveAttrSchema.from_orm(Obj()).dict() == {"id": "1", "resolve_attr": "2"}
+
+
+def test_dict_to_obj_wrapper():
+    data = {"a": 1, "b": 2}
+    wrapper = _DictToObjectWrapper(data)
+    assert wrapper.a == 1
+    assert wrapper.b == 2
+    with pytest.raises(AttributeError):
+        assert wrapper.c

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -192,3 +192,35 @@ def test_dict_to_obj_wrapper():
     assert wrapper.b == 2
     with pytest.raises(AttributeError):
         assert wrapper.c
+
+
+def test_resolver_called_with_always_resolve_false_and_object():
+    class TestSchema(Schema):
+        name: str
+
+        class Config:
+            always_resolve = False
+
+        @staticmethod
+        def resolve_name(obj):
+            return "test"
+
+    class TestObject:
+        def __init__(self, name):
+            self.name = name
+
+    assert TestSchema.from_orm(TestObject(name="bob")).dict() == {"name": "test"}
+
+
+def test_resolver_skipped_with_always_resolve_false_and_dict():
+    class TestSchema(Schema):
+        name: str
+
+        class Config:
+            always_resolve = False
+
+        @staticmethod
+        def resolve_name(obj):
+            return "test"
+
+    assert TestSchema.from_orm({"name": "bob"}).dict() == {"name": "bob"}

--- a/tests/test_schema_context.py
+++ b/tests/test_schema_context.py
@@ -7,7 +7,7 @@ class ResolveWithKWargs(Schema):
     @staticmethod
     def resolve_value(obj, **kwargs):
         context = kwargs["context"]
-        return obj["value"] + context["extra"]
+        return obj.value + context["extra"]
 
 
 class ResolveWithContext(Schema):
@@ -15,7 +15,7 @@ class ResolveWithContext(Schema):
 
     @staticmethod
     def resolve_value(obj, context):
-        return obj["value"] + context["extra"]
+        return obj.value + context["extra"]
 
 
 def test_schema_with_context():


### PR DESCRIPTION
Allows skipping resolvers by adding `always_resolve = False` to a schema config, which will not run any resolvers if the `GetterDict` object is a dictionary. This is still a breaking change, as `always_resolve` defaults to `True`, but this was kept to ensure that new features with context are easy to use.

Additionally, this now wraps dicts passed to resolvers in a `_DictToObjectWrapper` instance, allowing resolvers to always use attributes. As having dicts or objects passed to resolvers meant resolvers would only work for input or output, otherwise they would have convolutedly handle accessing data from a parameter that could be an object or a dict.

Closes #871