### PR TITLE
Add default headers for NinjaClientBase instance

### DIFF
--- a/docs/docs/guides/testing.md
+++ b/docs/docs/guides/testing.md
@@ -41,3 +41,10 @@ class HelloTest(TestCase):
         # request.company_id will now be set within the view
         response = client.get("/hello", company_id=1)
 ```
+
+It is also possible to specify headers, both from the TestCase instanciation and the actual request:
+```python
+    client = TestClient(router, headers={"A": "a", "B": "b"})
+    # The request will be made with {"A": "na", "B": "b", "C": "nc"} headers
+    response = client.get("/test-headers", headers={"A": "na", "C": "nc"})
+```

--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -26,7 +26,12 @@ def build_absolute_uri(location: Optional[str] = None) -> str:
 class NinjaClientBase:
     __test__ = False  # <- skip pytest
 
-    def __init__(self, router_or_app: Union[NinjaAPI, Router]) -> None:
+    def __init__(
+        self,
+        router_or_app: Union[NinjaAPI, Router],
+        headers: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.headers = headers or {}
         self.router_or_app = router_or_app
 
     def get(
@@ -82,6 +87,11 @@ class NinjaClientBase:
             request_params["body"] = json_dumps(json, cls=NinjaJSONEncoder)
         if data is None:
             data = {}
+        if self.headers or request_params.get("headers"):
+            request_params["headers"] = {
+                **self.headers,
+                **request_params.get("headers", {}),
+            }
         func, request, kwargs = self._resolve(method, path, data, request_params)
         return self._call(func, request, kwargs)  # type: ignore
 

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -27,6 +27,11 @@ def simple_get(request):
     return "test"
 
 
+@router.get("/test-headers")
+def get_headers(request):
+    return dict(request.headers)
+
+
 client = TestClient(router)
 
 
@@ -78,3 +83,21 @@ def test_json_as_body():
             ClientTestSchema.model_validate_json(request.body).model_dump_json()
             == schema_instance.model_dump_json()
         )
+
+
+headered_client = TestClient(router, headers={"A": "a", "B": "b"})
+
+
+def test_client_request_only_header():
+    r = client.get("/test-headers", headers={"A": "na"})
+    assert r.json() == {"A": "na"}
+
+
+def test_headered_client_request_with_default_headers():
+    r = headered_client.get("/test-headers")
+    assert r.json() == {"A": "a", "B": "b"}
+
+
+def test_headered_client_request_with_overwritten_and_additional_headers():
+    r = headered_client.get("/test-headers", headers={"A": "na", "C": "nc"})
+    assert r.json() == {"A": "na", "B": "b", "C": "nc"}


### PR DESCRIPTION
Those changes let you set default headers for instances of NinjaClientBases, which are passed through all requests, unless overwritten.
Related to #664 

- [x] documentation update