### PR TITLE
Add dark mode to ninja docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -13,7 +13,23 @@ extra_css:
 theme:
   name: material
   palette:
-    primary: green
+    - media: "(prefers-color-scheme)"
+      primary: green
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: green
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)" 
+      scheme: slate
+      primary: green
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
   logo: img/docs-logo.png
   favicon: img/favicon.png
   language: en
@@ -91,5 +107,3 @@ plugins:
           setup_commands:
             - from django.conf import settings
             - settings.configure()
-      watch:
-        - ../ninja

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,3 @@
-mkdocs==1.3.1
-mkdocs-material==8.3.9
-markdown-include==0.7.0
-Jinja2==3.1.2
-mkdocstrings[python]==0.19.0
+mkdocs-material==9.5.4
+markdown-include==0.8.1
+mkdocstrings[python]==0.24.0


### PR DESCRIPTION
Adds dark mode to docs. Also allows to use default system theme. Closes #1051.

Dark Mode:
![image](https://github.com/vitalik/django-ninja/assets/45965466/170b0bde-f774-425d-8a8d-a740a2545ceb)

Light Mode:
![image](https://github.com/vitalik/django-ninja/assets/45965466/5edab08d-de91-4602-b1eb-1b8633b40d00)

Auto Mode:
![image](https://github.com/vitalik/django-ninja/assets/45965466/279d0494-b9dd-41b7-81e1-c0668a19ff42)


