### PR TITLE
Add SCHEMA_GENERATION_CLASS to settings, Allow NinjaGenerateJsonSchema to be overridden

### DIFF
--- a/ninja/conf.py
+++ b/ninja/conf.py
@@ -25,6 +25,10 @@ class Settings(BaseModel):
     PAGINATION_PER_PAGE: int = Field(100, alias="NINJA_PAGINATION_PER_PAGE")
     PAGINATION_MAX_LIMIT: int = Field(inf, alias="NINJA_PAGINATION_MAX_LIMIT")
 
+    SCHEMA_GENERATION_CLASS: str = Field(
+        "ninja.schema.NinjaGenerateJsonSchema", alias="NINJA_SCHEMA_GENERATION_CLASS"
+    )
+
     class Config:
         from_attributes = True
 

--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -4,10 +4,12 @@ import warnings
 from http.client import responses
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Set, Tuple
 
+from django.utils.module_loading import import_string
+
+from ninja.conf import settings
 from ninja.constants import NOT_SET
 from ninja.operation import Operation
 from ninja.params.models import TModel, TModels
-from ninja.schema import NinjaGenerateJsonSchema
 from ninja.types import DictStrAny
 from ninja.utils import normalize_path
 
@@ -149,7 +151,7 @@ class OpenAPISchema(dict):
 
         schema = model.model_json_schema(
             ref_template=REF_TEMPLATE,
-            schema_generator=NinjaGenerateJsonSchema,
+            schema_generator=import_string(settings.SCHEMA_GENERATION_CLASS),
         )
 
         required = set(schema.get("required", []))
@@ -214,7 +216,7 @@ class OpenAPISchema(dict):
             schema = model.model_json_schema(
                 ref_template=REF_TEMPLATE,
                 by_alias=by_alias,
-                schema_generator=NinjaGenerateJsonSchema,
+                schema_generator=import_string(settings.SCHEMA_GENERATION_CLASS),
             ).copy()
 
         # move Schemas from definitions

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -25,18 +25,27 @@ import pydantic
 from django.db.models import Manager, QuerySet
 from django.db.models.fields.files import FieldFile
 from django.template import Variable, VariableDoesNotExist
+from django.utils.module_loading import import_string
 from pydantic import BaseModel, Field, ValidationInfo, model_validator, validator
 from pydantic._internal._model_construction import ModelMetaclass
 from pydantic.functional_validators import ModelWrapValidatorHandler
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
 
+from ninja.conf import settings
 from ninja.signature.utils import get_args_names, has_kwargs
 from ninja.types import DictStrAny
 
 pydantic_version = list(map(int, pydantic.VERSION.split(".")[:2]))
 assert pydantic_version >= [2, 0], "Pydantic 2.0+ required"
 
-__all__ = ["BaseModel", "Field", "validator", "DjangoGetter", "Schema"]
+__all__ = [
+    "BaseModel",
+    "Field",
+    "validator",
+    "DjangoGetter",
+    "Schema",
+    "NinjaGenerateJsonSchema",
+]
 
 S = TypeVar("S", bound="Schema")
 
@@ -223,7 +232,9 @@ class Schema(BaseModel, metaclass=ResolverMetaclass):
 
     @classmethod
     def json_schema(cls) -> DictStrAny:
-        return cls.model_json_schema(schema_generator=NinjaGenerateJsonSchema)
+        return cls.model_json_schema(
+            schema_generator=import_string(settings.SCHEMA_GENERATION_CLASS)
+        )
 
     @classmethod
     def schema(cls) -> DictStrAny:  # type: ignore


### PR DESCRIPTION
Hi, 

This pull request allow `NinjaGenerateJsonSchema` to be changed via settings

**Usecase**
I encounter a problem like https://github.com/vitalik/django-ninja/issues/965.
while waiting for bug to be resolved. I have a workaround solution by custom  behaviour of `get_defs_ref` inside NinjaGenerateJsonSchema 

Allowing `NinjaGenerateJsonSchema` to be changed via settings enable clean solution to do this.
(I don't want to do monky patch)
