### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,18 +10,3 @@ Please use `python -m pip install` instead.
 """
 )
 sys.exit(1)
-
-
-# The below code will never execute, however GitHub is particularly
-# picky about where it finds Python packaging metadata.
-# See: https://github.com/github/feedback/discussions/6456
-#
-# To be removed once GitHub catches up.
-
-setup(
-    name="django-ninja",
-    install_requires=[
-        "Django>=2.0.13",
-        "pydantic>=2.0.0",
-    ],
-)


### PR DESCRIPTION
This is no longer necessary: 
* https://github.blog/changelog/2023-02-13-dependency-graph-supports-the-python-pep-621-standard/
* https://github.com/orgs/community/discussions/6456#discussioncomment-5244057