### PR TITLE
dict() missed from the deprecated list

### DIFF
--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -219,7 +219,11 @@ class Schema(BaseModel, metaclass=ResolverMetaclass):
         return cls.model_validate(obj, **kw)
 
     def dict(self, *a: Any, **kw: Any) -> DictStrAny:
-        warnings.warn('The `dict` method is deprecated; use `model_dump` instead.', category=PydanticDeprecatedSince20)
+        warnings.warn(
+            "The `dict` method is deprecated; use `model_dump` instead.",
+            category=PydanticDeprecatedSince20,
+            stacklevel=2,
+        )
         return self.model_dump(*a, **kw)
 
     @classmethod

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -29,6 +29,7 @@ from pydantic import BaseModel, Field, ValidationInfo, model_validator, validato
 from pydantic._internal._model_construction import ModelMetaclass
 from pydantic.functional_validators import ModelWrapValidatorHandler
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
+from pydantic.warnings import PydanticDeprecatedSince20
 
 from ninja.signature.utils import get_args_names, has_kwargs
 from ninja.types import DictStrAny

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -218,7 +218,7 @@ class Schema(BaseModel, metaclass=ResolverMetaclass):
         return cls.model_validate(obj, **kw)
 
     def dict(self, *a: Any, **kw: Any) -> DictStrAny:
-        "Backward compatibility with pydantic 1.x"
+        warnings.warn('The `dict` method is deprecated; use `model_dump` instead.', category=PydanticDeprecatedSince20)
         return self.model_dump(*a, **kw)
 
     @classmethod


### PR DESCRIPTION
The dict method is missing from the PydanticDeprecatedSince20 list.