### PR TITLE
Implement choices as Literal for PyDantic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,12 @@ repos:
       - id: check-yaml
       # - id: end-of-file-fixer
       # - id: trailing-whitespace
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
-    hooks:
-      - id: mypy
-        additional_dependencies: ["django-stubs", "pydantic"]
-        exclude: (tests|docs)/
+#  - repo: https://github.com/pre-commit/mirrors-mypy
+#    rev: v1.7.1
+#    hooks:
+#      - id: mypy
+#        additional_dependencies: ["django-stubs", "pydantic"]
+#        exclude: (tests|docs)/
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.6
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,12 @@ repos:
       - id: check-yaml
       # - id: end-of-file-fixer
       # - id: trailing-whitespace
-#  - repo: https://github.com/pre-commit/mirrors-mypy
-#    rev: v1.7.1
-#    hooks:
-#      - id: mypy
-#        additional_dependencies: ["django-stubs", "pydantic"]
-#        exclude: (tests|docs)/
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.7.1
+    hooks:
+      - id: mypy
+        additional_dependencies: ["django-stubs", "pydantic"]
+        exclude: (tests|docs)/
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.6
     hooks:

--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -43,6 +43,7 @@ class SchemaFactory:
         optional_fields: Optional[List[str]] = None,
         custom_fields: Optional[List[Tuple[str, Any, Any]]] = None,
         base_class: Type[Schema] = Schema,
+        choices_exclude: Optional[List[str]] = None,
     ) -> Type[Schema]:
         name = name or model.__name__
 
@@ -66,6 +67,7 @@ class SchemaFactory:
                 fld,
                 depth=depth,
                 optional=optional_fields and (fld.name in optional_fields),
+                choices_exclude=choices_exclude,
             )
             definitions[fld.name] = (python_type, field_info)
 

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -3,11 +3,12 @@ from decimal import Decimal
 from typing import Any, Callable, Dict, List, Tuple, Type, TypeVar, Union, no_type_check
 from uuid import UUID
 
-from django.db.models import ManyToManyField
+from django.db.models import Choices, ManyToManyField
 from django.db.models.fields import Field as DjangoField
 from pydantic import IPvAnyAddress
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined, core_schema
+from typing_extensions import Literal
 
 from ninja.openapi.schema import OpenAPISchema
 from ninja.types import DictStrAny
@@ -139,9 +140,18 @@ def get_schema_field(
         blank = field_options.get("blank", False)
         null = field_options.get("null", False)
         max_length = field_options.get("max_length")
+        choices = field_options.get("choices")
 
-        internal_type = field.get_internal_type()
-        python_type = TYPES[internal_type]
+        if not choices:
+            internal_type = field.get_internal_type()
+            python_type = TYPES[internal_type]
+        else:
+            # Django 5.x compat: choices can be an enum
+            if isinstance(choices, type) and issubclass(choices, Choices):
+                choices = choices.choices
+            # Python 3.8 compat: can't unpack inline
+            choice_list = [c[0] for c in choices]
+            python_type = Literal[tuple(choice_list)]
 
         if field.has_default():
             if callable(field.default):

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -1,6 +1,17 @@
 import datetime
 from decimal import Decimal
-from typing import Any, Callable, Dict, List, Tuple, Type, TypeVar, Union, no_type_check
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    no_type_check,
+)
 from uuid import UUID
 
 from django.db.models import Choices, ManyToManyField
@@ -106,7 +117,11 @@ def create_m2m_link_type(type_: Type[TModel]) -> Type[TModel]:
 
 @no_type_check
 def get_schema_field(
-    field: DjangoField, *, depth: int = 0, optional: bool = False
+    field: DjangoField,
+    *,
+    depth: int = 0,
+    optional: bool = False,
+    choices_exclude: Optional[List[str]] = None,
 ) -> Tuple:
     "Returns pydantic field from django's model field"
     alias = None
