### PR TITLE
Suppress async-auth Warning "never awaited"

### DIFF
--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -2,6 +2,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Coroutine,
     Dict,
     Iterable,
     List,
@@ -305,9 +306,11 @@ class AsyncOperation(Operation):
         for callback in self.auth_callbacks:
             try:
                 if is_async_callable(callback) or getattr(callback, "is_async", False):
-                    result = callback(request)
-                    if result is not None:
-                        result = await callback(request)
+                    cor: Optional[Coroutine] = callback(request)
+                    if cor is None:
+                        result = None
+                    else:
+                        result = await cor
                 else:
                     result = callback(request)
             except Exception as exc:


### PR DESCRIPTION
Address for a Warning during async-auth request.
detail is here https://github.com/vitalik/django-ninja/issues/44#issuecomment-1805733011