### PR TITLE
add_api_operation refactor

### DIFF
--- a/ninja/router.py
+++ b/ninja/router.py
@@ -281,11 +281,11 @@ class Router:
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
     ) -> None:
-        if path not in self.path_operations:
+        path_view: Optional[PathView] = self.path_operations.get(path)
+        if not path_view:
             path_view = PathView()
             self.path_operations[path] = path_view
-        else:
-            path_view = self.path_operations[path]
+
         path_view.add_operation(
             path=path,
             methods=methods,


### PR DESCRIPTION
Hello,

I've refactored the conditional logic in the `add_api_operation` method of the `Router` class for improved readability. The new approach uses the dictionary's `get` method, which simplifies the code.

Here's the updated code snippet:

```python
path_view: Optional[PathView] = self.path_operations.get(path)
if not path_view:
    path_view = PathView()
    self.path_operations[path] = path_view
```

Thank you for considering this change.