### PR TITLE
Add QuerySet check to _inject_pagination

### DIFF
--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -141,6 +141,14 @@ def _inject_pagination(
 
         items = func(request, **kwargs)
 
+        # check if response is tuple and if the last item is a QuerySet
+        # if False then return it to get operation deal with the response
+        if isinstance(items, tuple):
+            status = items[0]
+            items = items[1]
+            if not isinstance(items, QuerySet):
+                return (status, items)
+
         result = paginator.paginate_queryset(
             items, pagination=pagination_params, request=request, **kwargs
         )


### PR DESCRIPTION
- add tuple and QueryCheck to allow for custom respose type for paginate route
Use Case

This usually will throw error since paginate will use items return from `func` to resolve `paginate_queryset`
 
```py
@router.get(path="/", response={200: list[ProfileSchemaOut], 409: ResponseMessage})
@paginate(PageNumberSizePagination)
def get_all_profiles(request: WSGIRequest):
    """Get all profiles"""
    User.objects.all()
    return 409, codes[409]
```

The check will allow for custom response on paginated route will still have the pydantic check on response types