### PR TITLE
Remove Redoc body margin

### DIFF
--- a/ninja/templates/ninja/redoc.html
+++ b/ninja/templates/ninja/redoc.html
@@ -4,6 +4,12 @@
 <head>
     <link rel="shortcut icon" href="{% static 'ninja/favicon.png' %}">
     <title>{{ api.title }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+        body {
+            margin: 0px;
+        }
+    </style>
 </head>
 <body>
     <div id="redoc-ui"></div>


### PR DESCRIPTION
Updates:
- Remove Redoc body margin
- Add viewport meta tag in redoc.html

In most major browsers, the default body margin is 8px. This causes the redoc content to be a bit (8px) off the screen. Also, the docs are kept in desktop mode in mobile because of the absence of the viewport meta tag, which is also added here.