### PR TITLE
Fix README.md test badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 
-![Test](https://github.com/vitalik/django-ninja/workflows/Test/badge.svg)
+![Test](https://github.com/vitalik/django-ninja/actions/workflows/test_full.yml/badge.svg)
 ![Coverage](https://img.shields.io/codecov/c/github/vitalik/django-ninja)
 [![PyPI version](https://badge.fury.io/py/django-ninja.svg)](https://badge.fury.io/py/django-ninja)
 [![Downloads](https://static.pepy.tech/personalized-badge/django-ninja?period=month&units=international_system&left_color=black&right_color=brightgreen&left_text=downloads/month)](https://pepy.tech/project/django-ninja)


### PR DESCRIPTION
Updates the README to use the correct link to the test workflow badge, fixing the rendering error. I assumed it was best to use the `test_full` workflow rather than just `test` (which has the name "Test Coverage" in the badge), but happy to change to either. 

Currently -
<img width="653" alt="Screenshot 2023-12-18 at 8 00 34 PM" src="https://github.com/vitalik/django-ninja/assets/3912019/8f666e51-3b2c-4c47-89df-b301c6f7135b">

After change -
<img width="867" alt="Screenshot 2023-12-18 at 8 00 59 PM" src="https://github.com/vitalik/django-ninja/assets/3912019/b43e24f1-2db9-4a1f-9cfb-795b06a6a7a0">