### PR TITLE
fix: also set default_factory to None when fields are optional

### DIFF
--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -156,6 +156,7 @@ def get_schema_field(
 
     if optional:
         default = None
+        default_factory = None
 
     if default is None:
         default = None


### PR DESCRIPTION
This also set `default_factory = None` when using `fields_optional='__all__'`.

It is related to this issue https://github.com/vitalik/django-ninja/issues/1080