### PR TITLE
chore: modernize ruff config to work with ruff >= v0.2

### DIFF
--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -68,6 +68,6 @@ jobs:
       - name: Ruff format
         run: ruff format --check ninja tests
       - name: Ruff lint
-        run: ruff ninja tests
+        run: ruff check ninja tests
       - name: mypy
         run: mypy ninja tests/mypy_test.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Alternatively, manually check your code with:
 
 ```
 ruff format --check ninja tests
-ruff ninja tests
+ruff check ninja tests
 mypy ninja
 ```
 
@@ -67,7 +67,7 @@ Or reformat your code with:
 
 ```
 ruff format ninja tests
-ruff ninja tests --fix
+ruff check ninja tests --fix
 ```
 
 or using Makefile:

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ install: ## Install dependencies
 .PHONY: lint
 lint: ## Run code linters
 	ruff format --preview --check ninja tests
-	ruff --preview ninja tests
+	ruff check --preview ninja tests
 	mypy ninja
 
 .PHONY: fmt format
 fmt format: ## Run code formatters
 	ruff format --preview ninja tests
-	ruff --preview --fix ninja tests 
+	ruff check --preview --fix ninja tests 
 
 .PHONY: test
 test: ## Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ dev = ["pre-commit"]
 
 [tool.ruff]
 target-version = "py37"
+
+[tool.ruff.lint]
 select = [
     "B",    # flake8-bugbear
     "C",    # flake8-comprehensions
@@ -85,7 +87,7 @@ ignore = [
     "C901", # too complex
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "ninja/compatibility/datastructures.py" = ["C416"]
 "ninja/utils.py" = ["B004"]
 "tests/*" = ["C408"]


### PR DESCRIPTION
Hi, this is my first PR to the project. Please let me know, if I missed anything.

This PR modernizes the ruff configuration to work with ruff >= v0.2.

It gets rid of these warnings:

```console
$ ruff ninja tests
warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
All checks passed!
```