### PR TITLE
Add Generic Typing for `decorate_view` to resolve Pyright Issues

### DIFF
--- a/ninja/decorators.py
+++ b/ninja/decorators.py
@@ -1,7 +1,8 @@
 from functools import partial
-from typing import Callable, Tuple
+from typing import Any, Callable, Tuple
 
 from ninja.operation import Operation
+from ninja.types import TCallable
 from ninja.utils import contribute_operation_callback
 
 # Since @api.method decorator is applied to function
@@ -18,8 +19,8 @@ from ninja.utils import contribute_operation_callback
 #
 
 
-def decorate_view(*decorators: Callable) -> Callable:
-    def outer_wrapper(op_func: Callable) -> Callable:
+def decorate_view(*decorators: Callable[..., Any]) -> Callable[[TCallable], TCallable]:
+    def outer_wrapper(op_func: TCallable) -> TCallable:
         if hasattr(op_func, "_ninja_operation"):
             # Means user used decorate_view on top of @api.method
             _apply_decorators(decorators, op_func._ninja_operation)  # type: ignore
@@ -34,6 +35,8 @@ def decorate_view(*decorators: Callable) -> Callable:
     return outer_wrapper
 
 
-def _apply_decorators(decorators: Tuple[Callable], operation: Operation) -> None:
+def _apply_decorators(
+    decorators: Tuple[Callable[..., Any]], operation: Operation
+) -> None:
     for deco in decorators:
         operation.run = deco(operation.run)  # type: ignore

--- a/ninja/files.py
+++ b/ninja/files.py
@@ -8,7 +8,9 @@ __all__ = ["UploadedFile"]
 
 class UploadedFile(DjangoUploadedFile):
     @classmethod
-    def __get_pydantic_json_schema__(cls, core_schema: Any, handler: Callable) -> Dict:
+    def __get_pydantic_json_schema__(
+        cls, core_schema: Any, handler: Callable[..., Any]
+    ) -> Dict:
         # calling handler(core_schema) here raises an exception
         json_schema: Dict[str, str] = {}
         json_schema.update(type="string", format="binary")
@@ -21,5 +23,7 @@ class UploadedFile(DjangoUploadedFile):
         return v
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, source: Any, handler: Callable) -> Any:
+    def __get_pydantic_core_schema__(
+        cls, source: Any, handler: Callable[..., Any]
+    ) -> Any:
         return core_schema.with_info_plain_validator_function(cls._validate)

--- a/ninja/main.py
+++ b/ninja/main.py
@@ -473,8 +473,10 @@ class NinjaAPI:
         assert issubclass(exc_class, Exception)
         self._exception_handlers[exc_class] = handler
 
-    def exception_handler(self, exc_class: Type[Exception]) -> Callable[..., Any]:
-        def decorator(func: Callable) -> Callable:
+    def exception_handler(
+        self, exc_class: Type[Exception]
+    ) -> Callable[[TCallable], TCallable]:
+        def decorator(func: TCallable) -> TCallable:
             self.add_exception_handler(exc_class, func)
             return func
 

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -26,11 +26,15 @@ def title_if_lower(s: str) -> str:
 
 class AnyObject:
     @classmethod
-    def __get_pydantic_core_schema__(cls, source: Any, handler: Callable) -> Any:
+    def __get_pydantic_core_schema__(
+        cls, source: Any, handler: Callable[..., Any]
+    ) -> Any:
         return core_schema.with_info_plain_validator_function(cls.validate)
 
     @classmethod
-    def __get_pydantic_json_schema__(cls, schema: Any, handler: Callable) -> DictStrAny:
+    def __get_pydantic_json_schema__(
+        cls, schema: Any, handler: Callable[..., Any]
+    ) -> DictStrAny:
         return {"type": "object"}
 
     @classmethod

