### PR TITLE
Pagination set max limit

### DIFF
--- a/ninja/conf.py
+++ b/ninja/conf.py
@@ -1,5 +1,6 @@
 from django.conf import settings as django_settings
 from pydantic import BaseModel, Field
+from math import inf
 
 
 class Settings(BaseModel):
@@ -19,6 +20,7 @@ class Settings(BaseModel):
         "ninja.pagination.LimitOffsetPagination", alias="NINJA_PAGINATION_CLASS"
     )
     PAGINATION_PER_PAGE: int = Field(100, alias="NINJA_PAGINATION_PER_PAGE")
+    PAGINATION_MAX_LIMIT:int = Field(inf, alias="NINJA_PAGINATION_MAX_LIMIT")
 
     class Config:
         from_attributes = True

--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -65,7 +65,7 @@ class LimitOffsetPagination(PaginationBase):
         **params: Any,
     ) -> Any:
         offset = pagination.offset
-        limit: int = pagination.limit
+        limit: int = min(pagination.limit, settings.PAGINATION_MAX_LIMIT)
         return {
             "items": queryset[offset : offset + limit],
             "count": self._items_count(queryset),


### PR DESCRIPTION
As a python junior developer, I offer a tiny opinion.

django-ninja LimitOffsetPagination does not provide a maximum limit, so I always create a new CustomPagination class.
I modified the code a bit in the hope that django ninja would provide this by default.