### PR TITLE
Postgres ArrayField Inner Type And CharField Choices

### DIFF
--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -36,23 +36,21 @@ class OpenAPISchema(dict):
         self.securitySchemes: DictStrAny = {}
         self.all_operation_ids: Set = set()
         extra_info = api.openapi_extra.get("info", {})
-        super().__init__(
-            [
-                ("openapi", "3.1.0"),
-                (
-                    "info",
-                    {
-                        "title": api.title,
-                        "version": api.version,
-                        "description": api.description,
-                        **extra_info,
-                    },
-                ),
-                ("paths", self.get_paths()),
-                ("components", self.get_components()),
-                ("servers", api.servers),
-            ]
-        )
+        super().__init__([
+            ("openapi", "3.1.0"),
+            (
+                "info",
+                {
+                    "title": api.title,
+                    "version": api.version,
+                    "description": api.description,
+                    **extra_info,
+                },
+            ),
+            ("paths", self.get_paths()),
+            ("components", self.get_components()),
+            ("servers", api.servers),
+        ])
         for k, v in api.openapi_extra.items():
             if k not in self:
                 self[k] = v
@@ -237,12 +235,10 @@ class OpenAPISchema(dict):
         content_type = BODY_CONTENT_TYPES["file"]
 
         # get the various schemas
-        result = merge_schemas(
-            [
-                self._create_schema_from_model(model, remove_level=False)[0]
-                for model in models
-            ]
-        )
+        result = merge_schemas([
+            self._create_schema_from_model(model, remove_level=False)[0]
+            for model in models
+        ])
         result["title"] = "MultiPartBodyParams"
 
         return result, content_type

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -5,12 +5,12 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     Tuple,
     Type,
     TypeVar,
     Union,
     no_type_check,
-    Literal,
 )
 from uuid import UUID
 

--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -127,12 +127,10 @@ class NinjaClientBase:
         request.META = request_params.pop("META", {"REMOTE_ADDR": "127.0.0.1"})
         request.FILES = request_params.pop("FILES", {})
 
-        request.META.update(
-            {
-                f"HTTP_{k.replace('-', '_')}": v
-                for k, v in request_params.pop("headers", {}).items()
-            }
-        )
+        request.META.update({
+            f"HTTP_{k.replace('-', '_')}": v
+            for k, v in request_params.pop("headers", {}).items()
+        })
 
         request.headers = HttpHeaders(request.META)
 

--- a/tests/test_orm_schemas.py
+++ b/tests/test_orm_schemas.py
@@ -1,12 +1,12 @@
 from typing import List, Literal
 from unittest.mock import Mock
 
-from ninja import Schema
 import pytest
 from django.contrib.postgres import fields as ps_fields
 from django.db import models
 from django.db.models import Manager
 
+from ninja import Schema
 from ninja.errors import ConfigError
 from ninja.orm import create_schema
 from ninja.orm.shortcuts import L, S


### PR DESCRIPTION
- ArrayField Inner Field, similar to what the other has try to do before here https://github.com/vitalik/django-ninja/pull/386/files (Not sure why it is not in main now)
- Choices of the CharField


Example:
```python
class TypeChoice(models.TextChoices):
    NAME_A = "VALUE_A"
    NAME_B = "VALUE_B"

class ArrayModel(models.Model):
    array_of_int = ps_fields.ArrayField(models.IntegerField())
    array_of_str = ps_fields.ArrayField(models.CharField(max_length=100))
    array_of_choice = ps_fields.ArrayField(
        models.CharField(choices=TypeChoice.choices)
    )
```
Produces the same OpenAPI schema as 
```Python
class ExpectedSchema(Schema):
    array_of_int: List[int]
    array_of_str: List[str]
    array_of_choice: List[Literal["VALUE_A", "VALUE_B"]]
```


Let me know if the added tests are enough. Thank you.