### PR TITLE
Fix typing for Exception Handlers

### DIFF
--- a/ninja/main.py
+++ b/ninja/main.py
@@ -37,7 +37,7 @@ __all__ = ["NinjaAPI"]
 
 _E = TypeVar("_E", bound=Exception)
 Exc = Union[_E, Type[_E]]
-ExcHandler = Callable[[HttpRequest, _E], HttpResponse]
+ExcHandler = Callable[[HttpRequest, Exc[_E]], HttpResponse]
 
 
 class NinjaAPI:

--- a/ninja/main.py
+++ b/ninja/main.py
@@ -10,8 +10,8 @@ from typing import (
     Sequence,
     Tuple,
     Type,
-    Union,
     TypeVar,
+    Union,
 )
 
 from django.http import HttpRequest, HttpResponse


### PR DESCRIPTION
Fix typing for the exception handlers in `ninja.main`, which is currently leading to typing errors in my codebase due to the lack of generics.