### PR TITLE
Fix Ninja Schema Typing

### DIFF
--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -19,7 +19,15 @@ dotted attributes and resolver methods. For example::
 """
 
 import warnings
-from typing import Any, Callable, Dict, Type, TypeVar, Union, no_type_check
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Type,
+    TypeVar,
+    Union,
+    no_type_check,
+)
 
 import pydantic
 from django.db.models import Manager, QuerySet
@@ -29,6 +37,7 @@ from pydantic import BaseModel, Field, ValidationInfo, model_validator, validato
 from pydantic._internal._model_construction import ModelMetaclass
 from pydantic.functional_validators import ModelWrapValidatorHandler
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
+from typing_extensions import dataclass_transform
 
 from ninja.signature.utils import get_args_names, has_kwargs
 from ninja.types import DictStrAny
@@ -146,6 +155,7 @@ class Resolver:
     #     return PartialSchema()
 
 
+@dataclass_transform(kw_only_default=True, field_specifiers=(Field,))
 class ResolverMetaclass(ModelMetaclass):
     _ninja_resolvers: Dict[str, Resolver]
 


### PR DESCRIPTION
Fix Ninja schema typing by adding a dataclass transformer, as specified in [PEP 681](https://peps.python.org/pep-0681/). This transformer matches that of Pydantic's model metaclass.

Now, instead of Ninja schemas being typed as `**kwargs: Any`, one will get static type-checking on each field.

Fixes: https://github.com/vitalik/django-ninja/issues/1094, https://github.com/vitalik/django-ninja/issues/1050, https://github.com/vitalik/django-ninja/issues/1053

Example:

![CleanShot 2024-05-14 at 23 28 35@2x](https://github.com/vitalik/django-ninja/assets/41130755/19312e1d-2c86-4f86-84b4-9b97dce2d765)