--- a/ninja/params/__init__.py
+++ b/ninja/params/__init__.py
@@ -25,7 +25,7 @@ __all__ = [
 
 
 class ParamShortcut:
-    def __init__(self, base_func: Callable) -> None:
+    def __init__(self, base_func: Callable[..., Any]) -> None:
         self._base_func = base_func
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:

--- a/ninja/signature/details.py
+++ b/ninja/signature/details.py
@@ -43,7 +43,7 @@ class ViewSignature:
     )
     response_arg: Optional[str] = None
 
-    def __init__(self, path: str, view_func: Callable) -> None:
+    def __init__(self, path: str, view_func: Callable[..., Any]) -> None:
         self.view_func = view_func
         self.signature = get_typed_signature(self.view_func)
         self.path = path

--- a/ninja/signature/utils.py
+++ b/ninja/signature/utils.py
@@ -31,7 +31,7 @@ __all__ = [
 ]
 
 
-def get_typed_signature(call: Callable) -> inspect.Signature:
+def get_typed_signature(call: Callable[..., Any]) -> inspect.Signature:
     "Finds call signature and resolves all forwardrefs"
     signature = inspect.signature(call)
     globalns = getattr(call, "__globals__", {})
@@ -65,18 +65,18 @@ def get_path_param_names(path: str) -> Set[str]:
     return {item.strip("{}").split(":")[-1] for item in re.findall("{[^}]*}", path)}
 
 
-def is_async(callable: Callable) -> bool:
+def is_async(callable: Callable[..., Any]) -> bool:
     return asyncio.iscoroutinefunction(callable)
 
 
-def has_kwargs(func: Callable) -> bool:
+def has_kwargs(func: Callable[..., Any]) -> bool:
     for param in inspect.signature(func).parameters.values():
         if param.kind == param.VAR_KEYWORD:
             return True
     return False
 
 
-def get_args_names(func: Callable) -> List[str]:
+def get_args_names(func: Callable[..., Any]) -> List[str]:
     "returns list of function argument names"
     return list(inspect.signature(func).parameters.keys())
 

--- a/ninja/utils.py
+++ b/ninja/utils.py
@@ -44,20 +44,22 @@ def is_debug_server() -> bool:
     )
 
 
-def is_async_callable(f: Callable) -> bool:
+def is_async_callable(f: Callable[..., Any]) -> bool:
     return inspect.iscoroutinefunction(f) or inspect.iscoroutinefunction(
         getattr(f, "__call__", None)
     )
 
 
-def contribute_operation_callback(func: Callable, callback: Callable) -> None:
+def contribute_operation_callback(
+    func: Callable[..., Any], callback: Callable[..., Any]
+) -> None:
     if not hasattr(func, "_ninja_contribute_to_operation"):
         func._ninja_contribute_to_operation = []  # type: ignore
     func._ninja_contribute_to_operation.append(callback)  # type: ignore
 
 
 def contribute_operation_args(
-    func: Callable, arg_name: str, arg_type: Type, arg_source: Any
+    func: Callable[..., Any], arg_name: str, arg_type: Type, arg_source: Any
 ) -> None:
     if not hasattr(func, "_ninja_contribute_args"):
         func._ninja_contribute_args = []  # type: ignore


### PR DESCRIPTION
For projects using Django Ninja that utilize [Pyright](https://github.com/microsoft/pyright), the typing for `decorate_view` leads to a `reportUntypedFunctionDecorator` error.

Let's take this example from the documentation:

```python
from django.views.decorators.cache import cache_page

@api.get("/test")
@decorate_view(cache_page(5)) # Untyped function decorator obscures type of function
def test_view(request):
    return str(datetime.now())
```

By having `decorate_view` utilize generics, we can can avoid this. I also went about generally cleaning up the callable types, `Callable[..., Any]` is more descriptive than `Callable`. In Pyright the former would be preferred to avoid unknowns, as `Callable == Callable[..., Unknown]` instead of being `Any`. There have been times where I've imported private functions from ninja internals, while not often, it would be nice to avoid unknowns in these cases.
