### PR TITLE
Cleanup documentation warnings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,11 +30,8 @@ make test
 Now you are ready to make your contribution
 
 
-When you done:
-
-Please make sure you made tests to cover your functionality 
-
-and finally check the resulting coverage of your contribution did not suffer
+When you're done please make sure you to test your functionality 
+and check the coverage of your contribution.
 
 ```
 pytest --cov=ninja --cov-report term-missing tests

--- a/docs/docs/guides/input/form-params.md
+++ b/docs/docs/guides/input/form-params.md
@@ -27,7 +27,7 @@ username: Form[str]
 
 ## Using a Schema
 
-In a similar manner to [Body](../body/#declare-it-as-a-parameter), you can use
+In a similar manner to [Body](body.md#declare-it-as-a-parameter), you can use
 a Schema to organize your parameters.
 
 ```python hl_lines="12"
@@ -36,7 +36,7 @@ a Schema to organize your parameters.
 
 ## Request form + path + query parameters
 
-In a similar manner to [Body](../body/#request-body-path-query-parameters), you can use
+In a similar manner to [Body](body.md#request-body-path-query-parameters), you can use
 Form data in combination with other parameter sources.
 
 You can declare query **and** path **and** form field, **and** etc... parameters at the same time.

--- a/docs/docs/guides/response/config-pydantic.md
+++ b/docs/docs/guides/response/config-pydantic.md
@@ -69,7 +69,7 @@ results:
 
 ## Custom Config from Django Model
 
-When using [`create_schema`](../django-pydantic-create-schema/#create_schema), the resulting
+When using [`create_schema`](django-pydantic-create-schema.md#create_schema), the resulting
 schema can be used to build another class with a custom config like:
 
 ```python hl_lines="10"

--- a/docs/docs/guides/response/django-pydantic-create-schema.md
+++ b/docs/docs/guides/response/django-pydantic-create-schema.md
@@ -1,6 +1,6 @@
 # Using create_schema
 
-Under the hood, [`ModelSchema`](../django-pydantic/#modelschema) uses the `create_schema` function.
+Under the hood, [`ModelSchema`](django-pydantic.md#modelschema) uses the `create_schema` function.
 This is a more advanced (and less safe) method - please use it carefully.
 
 ## `create_schema`

--- a/docs/docs/guides/response/index.md
+++ b/docs/docs/guides/response/index.md
@@ -227,7 +227,7 @@ def tasks(request):
         return Task.objects.all()
     ```
 
-    See the [async support](../async-support#using-orm) guide for more information.
+    See the [async support](../async-support.md#using-orm) guide for more information.
 
 
 ## FileField and ImageField

--- a/docs/docs/motivation.md
+++ b/docs/docs/motivation.md
@@ -56,7 +56,7 @@ Some companies are already looking for developers with django ninja experience.
 
 #### Main Features
 
-1) Since you can have multiple Django Ninja API instances - you can run [multiple API versions](/guides/versioning/) inside one Django project.
+1) Since you can have multiple Django Ninja API instances - you can run [multiple API versions](guides/versioning.md) inside one Django project.
 
 ```python
 api_v1 = NinjaAPI(version='1.0', auth=token_auth)
@@ -75,7 +75,7 @@ urlpatterns = [
 ]
 ```
 
-2) The Django Ninja 'Schema' class is integrated with the ORM, so you can [serialize querysets](/guides/response/#returning-querysets) or ORM objects:
+2) The Django Ninja 'Schema' class is integrated with the ORM, so you can [serialize querysets](guides/response/index.md#returning-querysets) or ORM objects:
 
 ```python
 @api.get("/tasks", response=List[TaskSchema])
@@ -88,6 +88,6 @@ def tasks_details(request):
     task = Task.objects.first()
     return task
 ```
-3) [Create Schema's from Django Models](/guides/response/django-pydantic/).
+3) [Create Schema's from Django Models](guides/response/django-pydantic.md).
 
-4) Instead of dependency arguments, **Django Ninja** uses `request` instance attributes (in the same way as regular Django views) - more detail at [Authentication](/guides/authentication/).
+4) Instead of dependency arguments, **Django Ninja** uses `request` instance attributes (in the same way as regular Django views) - more detail at [Authentication](guides/authentication.md).

--- a/docs/docs/proposals/index.md
+++ b/docs/docs/proposals/index.md
@@ -6,4 +6,4 @@ You can create a proposal by making a pull request with a new page under [`docs/
 
 Please see the current proposals:
 
- - [Class Based Operations](cbv)
+ - [Class Based Operations](cbv.md)

--- a/docs/docs/whatsnew_v1.md
+++ b/docs/docs/whatsnew_v1.md
@@ -208,17 +208,9 @@ def test_view(request):
 `paginate_queryset` method now takes `request` object
 
 
-
-
 #### Backwards incompatible stuff
  - resolve_xxx(self, ...) - support resolve with (self) is dropped in favor of pydantic build-in functionality
  - pydantic v1 is no longer supported
  - python 3.6 is no longer supported
 
 BTW - if you like this project and still did not give it a github start - please do so ![github star](img/github-star.png)
-
-[button]
-
-
-
-

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
       - Intro: proposals/index.md
       - proposals/cbv.md
       - proposals/v1.md
+  - What's new in V1: whatsnew_v1.md
 markdown_extensions:
   - markdown_include.include
   - markdown.extensions.codehilite:


### PR DESCRIPTION
Generating the documentation produces a number of warnings, which could be disconcerting or confusing for first time contributors. This PR cleans up those warnings. 

It also:
- Adds "What's new in V1" to the documentation navigation.
- Cleans up some language in the contributors guide. 

Existing warnings:
```INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
             - whatsnew_v1.md
INFO    -  Doc file 'motivation.md' contains an absolute link '/guides/versioning/', it was left as is. Did you mean
           'guides/versioning.md'?
INFO    -  Doc file 'motivation.md' contains an absolute link '/guides/response/#returning-querysets', it was left as is. Did you mean
           'guides/response/index.md#returning-querysets'?
INFO    -  Doc file 'motivation.md' contains an absolute link '/guides/response/django-pydantic/', it was left as is. Did you mean
           'guides/response/django-pydantic.md'?
INFO    -  Doc file 'motivation.md' contains an absolute link '/guides/authentication/', it was left as is. Did you mean
           'guides/authentication.md'?
INFO    -  Doc file 'guides/input/form-params.md' contains an unrecognized relative link '../body/#declare-it-as-a-parameter', it was
           left as is. Did you mean 'body.md#declare-it-as-a-parameter'?
INFO    -  Doc file 'guides/input/form-params.md' contains an unrecognized relative link '../body/#request-body-path-query-parameters',
           it was left as is. Did you mean 'body.md#request-body-path-query-parameters'?
INFO    -  Doc file 'guides/response/index.md' contains an unrecognized relative link '../async-support#using-orm', it was left as is.
           Did you mean '../async-support.md#using-orm'?
INFO    -  Doc file 'guides/response/config-pydantic.md' contains an unrecognized relative link
           '../django-pydantic-create-schema/#create_schema', it was left as is. Did you mean
           'django-pydantic-create-schema.md#create_schema'?
INFO    -  Doc file 'guides/response/django-pydantic-create-schema.md' contains an unrecognized relative link
           '../django-pydantic/#modelschema', it was left as is. Did you mean 'django-pydantic.md#modelschema'?
INFO    -  Doc file 'proposals/index.md' contains an unrecognized relative link 'cbv', it was left as is. Did you mean 'cbv.md'?
```