### PR TITLE
Pass serialisation context to model_dump (fixes #1233)

### DIFF
--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -262,9 +262,11 @@ class Operation:
         )
 
         model_dump_kwargs = {}
-        if pydantic_version >= [2,7]:
+        if pydantic_version >= [2, 7]:
             # pydantic added support for serialization context at 2.7
-            model_dump_kwargs.update(context={"request": request, "response_status": status})
+            model_dump_kwargs.update(
+                context={"request": request, "response_status": status}
+            )
 
         result = validated_object.model_dump(
             by_alias=self.by_alias,

--- a/tests/test_serialization_context.py
+++ b/tests/test_serialization_context.py
@@ -1,0 +1,75 @@
+from unittest import mock
+
+import pytest
+from pydantic import model_serializer
+
+from ninja import Router, Schema
+from ninja.schema import pydantic_version
+from ninja.testing import TestClient
+
+
+def api_endpoint_test(request):
+    return {
+        "test1": "foo",
+        "test2": "bar",
+    }
+
+
+@pytest.mark.skipif(
+    pydantic_version < [2, 7],
+    reason="Serialization context was introduced in Pydantic 2.7",
+)
+def test_request_is_passed_in_context_when_supported():
+    class SchemaWithCustomSerializer(Schema):
+        test1: str
+        test2: str
+
+        @model_serializer(mode="wrap")
+        def ser_model(self, handler, info):
+            assert "request" in info.context
+            assert info.context["request"].path == "/test"  # check it is HttRequest
+            assert "response_status" in info.context
+
+            return handler(self)
+
+    router = Router()
+    router.add_api_operation(
+        "/test", ["GET"], api_endpoint_test, response=SchemaWithCustomSerializer
+    )
+
+    TestClient(router).get("/test")
+
+
+@pytest.mark.parametrize(
+    ["pydantic_version"],
+    [
+        [[2, 0]],
+        [[2, 4]],
+        [[2, 6]],
+    ],
+)
+def test_no_serialisation_context_used_when_no_supported(pydantic_version):
+    class SchemaWithCustomSerializer(Schema):
+        test1: str
+        test2: str
+
+        @model_serializer(mode="wrap")
+        def ser_model(self, handler, info):
+            if hasattr(info, "context"):
+                # an actually newer Pydantic, but pydantic_version is still mocked, so no context is expected
+                assert info.context is None
+
+            return handler(self)
+
+    with mock.patch("ninja.operation.pydantic_version", pydantic_version):
+        router = Router()
+        router.add_api_operation(
+            "/test", ["GET"], api_endpoint_test, response=SchemaWithCustomSerializer
+        )
+
+        resp_json = TestClient(router).get("/test").json()
+
+        assert resp_json == {
+            "test1": "foo",
+            "test2": "bar",
+        }


### PR DESCRIPTION
Pydantic starting with 2.7 added [support for context param in `model_dump` and `model_dump_json`](https://docs.pydantic.dev/latest/changelog/#new-features_2) allowing to pass arbitrary additional data into custom serializers.

Passing request in serialisation context may be useful in cases where customising serialisation is necessary.