### PR TITLE
Fix test warning

### DIFF
--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -57,7 +57,7 @@ def cookies2(request, wpn: str = Cookie(..., alias="weapon")):
 
 
 @router.post("/test-schema")
-def test_schema(request, payload: ExtraForbidSchema = Body(...)):
+def schema(request, payload: ExtraForbidSchema = Body(...)):
     return "ok"
 
 


### PR DESCRIPTION
pytest assumes router function with test prefix as a test.. but it's not.

```
tests/test_request.py::test_schema
  /envs/django-ninja/lib/python3.12/site-packages/_pytest/python.py:198: PytestReturnNotNoneWarning: Expected None, but tests/test_request.py::test_schema returned 'ok', which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    warnings.warn(
```