### PR TITLE
Fix pytest.mark.asyncio warning

### DIFF
--- a/tests/test_auth_async.py
+++ b/tests/test_auth_async.py
@@ -140,7 +140,6 @@ async def test_sync_authenticate_method():
 
 
 @pytest.mark.skipif(django.VERSION < (3, 1), reason="requires django 3.1 or higher")
-@pytest.mark.asyncio
 def test_async_authenticate_method_in_sync_context():
     class KeyAuth(APIKeyQuery):
         async def authenticate(self, request, key):


### PR DESCRIPTION
Fix this warning in the test suite:

```
test_auth_async.py::test_async_authenticate_method_in_sync_context
  test_auth_async.py:142: PytestWarning: The test <Function test_async_authenticate_method_in_sync_context> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove asyncio marker. If the test is not marked explicitly, check for global markers applied via 'pytestmark'.
    @pytest.mark.skipif(django.VERSION < (3, 1), reason="requires django 3.1 or higher")
```