### PR TITLE
fix typo in whatsnew_v1.md

### DIFF
--- a/docs/docs/whatsnew_v1.md
+++ b/docs/docs/whatsnew_v1.md
@@ -181,7 +181,7 @@ api.add_router('/app5', 'myproject.app5.router')
 
 When django ninja decorates a view with .get/.post etc - it wraps the result of the function (which in most cases are not HttpResponse - but some serializable object) so it's not really possible to use some built-in or 3rd-party decorators like:
 
-```python hl="4"
+```python hl_lines="4"
 from django.views.decorators.cache import cache_page
 
 @api.get("/test")
@@ -193,7 +193,7 @@ This example do not work.
 
 Now django ninja introduces a decorator decorate_view that allows inject decorators that work with http response:
 
-```python hl="1 4"
+```python hl_lines="1 4"
 from ninja.decorators import decorate_view
 
 @api.get("/test")

--- a/docs/docs/whatsnew_v1.md
+++ b/docs/docs/whatsnew_v1.md
@@ -134,7 +134,7 @@ class Auth(HttpBearer):
 ## Changed CSRF Behavior
 
 
-`async=True` requirement is no longer required if you use cookie based authentication. Instead CSRF protection is enabled automatically. This also allow you to  mix csrf-protected authenticators and other methods that does not requrie cookies:
+`csrf=True` requirement is no longer required if you use cookie based authentication. Instead CSRF protection is enabled automatically. This also allow you to  mix csrf-protected authenticators and other methods that does not requrie cookies:
 
 ```Python
 api = NinjaAPI(auth=[django_auth, Auth()])


### PR DESCRIPTION
Fix typo in whatsnew documetation.

1. async -> csrf
2. markdown break (hl does'nt work in MkDocs)
    <img width="800" alt="image" src="https://github.com/vitalik/django-ninja/assets/52434903/3f93ebaf-e2ef-4bb4-9ccc-cef0c3d09441">

