### PR TITLE
Update code with `make fmt` and the pipeline to use the same `--preview` option of Ruff

### DIFF
--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -67,8 +67,8 @@ jobs:
       - name: Install Dependencies
         run: flit install --symlink
       - name: Ruff format
-        run: ruff format --check ninja tests
+        run: ruff format --preview --check ninja tests
       - name: Ruff lint
-        run: ruff check ninja tests
+        run: ruff check --preview ninja tests
       - name: mypy
         run: mypy ninja tests/mypy_test.py

--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -40,23 +40,21 @@ class OpenAPISchema(dict):
         self.securitySchemes: DictStrAny = {}
         self.all_operation_ids: Set = set()
         extra_info = api.openapi_extra.get("info", {})
-        super().__init__(
-            [
-                ("openapi", "3.1.0"),
-                (
-                    "info",
-                    {
-                        "title": api.title,
-                        "version": api.version,
-                        "description": api.description,
-                        **extra_info,
-                    },
-                ),
-                ("paths", self.get_paths()),
-                ("components", self.get_components()),
-                ("servers", api.servers),
-            ]
-        )
+        super().__init__([
+            ("openapi", "3.1.0"),
+            (
+                "info",
+                {
+                    "title": api.title,
+                    "version": api.version,
+                    "description": api.description,
+                    **extra_info,
+                },
+            ),
+            ("paths", self.get_paths()),
+            ("components", self.get_components()),
+            ("servers", api.servers),
+        ])
         for k, v in api.openapi_extra.items():
             if k not in self:
                 self[k] = v
@@ -242,12 +240,10 @@ class OpenAPISchema(dict):
         content_type = BODY_CONTENT_TYPES["file"]
 
         # get the various schemas
-        result = merge_schemas(
-            [
-                self._create_schema_from_model(model, remove_level=False)[0]
-                for model in models
-            ]
-        )
+        result = merge_schemas([
+            self._create_schema_from_model(model, remove_level=False)[0]
+            for model in models
+        ])
         result["title"] = "MultiPartBodyParams"
 
         return result, content_type

--- a/ninja/params/__init__.py
+++ b/ninja/params/__init__.py
@@ -19,7 +19,6 @@ __all__ = [
     "HeaderEx",
     "PathEx",
     "QueryEx",
-    "Router",
     "P",
 ]
 

--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -138,12 +138,10 @@ class NinjaClientBase:
         request.META = request_params.pop("META", {"REMOTE_ADDR": "127.0.0.1"})
         request.FILES = request_params.pop("FILES", {})
 
-        request.META.update(
-            {
-                f"HTTP_{k.replace('-', '_')}": v
-                for k, v in request_params.pop("headers", {}).items()
-            }
-        )
+        request.META.update({
+            f"HTTP_{k.replace('-', '_')}": v
+            for k, v in request_params.pop("headers", {}).items()
+        })
 
         request.headers = HttpHeaders(request.META)
 


### PR DESCRIPTION
Just updating the code
- by having executed `make fmt` using the already present `--preview` argument of ruff
- so the pipeline use the same `--preview` option to stay consistent

Otherwise I'm just surprised that there is a difference between the pipeline and the Makefile, I can just remove the `--preview` in the Makefile if needed, or you can close that PR.