### PR TITLE
Allow Schema model_config.extra = "allow"

### DIFF
--- a/docs/docs/guides/response/config-pydantic.md
+++ b/docs/docs/guides/response/config-pydantic.md
@@ -9,6 +9,46 @@ There are many customizations available for a **Django Ninja `Schema`**, via the
     when using Django models, as Pydantic's model class is called Model by default, and conflicts with
     Django's Model class.
 
+## Allow extra fields in POST request body
+
+You can allow extra fields to be passed to your view using the Pydantic model config option `extra="allow"`
+
+```python
+from ninja import Schema
+
+class UserInSchema(Schema):
+    name: str
+
+    class Config(Schema.Config):
+        extra = "allow"
+
+# ---
+# views.py
+
+@api.post("/users")
+def create_user(request, payload: UserInSchema):
+    print(payload)
+    return payload
+
+```
+
+Call the endpoint with more data than the schema defined
+
+```bash
+# POST: /users
+# JSON Payload { "name": "your name", "age": 100 }
+```
+
+Result:
+
+```json
+{
+  "name": "your name",
+  "age": 1000
+}
+```
+
+
 ## Example Camel Case mode
 
 One interesting `Config` attribute is [`alias_generator`](https://pydantic-docs.helpmanual.io/usage/model_config/#alias-generator).

--- a/ninja/orm/metaclass.py
+++ b/ninja/orm/metaclass.py
@@ -101,8 +101,6 @@ class ModelSchemaMetaclass(ResolverMetaclass):
                 # cls.__fields__ = {}  # forcing pydantic recreate
                 # # assert False, "!! cls.model_fields"
 
-                # print(config.model, name, fields, exclude, "!!")
-
                 model_schema = create_schema(
                     meta_conf.model,
                     name=name,

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -210,6 +210,10 @@ class Schema(BaseModel, metaclass=ResolverMetaclass):
         if cls.model_config.get("extra") == "forbid":
             handler(values)
 
+        if cls.model_config.get("extra") == "allow" and isinstance(values, (dict, list)):
+            # Extra values only work with python dictionary or list, DjangoGetter applies more strict validation
+            return handler(values)
+
         values = DjangoGetter(values, cls, info.context)
         return handler(values)
 

--- a/tests/test_inheritance_routers.py
+++ b/tests/test_inheritance_routers.py
@@ -91,7 +91,6 @@ def test_inheritance_responses(path, expected_status, expected_response):
 
 def test_tags():
     schema = api.get_openapi_schema()
-    # print(schema)
     glob = schema["paths"]["/api/first/endpoint_1"]["get"]
     assert glob["tags"] == ["global"]
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -7,7 +7,7 @@ import pytest
 from django.http import HttpResponse
 from pydantic import BaseModel, ValidationError
 
-from ninja import Router
+from ninja import Router, Schema
 from ninja.responses import Response
 from ninja.testing import TestClient
 
@@ -49,6 +49,27 @@ class UserModel(BaseModel):
         from_attributes = True
         alias_generator = to_camel
         populate_by_name = True
+
+
+class DefaultOutSchema(Schema):
+    name: str
+
+
+class ExtraAllowedOutSchema(Schema):
+    name: str
+
+    class Config(Schema.Config):
+        extra = "allow"
+
+
+@router.get("/user-extra-allowed", response=ExtraAllowedOutSchema)
+def get_user_extra_values(request):
+    return dict(name="test", age=100)
+
+
+@router.get("/user-extra-dropped", response=DefaultOutSchema)
+def get_user_extra_values_dropped(request):
+    return dict(name="test", age=100)
 
 
 @router.get("/check_model", response=UserModel)
@@ -170,3 +191,20 @@ def test_enum_encoding():
     response = Response(data)
     response_data = json.loads(response.content)
     assert response_data["enum"] == str(data["enum"])
+
+
+# Test Schema.model_config extra behavior
+def test_extra_allowed_response():
+    """
+    Output Schema only defines "name" but has extra="allow"
+    """
+    response = client.get("/user-extra-allowed")
+    assert response.json() == {"name": "test", "age": 100}
+
+
+def test_extra_defaulted_dropped():
+    """
+    Test default behavior where schema defines "name" and drops any extra keys
+    """
+    response = client.get("/user-extra-dropped")
+    assert response.json() == {"name": "test"}


### PR DESCRIPTION
Allow setting the model_config key `extra="allow"`

```python
# schemas.py

class ExtraAllowedSchema(Schema):
    name: str

    class Config(Schema.Config):
        extra = "allow"

# views.py
@api.post("/extra")
def extra_params(request, payload: ExtraAllowedSchema):
    """
    Test that a Schema with model_config.extra = "allow" will allow keys not defined in schema
    """
    return payload
```

A request with extra keys will be honored and returned

```bash
# Request
POST: /extra
JSON payload {"name": "my name", "age": 100}
Response
{"name": "my name", "age": 100}

```

Also works on response schemas if you return a dictionary with extra keys outside your OutSchema.

Fixes issue: https://github.com/vitalik/django-ninja/issues/1087