### PR TITLE
Update pydantic model Config classes

### DIFF
--- a/ninja/conf.py
+++ b/ninja/conf.py
@@ -1,5 +1,5 @@
 from django.conf import settings as django_settings
-from pydantic import BaseModel, Field
+from pydantic import ConfigDict, BaseModel, Field
 
 
 class Settings(BaseModel):
@@ -19,9 +19,7 @@ class Settings(BaseModel):
         "ninja.pagination.LimitOffsetPagination", alias="NINJA_PAGINATION_CLASS"
     )
     PAGINATION_PER_PAGE: int = Field(100, alias="NINJA_PAGINATION_PER_PAGE")
-
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 settings = Settings.model_validate(django_settings)

--- a/ninja/filter_schema.py
+++ b/ninja/filter_schema.py
@@ -1,38 +1,30 @@
-from typing import Any, cast
+from typing import Any
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q, QuerySet
+from pydantic import ConfigDict
 from pydantic.fields import FieldInfo
 from typing_extensions import Literal
 
 from .schema import Schema
 
-DEFAULT_IGNORE_NONE = True
-DEFAULT_CLASS_LEVEL_EXPRESSION_CONNECTOR = "AND"
-DEFAULT_FIELD_LEVEL_EXPRESSION_CONNECTOR = "OR"
-
 # XOR is available only in Django 4.1+: https://docs.djangoproject.com/en/4.1/ref/models/querysets/#xor
 ExpressionConnector = Literal["AND", "OR", "XOR"]
 
-
-# class FilterConfig(BaseConfig):
-#     ignore_none: bool = DEFAULT_IGNORE_NONE
-#     expression_connector: ExpressionConnector = cast(
-#         ExpressionConnector, DEFAULT_CLASS_LEVEL_EXPRESSION_CONNECTOR
-#     )
+DEFAULT_IGNORE_NONE = True
+DEFAULT_CLASS_LEVEL_EXPRESSION_CONNECTOR: ExpressionConnector = "AND"
+DEFAULT_FIELD_LEVEL_EXPRESSION_CONNECTOR: ExpressionConnector = "OR"
 
 
 class FilterSchema(Schema):
     # if TYPE_CHECKING:
     #     __config__: ClassVar[Type[FilterConfig]] = FilterConfig  # pragma: no cover
 
-    # Config = FilterConfig
-
-    class Config(Schema.Config):
-        ignore_none: bool = DEFAULT_IGNORE_NONE
-        expression_connector: ExpressionConnector = cast(
-            ExpressionConnector, DEFAULT_CLASS_LEVEL_EXPRESSION_CONNECTOR
-        )
+    model_config = ConfigDict(
+        **Schema.model_config,
+        ignore_none=DEFAULT_IGNORE_NONE,
+        expression_connector=DEFAULT_CLASS_LEVEL_EXPRESSION_CONNECTOR,
+    )
 
     def custom_expression(self) -> Q:
         """

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -24,7 +24,7 @@ import pydantic
 from django.db.models import Manager, QuerySet
 from django.db.models.fields.files import FieldFile
 from django.template import Variable, VariableDoesNotExist
-from pydantic import BaseModel, Field, ValidationInfo, model_validator, validator
+from pydantic import ConfigDict, BaseModel, Field, ValidationInfo, model_validator, validator
 from pydantic._internal._model_construction import ModelMetaclass
 from pydantic.functional_validators import ModelWrapValidatorHandler
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
@@ -193,8 +193,7 @@ class NinjaGenerateJsonSchema(GenerateJsonSchema):
 
 
 class Schema(BaseModel, metaclass=ResolverMetaclass):
-    class Config:
-        from_attributes = True  # aka orm_mode
+    model_config = ConfigDict(from_attributes=True)
 
     @model_validator(mode="wrap")
     @classmethod

--- a/tests/demo_project/multi_param/api.py
+++ b/tests/demo_project/multi_param/api.py
@@ -1,5 +1,7 @@
 """Test App to use with Swagger UI and in unit tests"""
 
+from pydantic import ConfigDict
+
 from ninja import (
     Body,
     Cookie,
@@ -44,14 +46,16 @@ class TestData(Schema):
 
 
 class ResponseData(Schema):
+    model_config = ConfigDict(
+        **Schema.model_config,
+        alias_generator=to_kebab,
+        populate_by_name=True,
+    )
+
     i: int
     s: str
     data: TestData4
     nested_data: TestData
-
-    class Config(Schema.Config):
-        alias_generator = to_kebab
-        populate_by_name = True
 
 
 test_data4_extra = dict(title="Data4 Title", description="Data4 Desc")

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 import pytest
 from django.contrib.admin.views.decorators import staff_member_required
 from django.test import Client, override_settings
+from pydantic import ConfigDict
 
 from ninja import Body, Field, File, Form, NinjaAPI, Query, Schema, UploadedFile
 from ninja.openapi.urls import get_openapi_urls
@@ -32,12 +33,14 @@ def to_camel(string: str) -> str:
 
 
 class Response(Schema):
+    model_config = ConfigDict(
+        **Schema.model_config,
+        alias_generator=to_camel,
+        populate_by_name=True,
+    )
+
     i: int
     f: float = Field(..., title="f title", description="f desc")
-
-    class Config(Schema.Config):
-        alias_generator = to_camel
-        populate_by_name = True
 
 
 @api.post("/test", response=Response)

--- a/tests/test_orm_metaclass.py
+++ b/tests/test_orm_metaclass.py
@@ -14,9 +14,9 @@ def test_simple():
             app_label = "tests"
 
     class SampleSchema(ModelSchema):
-        class Config:
+        class Meta:
             model = User
-            model_fields = ["firstname", "lastname"]
+            fields = ["firstname", "lastname"]
 
         def hello(self):
             return f"Hello({self.firstname})"


### PR DESCRIPTION
Update `Schema` class and subclasses for the [pydantic config changes](https://docs.pydantic.dev/2.5/migration/#changes-to-config) from its version 2.

I stopped part way since I realized the changes affect the API. Do you think using `model_config` makes sense for subclasses, or would you go with another design like `ModelSchema.Meta`?