### PR TITLE
DRF-style data property for responses in tests

### DIFF
--- a/docs/docs/guides/testing.md
+++ b/docs/docs/guides/testing.md
@@ -33,6 +33,11 @@ class HelloTest(TestCase):
         self.assertEqual(response.json(), {"msg": "Hello World"})
 ```
 
+It is also possible to access the deserialized data using the `data` property:
+```python
+    self.assertEqual(response.data, {"msg": "Hello World"})
+```
+
 Arbitrary attributes can be added to the request object by passing keyword arguments to the client request methods:
 ```python
 class HelloTest(TestCase):

--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -189,9 +189,16 @@ class NinjaResponse:
             self.content = b"".join(http_response.streaming_content)  # type: ignore
         else:
             self.content = http_response.content  # type: ignore[union-attr]
+        self._data = None
 
     def json(self) -> Any:
         return json_loads(self.content)
+
+    @property
+    def data(self) -> Any:
+        if self._data is None:  # Recomputes if json() is None but cheap then
+            self._data = self.json()
+        return self._data
 
     def __getitem__(self, key: str) -> Any:
         return self._response[key]

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -117,6 +117,7 @@ def test_responses(path, expected_response):
     response = client.get(path)
     assert response.status_code == 200, response.content
     assert response.json() == expected_response
+    assert response.data == response.data == expected_response  # Ensures cache works
 
 
 def test_validates():


### PR DESCRIPTION
DRF lets you access a `data` attribute containing the deserialized data from the responses in tests.
Having the same kind of attribute (which, here, is computed and cached on the fly) would not only make writing tests slightly more comfortable, but would also make porting tests from DRF to Ninja a lot easier.
Related to #664 

- [x] documentation update
- [x] fix coverage