### PR TITLE
[testing] Add `resolver_match` to the mocked request object in the Ninja's TestClient

### DIFF
--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -104,12 +104,17 @@ class NinjaClientBase:
         for url in self.urls:
             match = url.resolve(url_path)
             if match:
-                request = self._build_request(method, path, data, request_params)
+                request = self._build_request(method, path, data, request_params, match)
                 return match.func, request, match.kwargs
         raise Exception(f'Cannot resolve "{path}"')
 
     def _build_request(
-        self, method: str, path: str, data: Dict, request_params: Any
+        self,
+        method: str,
+        path: str,
+        data: Dict,
+        request_params: Any,
+        resolver_match: Any,
     ) -> Mock:
         request = Mock()
         request.method = method
@@ -119,6 +124,7 @@ class NinjaClientBase:
         request._dont_enforce_csrf_checks = True
         request.is_secure.return_value = False
         request.build_absolute_uri = build_absolute_uri
+        request.resolver_match = resolver_match
 
         if "user" not in request_params:
             request.user.is_authenticated = False


### PR DESCRIPTION
# The problem

Previously, the Ninja's `TestClient` did not include the `resolver_match` in the mocked request object. That's causing issue when having the following setup:

```python
# in schemas.py

class EntityUpdateSchema(Schema):
    id: int

    class Meta:
        exclude: ("id",)
        fields_optional = "__all__"
        model = Entity

    @staticmethod
    def resolve_id(obj, context):
        return context["request"].resolver_match.kwargs.get("id")
```

The above schema will infer the `id` property from the path. So, assuming you have the following path:
```python
@router.patch("/entities/{id}/")
def patch_entity(request: HttpRequest, id: int, partial_entity_data: EntityUpdateSchema):
    ...
```

the `EntityUpdateSchema` will be populated with the `id` received from the path. I find this useful for when we need to do some validation against the object and we need to query the object that we're currently working with.

And the good news is - this works perfectly! When I call the endpoint, everything is behaving as it should :chef-kiss:

## So, what's the problem?

When writing tests, though, and using the `TestClient` from Ninja, this is not working at all. Doing `client.patch("/entities/123")` will never populate the schema field, and we will get a validation error back, saying the id field is missing.

# The solution

The solution for this is quite simple - when we build the mock request object, we need to set the `resolver_match` to the ninja resolver that we get back from the URL. By doing that, the schema is again able to infer the id and everything works as it should, even in tests.

While I could just create my own TestClient that would inherit from Ninja's test client, and override the `_resolve` method, I assume this would be beneficial to others as well. Hence, creating a PR with the fix in hopes that others will find it useful as well.