### PR TITLE
Use property to alias ForeignKey fields instead of Pydantic alias

### DIFF
--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -108,6 +108,7 @@ def get_schema_field(
     field: DjangoField, *, depth: int = 0, optional: bool = False
 ) -> Tuple:
     "Returns pydantic field from django's model field"
+    name = field.name
     alias = None
     default = ...
     default_factory = None
@@ -118,14 +119,14 @@ def get_schema_field(
 
     if field.is_relation:
         if depth > 0:
-            return get_related_field_schema(field, depth=depth)
+            return name, *get_related_field_schema(field, depth=depth)
 
         internal_type = field.related_model._meta.pk.get_internal_type()
 
         if not field.concrete and field.auto_created or field.null:
             default = None
 
-        alias = getattr(field, "get_attname", None) and field.get_attname()
+        name = getattr(field, "get_attname", None) and field.get_attname()
 
         pk_type = TYPES.get(internal_type, int)
         if field.one_to_many or field.many_to_many:
@@ -165,6 +166,7 @@ def get_schema_field(
     title = title_if_lower(field.verbose_name)
 
     return (
+        name,
         python_type,
         FieldInfo(
             default=default,
@@ -199,3 +201,12 @@ def get_related_field_schema(field: DjangoField, *, depth: int) -> Tuple[OpenAPI
             title=title_if_lower(field.verbose_name),
         ),
     )
+
+
+@no_type_check
+def get_field_property_accessors(field: DjangoField):
+    attribute_name = getattr(field, "get_attname", None) and field.get_attname()
+    property_name = field.name
+    fget = lambda self: getattr(self, attribute_name)
+    fset = lambda self, value: setattr(self, attribute_name, value)
+    return property_name, property(fget, fset)


### PR DESCRIPTION
Fixes #828 and helps with #469. Full explanation [here](https://github.com/vitalik/django-ninja/issues/828#issuecomment-2013444804). Apologies if this explanation isn't quite clear, I'm definitely struggling to explain this properly lol.

Currently for ModelSchema, Ninja uses Pydantic aliases to alias between a ForeignKey field's property name as defined by the user, and the attribute name which holds the ID referenced by the foreign key (`author` vs `author_id`). However, this prevents users from using Pydantic's `alias_generator` with ForeignKey field names.

This PR removes the alias and then changes the property name on the Pydantic model to match the attribute name on the Django model (`author_id`), which should allow for data dumped out with `my_schema.model_dump()` to still correctly match up to Django fields as it does now. It then adds `property` fields to alias between the attribute name and the property name, so any accesses on the model, like `my_schema.author`, will get aliased to the real property name, `my_schema.author_id`.

Let me know if there are any changes I need to make. I'm going to also write some tests to polish this off.