### PR TITLE
Support import string in router.add_router

### DIFF
--- a/ninja/router.py
+++ b/ninja/router.py
@@ -12,6 +12,7 @@ from typing import (
 
 from django.urls import URLPattern
 from django.urls import path as django_path
+from django.utils.module_loading import import_string
 
 from ninja.constants import NOT_SET, NOT_SET_TYPE
 from ninja.errors import ConfigError
@@ -371,12 +372,16 @@ class Router:
     def add_router(
         self,
         prefix: str,
-        router: "Router",
+        router: Union["Router", str],
         *,
         auth: Any = NOT_SET,
         throttle: Union[BaseThrottle, List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
         tags: Optional[List[str]] = None,
     ) -> None:
+        if isinstance(router, str):
+            router = import_string(router)
+            assert isinstance(router, Router)
+
         if self.api:
             # we are already attached to an api
             self.api.add_router(

--- a/tests/test_router_add_router.py
+++ b/tests/test_router_add_router.py
@@ -1,0 +1,22 @@
+from ninja import NinjaAPI, Router
+from ninja.testing import TestClient
+
+
+router = Router()
+
+
+@router.get("/")
+def op(request):
+    return True
+
+
+def test_add_router_with_string_path():
+    main_router = Router()
+    main_router.add_router("sub", "tests.test_router_add_router.router")
+
+    api = NinjaAPI()
+    api.add_router("main", main_router)
+
+    client = TestClient(api)
+
+    assert client.get("/main/sub/").status_code == 200

--- a/tests/test_router_add_router.py
+++ b/tests/test_router_add_router.py
@@ -1,7 +1,6 @@
 from ninja import NinjaAPI, Router
 from ninja.testing import TestClient
 
-
 router = Router()
 
 


### PR DESCRIPTION
Added support for importing nested router with string path. This unifies behaviour with `api.add_router`:


```
# api.add_router
api = NinjaAPI()
api.add_router("main", "myproject.app1.router")

# router.add_router
router = Router()
router.add_router("nested", "myproject.app1.nested.router")
```