### PR TITLE
pagination set max limit

### DIFF
--- a/ninja/conf.py
+++ b/ninja/conf.py
@@ -1,5 +1,6 @@
 from django.conf import settings as django_settings
 from pydantic import BaseModel, Field
+from math import inf
 
 
 class Settings(BaseModel):
@@ -19,6 +20,8 @@ class Settings(BaseModel):
         "ninja.pagination.LimitOffsetPagination", alias="NINJA_PAGINATION_CLASS"
     )
     PAGINATION_PER_PAGE: int = Field(100, alias="NINJA_PAGINATION_PER_PAGE")
+    PAGINATION_MAX_LIMIT: int = Field(
+        inf, alias="NINJA_PAGINATION_MAX_LIMIT")
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
As a python junior developer, I offer a tiny opinion.

django-ninja LimitOffsetPagination does not provide a maximum limit, so I always create a new CustomPagination class. 
I modified the code a bit in the hope that django ninja would provide this by default.
