### PR TITLE
Fix issue when consulting request attributes while using mocked request

### DIFF
--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 from urllib.parse import urljoin
 
 from django.http import QueryDict, StreamingHttpResponse
-from django.http.request import HttpHeaders
+from django.http.request import HttpHeaders, HttpRequest
 
 from ninja import NinjaAPI, Router
 from ninja.responses import NinjaJSONEncoder
@@ -111,7 +111,7 @@ class NinjaClientBase:
     def _build_request(
         self, method: str, path: str, data: Dict, request_params: Any
     ) -> Mock:
-        request = Mock()
+        request = Mock(spec=HttpRequest)
         request.method = method
         request.path = path
         request.body = ""

--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -121,6 +121,7 @@ class NinjaClientBase:
         request.build_absolute_uri = build_absolute_uri
 
         request.auth = None
+        request.user = Mock()
         if "user" not in request_params:
             request.user.is_authenticated = False
 


### PR DESCRIPTION
# Problem

Fixes https://github.com/vitalik/django-ninja/issues/1240

When using Python builtin functions for managing/consulting object attributes (`getattr` & `hasattr` for example), the mocked request always mocks and returns the mocked attribute value.
For example:

```python
hasttr(request, "field_name")  # Will always return True during testing, even if it's expected to be False

getattr(request, "field_with_dict", {}). # Will return a Mock object if field doesn't exist, causing a non-subscriptable exception during testing.
```

The issue originates during the instantiation of the mocked request in `ninja.testing.client._build_request`. There are 3 possible ways to instantiate the Mock object.

# Proposed solution

Setting django HttpRequest as spec when instantiating the Mock object, will restrict the instance to behave closer to an HttpRequest, returning real values during the execution of the code showed above, and still allowing to add and modify new fields.

# Extra Note
When doing this change, mocking the user object itself becomes necessary, for provide more freedom when mocking the authenticated user

# Testing
I'm not sure if there is a need of adding extra tests in this case, since the tests would be testing Mock object behavior more than the test client behavior. If it's considered necessary I can add some tests at `test_test_client` testing the build request function.