@@ -116,6 +131,7 @@ def get_schema_field(
     title = None
     max_length = None
     python_type = None
+    choices_exclude = choices_exclude or []
 
     if field.is_relation:
         if depth > 0:
@@ -142,7 +158,7 @@ def get_schema_field(
         max_length = field_options.get("max_length")
         choices = field_options.get("choices")
 
-        if not choices:
+        if not choices or _f_name in choices_exclude:
             internal_type = field.get_internal_type()
             python_type = TYPES[internal_type]
         else:

--- a/ninja/orm/metaclass.py
+++ b/ninja/orm/metaclass.py
@@ -17,6 +17,7 @@ class MetaConf:
     fields: Optional[List[str]] = None
     exclude: Union[List[str], str, None] = None
     fields_optional: Union[List[str], str, None] = None
+    choices_exclude: Optional[List[str]] = None
 
     @staticmethod
     def from_schema_class(name: str, namespace: dict) -> "MetaConf":
@@ -26,6 +27,7 @@ class MetaConf:
             fields = getattr(meta, "fields", None)
             exclude = getattr(meta, "exclude", None)
             optional_fields = getattr(meta, "fields_optional", None)
+            choices_exclude = getattr(meta, "choices_exclude", None)
 
         elif "Config" in namespace:
             config = namespace["Config"]
@@ -33,6 +35,7 @@ class MetaConf:
             fields = getattr(config, "model_fields", None)
             exclude = getattr(config, "model_exclude", None)
             optional_fields = getattr(config, "model_fields_optional", None)
+            choices_exclude = getattr(config, "choices_exclude", None)
 
             warnings.warn(
                 "The use of `Config` class is deprecated for ModelSchema, use 'Meta' instead",
@@ -62,6 +65,7 @@ class MetaConf:
             fields=fields,
             exclude=exclude,
             fields_optional=optional_fields,
+            choices_exclude=choices_exclude,
         )
 
 
@@ -110,6 +114,7 @@ class ModelSchemaMetaclass(ResolverMetaclass):
                     exclude=meta_conf.exclude,
                     optional_fields=meta_conf.fields_optional,
                     custom_fields=custom_fields,
+                    choices_exclude=meta_conf.choices_exclude,
                     base_class=cls,
                 )
                 model_schema.__doc__ = cls.__doc__

--- a/tests/test_orm_schemas.py
+++ b/tests/test_orm_schemas.py
@@ -8,6 +8,7 @@ from django.db.models import Manager
 
 from ninja.errors import ConfigError
 from ninja.orm import create_schema
+from ninja.orm.factory import SchemaFactory
 from ninja.orm.shortcuts import L, S
 
 
@@ -578,6 +579,8 @@ def test_optional_fields():
 
 
 def test_choices():
+    from ninja import ModelSchema
+
     class ModelWithChoices(models.Model):
         class ThemeChoices(models.TextChoices):
             SYS = "system", "System"
@@ -610,5 +613,46 @@ def test_choices():
         },
         "required": ["theme", "score"],
         "title": "ModelWithChoices",
+        "type": "object",
+    }
+    # Avoid cache inside schemafactory instance
+    ChoiceExcludeScore = SchemaFactory().create_schema(
+        ModelWithChoices, choices_exclude=["score"]
+    )
+    assert ChoiceExcludeScore.json_schema() == {
+        "properties": {
+            "id": {"anyOf": [{"type": "integer"}, {"type": "null"}], "title": "ID"},
+            "score": {"title": "Score", "type": "integer"},
+            "theme": {
+                "enum": ["system", "dark", "light"],
+                "maxLength": 32,
+                "title": "Theme",
+                "type": "string",
+            },
+        },
+        "required": ["theme", "score"],
+        "title": "ModelWithChoices",
+        "type": "object",
+    }
+
+    class ModelWithChoicesSchema(ModelSchema):
+        class Meta:
+            model = ModelWithChoices
+            fields = "__all__"
+            choices_exclude = ["score"]
+
+    assert ModelWithChoicesSchema.json_schema() == {
+        "properties": {
+            "id": {"anyOf": [{"type": "integer"}, {"type": "null"}], "title": "ID"},
+            "score": {"title": "Score", "type": "integer"},
+            "theme": {
+                "enum": ["system", "dark", "light"],
+                "maxLength": 32,
+                "title": "Theme",
+                "type": "string",
+            },
+        },
+        "required": ["theme", "score"],
+        "title": "ModelWithChoicesSchema",
         "type": "object",
     }

--- a/tests/test_orm_schemas.py
+++ b/tests/test_orm_schemas.py
@@ -575,3 +575,40 @@ def test_optional_fields():
         SomeReqFieldModel, optional_fields=["some_field", "other_field", "optional"]
     )
     assert Schema.json_schema().get("required") is None
+
+
+def test_choices():
+    class ModelWithChoices(models.Model):
+        class ThemeChoices(models.TextChoices):
+            SYS = "system", "System"
+            DARK = "dark", "Dark"
+            LIGHT = "light", "Light"
+
+        class ScoreChoices(models.IntegerChoices):
+            GOOD = 10, "Good"
+            AVERAGE = 5, "Average"
+            BAD = 1, "Bad"
+
+        theme = models.CharField(max_length=32, choices=ThemeChoices.choices)
+        score = models.PositiveSmallIntegerField(choices=ScoreChoices.choices)
+
+        class Meta:
+            app_label = "tests"
+
+    OrmSchema = create_schema(ModelWithChoices)
+
+    assert OrmSchema.json_schema() == {
+        "properties": {
+            "id": {"anyOf": [{"type": "integer"}, {"type": "null"}], "title": "ID"},
+            "score": {"enum": [10, 5, 1], "title": "Score", "type": "integer"},
+            "theme": {
+                "enum": ["system", "dark", "light"],
+                "maxLength": 32,
+                "title": "Theme",
+                "type": "string",
+            },
+        },
+        "required": ["theme", "score"],
+        "title": "ModelWithChoices",
+        "type": "object",
+    }


### PR DESCRIPTION
Adds the ability to render choices as Literals, with a `choices_exclude` meta configuration to exclude fields that should not be literals.