### PR TITLE
Improves create_schema to get types from custom_fields

### DIFF
--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -66,12 +66,15 @@ class SchemaFactory:
         for fld in model_fields_list:
             if fld.name in custom_field_names:
                 continue
-            python_type, field_info = get_schema_field(
-                fld,
-                depth=depth,
-                optional=optional_fields and (fld.name in optional_fields),
-            )
-            definitions[fld.name] = (python_type, field_info)
+            try:
+                python_type, field_info = get_schema_field(
+                    fld,
+                    depth=depth,
+                    optional=optional_fields and (fld.name in optional_fields),
+                )
+                definitions[fld.name] = (python_type, field_info)
+            except KeyError as e:
+                raise KeyError("%s, you may need to provide a custom field." % e) from e
 
         if custom_fields:
             for fld_name, python_type, field_info in custom_fields:

--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -60,8 +60,12 @@ class SchemaFactory:
             if optional_fields == "__all__":
                 optional_fields = [f.name for f in model_fields_list]
 
+        custom_field_names = {name for name, *_ in (custom_fields or [])}
+
         definitions = {}
         for fld in model_fields_list:
+            if fld.name in custom_field_names:
+                continue
             python_type, field_info = get_schema_field(
                 fld,
                 depth=depth,

--- a/tests/test_orm_schemas.py
+++ b/tests/test_orm_schemas.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, TypeVar
 from unittest.mock import Mock
 
 import django
@@ -488,7 +488,6 @@ def test_custom_fields():
 
     Schema1 = create_schema(SmallModel, custom_fields=[("custom", int, ...)])
 
-    # print(Schema1.json_schema())
     assert Schema1.json_schema() == {
         "type": "object",
         "properties": {
@@ -502,7 +501,6 @@ def test_custom_fields():
     }
 
     Schema2 = create_schema(SmallModel, custom_fields=[("f1", int, ...)])
-    # print(Schema2.json_schema())
 
     assert Schema2.json_schema() == {
         "type": "object",
@@ -511,8 +509,32 @@ def test_custom_fields():
             "f1": {"type": "integer", "title": "F1"},
             "f2": {"type": "string", "title": "F2"},
         },
-        "required": ["f1", "f2"],
+        "required": ["f2", "f1"],
         "title": "SmallModel2",
+    }
+
+
+def test_custom_fields_with_custom_types():
+    class CustomField(models.fields.Field):
+        pass
+
+    class TestModel(models.Model):
+        custom = CustomField()
+
+        class Meta:
+            app_label = "tests"
+
+    CustomType = TypeVar("CustomType")
+    Schema1 = create_schema(TestModel, custom_fields=[("custom", CustomType, ...)])
+
+    assert Schema1.json_schema() == {
+        "type": "object",
+        "properties": {
+            "id": {"anyOf": [{"type": "integer"}, {"type": "null"}], "title": "ID"},
+            "custom": {"title": "Custom"},
+        },
+        "required": ["custom"],
+        "title": "TestModel",
     }
 
 

--- a/tests/test_orm_schemas.py
+++ b/tests/test_orm_schemas.py
@@ -9,6 +9,7 @@ from django.db.models import Manager
 
 from ninja.errors import ConfigError
 from ninja.orm import create_schema
+from ninja.orm.fields import TYPES
 from ninja.orm.shortcuts import L, S
 
 
@@ -536,6 +537,24 @@ def test_custom_fields_with_custom_types():
         "required": ["custom"],
         "title": "TestModel",
     }
+
+
+def test_custom_exception_when_missing_custom_fields():
+    class CustomField(models.fields.Field):
+        pass
+
+    class TestModel(models.Model):
+        custom = CustomField()
+
+        class Meta:
+            app_label = "tests"
+
+    with pytest.raises(KeyError) as error:
+        create_schema(TestModel)
+
+    assert (
+        error.value.args[0] == "'CustomField', you may need to provide a custom field."
+    )
 
 
 def test_duplicate_schema_names():


### PR DESCRIPTION
Related to #335, #694, #764

Removes the need to update TYPES for fields passed as custom_fields.

Example:

```python
class CustomField(models.fields.Field):
    pass

class TestModel(models.Model):
    custom = CustomField()

# before
CustomType = TypeVar("CustomType")
TYPES.update({'CustomField': CustomType})
Schema1 = create_schema(TestModel, custom_fields=[("custom", CustomType, ...)])

# with this PR
CustomType = TypeVar("CustomType")
Schema1 = create_schema(TestModel, custom_fields=[("custom", CustomType, ...)])
```