### PR TITLE
docs: remove extra backtick in api docs page

### DIFF
--- a/docs/docs/guides/api-docs.md
+++ b/docs/docs/guides/api-docs.md
@@ -101,7 +101,7 @@ In a Django template, for example:
 
 ## Creating custom docs viewer
 
-To create your own view for OpenaAPI - create a class inherited from DocsBase and overwrite `render_page`` method:
+To create your own view for OpenaAPI - create a class inherited from DocsBase and overwrite `render_page` method:
 
 ```python
 form ninja.openapi.docs import DocsBase


### PR DESCRIPTION
- removes extra backtick around `render_page`:

![Screenshot 2023-11-28 at 9 42 52 AM](https://github.com/vitalik/django-ninja/assets/23270779/a4baa7aa-d30e-460a-b9c2-4752178d518c)
