### PR TITLE
Fix ForwardRef._evaluate() missing 1 required keyword-only argument on python 3.12.4

### DIFF
--- a/ninja/signature/utils.py
+++ b/ninja/signature/utils.py
@@ -17,7 +17,7 @@ else:
     def evaluate_forwardref(type_: ForwardRef, globalns: Any, localns: Any) -> Any:
         # Even though it is the right signature for python 3.9, mypy complains with
         # `error: Too many arguments for "_evaluate" of "ForwardRef"` hence the cast...
-        return cast(Any, type_)._evaluate(globalns, localns, set())
+        return cast(Any, type_)._evaluate(globalns, localns, recursive_guard=set())
 
 
 from ninja.types import DictStrAny


### PR DESCRIPTION
Closes #1203

I would be nice to have minor version upgrade after this