### PR TITLE
respect the 'by_alias' route config also in generated docs for 'json body' data

### DIFF
--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -260,7 +260,7 @@ class OpenAPISchema(dict):
             model = models[0]
             content_type = BODY_CONTENT_TYPES[model.__ninja_param_source__]
             schema, required = self._create_schema_from_model(
-                model, remove_level=model.__ninja_param_source__ == "body"
+                model, remove_level=model.__ninja_param_source__ == "body", by_alias=operation.by_alias
             )
         else:
             schema, content_type = self._create_multipart_schema_from_models(models)


### PR DESCRIPTION
if you have an alias_generator to_camel, the current behavior does not respect the by_alias config from the router when it comes to request body data and how the api documentation then is generated for that request body. Today the code that generates the request body docs, defaults to True *without* ever passing the operation.by_alias into the function.
This PR should correct that. 