### PR TITLE
Use serialization aliases for responses in OpenAPI schema

### DIFF
--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -4,6 +4,8 @@ import warnings
 from http.client import responses
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Set, Tuple
 
+from pydantic.json_schema import JsonSchemaMode
+
 from ninja.constants import NOT_SET
 from ninja.operation import Operation
 from ninja.params.models import TModel, TModels
@@ -207,6 +209,7 @@ class OpenAPISchema(dict):
         model: TModel,
         by_alias: bool = True,
         remove_level: bool = True,
+        mode: JsonSchemaMode = "validation",
     ) -> Tuple[DictStrAny, bool]:
         if hasattr(model, "__ninja_flatten_map__"):
             schema = self._flatten_schema(model)
@@ -215,6 +218,7 @@ class OpenAPISchema(dict):
                 ref_template=REF_TEMPLATE,
                 by_alias=by_alias,
                 schema_generator=NinjaGenerateJsonSchema,
+                mode=mode,
             ).copy()
 
         # move Schemas from definitions
@@ -284,7 +288,7 @@ class OpenAPISchema(dict):
             if model not in [None, NOT_SET]:
                 # ::TODO:: test this: by_alias == True
                 schema = self._create_schema_from_model(
-                    model, by_alias=operation.by_alias
+                    model, by_alias=operation.by_alias, mode="serialization"
                 )[0]
                 details[status]["content"] = {
                     self.api.renderer.media_type: {"schema": schema}

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -942,3 +942,29 @@ def test_no_default_for_custom_items_attribute():
     paged_employee_out = schema["components"]["schemas"]["PagedEmployeeOut"]
     # a default value shouldn't be specified automatically
     assert "default" not in paged_employee_out["properties"]["data"]
+
+
+def test_renders_responses_with_serialization_alias():
+    api = NinjaAPI(renderer=TestRenderer)
+
+    class ResponseWithSerializationAlias(Schema):
+        my_field: str = Field(..., serialization_alias="myFieldName")
+
+    @api.get(
+        "/test-with-serialization-alias/",
+        response=ResponseWithSerializationAlias,
+        by_alias=True,
+    )
+    def method_test_with_serialization_alias(
+        request,
+    ):
+        return ResponseWithSerializationAlias(my_field="Field Value")
+
+    schema = api.get_openapi_schema()
+
+    assert (
+        "myFieldName"
+        in schema["components"]["schemas"]["ResponseWithSerializationAlias"][
+            "properties"
+        ]
+    )


### PR DESCRIPTION
When generating JSON schemas from the Pydantic types, the `mode` must be set in order for the correct aliases to be used. The default is to generate the schema for validation mode, which means that for building response schemas, the mode needs to be explicitly set to serialization.

This fixes issues I brought up in discussion #1132 