### PR TITLE
Update LimitOffsetPagination.Input schema

### DIFF
--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -1,6 +1,7 @@
 import inspect
 from abc import ABC, abstractmethod
 from functools import partial, wraps
+from math import inf
 from typing import Any, Callable, List, Optional, Tuple, Type
 
 from django.db.models import QuerySet
@@ -55,7 +56,13 @@ class PaginationBase(ABC):
 
 class LimitOffsetPagination(PaginationBase):
     class Input(Schema):
-        limit: int = Field(settings.PAGINATION_PER_PAGE, ge=1)
+        limit: int = Field(
+            settings.PAGINATION_PER_PAGE,
+            ge=1,
+            le=settings.PAGINATION_MAX_LIMIT
+            if settings.PAGINATION_MAX_LIMIT != inf
+            else None,
+        )
         offset: int = Field(0, ge=0)
 
     def paginate_queryset(


### PR DESCRIPTION
add `le=` parameter to LimitOffsetPagination.Input so the max input is visible and validated on the schema level.

Current implementation of limit is a little bit misleading - when `NINJA_PAGINATION_MAX_LIMIT` is set to 100 and limit in request is set to 1000 - the request is successful and only returns 100 items - see `LimitOffsetPagination.paginate_queryset`

```python 
        limit: int = min(pagination.limit, settings.PAGINATION_MAX_LIMIT)
```

This is a little bit misleading behaviour and enforcing the limit on schema level can remove some confusion and will directly tell the consumer what the limit actually is.


**Warning - this is a breaking change for integrations which are using higher limit in request than it is set on the server.**