### PR TITLE
Adding create_response method to class Router

### DIFF
--- a/docs/docs/guides/routers.md
+++ b/docs/docs/guides/routers.md
@@ -125,6 +125,26 @@ Now, include `api` to your urls as usual and open your browser at `/api/docs`, a
 
 ![Swagger UI Simple Routers](../img/simple-routers-swagger.png)
 
+## Router response
+Routers can output response like the main `NinjaAPI` class using `return` statements:
+```python
+@router.get('/')
+def users_only(request):
+    if not request.auth.is_authenticated():
+        return "YOU SHALL NOT PASS!"
+    ...
+```
+If a scenario where more advanced responses must be crafted, or responses with a different HTTP code must be returned, 
+the `create_response` method can be used.
+```python
+@router.get('/')
+def users_only(request):
+    if not request.auth.is_authenticated():
+        return router.create_response(request, "YOU SHALL NOT PASS!", status=401)
+    ...
+```
+If a status code is not provided, it will default to 200. Note this is different from previous behavior, where the code would not function without the definition of status.
+
 
 ## Router authentication
 

--- a/ninja/main.py
+++ b/ninja/main.py
@@ -420,7 +420,7 @@ class NinjaAPI:
         request: HttpRequest,
         data: Any,
         *,
-        status: Optional[int] = None,
+        status: Optional[int] = 200,
         temporal_response: Optional[HttpResponse] = None,
     ) -> HttpResponse:
         if temporal_response:

--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -36,23 +36,21 @@ class OpenAPISchema(dict):
         self.securitySchemes: DictStrAny = {}
         self.all_operation_ids: Set = set()
         extra_info = api.openapi_extra.get("info", {})
-        super().__init__(
-            [
-                ("openapi", "3.1.0"),
-                (
-                    "info",
-                    {
-                        "title": api.title,
-                        "version": api.version,
-                        "description": api.description,
-                        **extra_info,
-                    },
-                ),
-                ("paths", self.get_paths()),
-                ("components", self.get_components()),
-                ("servers", api.servers),
-            ]
-        )
+        super().__init__([
+            ("openapi", "3.1.0"),
+            (
+                "info",
+                {
+                    "title": api.title,
+                    "version": api.version,
+                    "description": api.description,
+                    **extra_info,
+                },
+            ),
+            ("paths", self.get_paths()),
+            ("components", self.get_components()),
+            ("servers", api.servers),
+        ])
         for k, v in api.openapi_extra.items():
             if k not in self:
                 self[k] = v
@@ -237,12 +235,10 @@ class OpenAPISchema(dict):
         content_type = BODY_CONTENT_TYPES["file"]
 
         # get the various schemas
-        result = merge_schemas(
-            [
-                self._create_schema_from_model(model, remove_level=False)[0]
-                for model in models
-            ]
-        )
+        result = merge_schemas([
+            self._create_schema_from_model(model, remove_level=False)[0]
+            for model in models
+        ])
         result["title"] = "MultiPartBodyParams"
 
         return result, content_type

--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -126,12 +126,10 @@ class NinjaClientBase:
         request.META = request_params.pop("META", {})
         request.FILES = request_params.pop("FILES", {})
 
-        request.META.update(
-            {
-                f"HTTP_{k.replace('-', '_')}": v
-                for k, v in request_params.pop("headers", {}).items()
-            }
-        )
+        request.META.update({
+            f"HTTP_{k.replace('-', '_')}": v
+            for k, v in request_params.pop("headers", {}).items()
+        })
 
         request.headers = HttpHeaders(request.META)
 


### PR DESCRIPTION
The class `Router` does not have the method `create_response` attached to it, which is not consistent with the behavior of the main class `NinjaAPI`. As such, I have added this method in the following pull request, and documented it under Routers in the documentation.

I also changed the default HTTP status-code of the method `create_response` to 200 in both `Router` and `NinjaAPI`, so that the method can be called without error if the parameter `status` is not defined.

Other changes came from reformatting using `make lint`. 

After doing a coverage test on the app, 99.37% of the app is covered, however this 0.63% seems to be from a skipped test from pre-commit, and it seems that this modification is both stable and passing, both with custom app testing, and unit testing.