### PR TITLE
Fixed coverage on Python>=3.11

### DIFF
--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -282,8 +282,7 @@ def make_response_paginated(paginator: PaginationBase, op: Operation) -> None:
     try:
         new_name = f"Paged{item_schema.__name__}"
     except AttributeError:
-        new_name = f"Paged{str(item_schema).replace('.', '_')}"  # typing.Any case
-
+        new_name = f"Paged{str(item_schema).replace('.', '_')}"  # typing.Any case, only for Python < 3.10
     new_schema = type(
         new_name,
         (paginator.Output,),

--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -282,7 +282,7 @@ def make_response_paginated(paginator: PaginationBase, op: Operation) -> None:
     try:
         new_name = f"Paged{item_schema.__name__}"
     except AttributeError:
-        new_name = f"Paged{str(item_schema).replace('.', '_')}"  # typing.Any case, only for Python < 3.10
+        new_name = f"Paged{str(item_schema).replace('.', '_')}"  # typing.Any case, only for Python < 3.11
     new_schema = type(
         new_name,
         (paginator.Output,),

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -427,15 +427,16 @@ def test_config_error_NOT_SET():
         def invalid2(request):
             pass
 
-
+@pytest.mark.skipif(sys.version_info < (3, 11), "Not needed at this Python version")
 def test_pagination_works_with_unnamed_classes():
     """
     This test lets you check that the typing.Any case handled in `ninja.pagination.make_response_paginated`
-    works for Python<3.10, as a typing.Any does possess the __name__ atribute past that version
+    works for Python>=3.11, as a typing.Any does possess the __name__ atribute past that version
     """
+    PydanticSchemaGenerationError if  else TypeError
     operation = Operation("/whatever", ["GET"], lambda: None, response=List[int])
     operation.response_models[200].__annotations__["response"] = List[object()]
     with pytest.raises(
-        PydanticSchemaGenerationError if sys.version_info >= (3, 11) else TypeError
-    ):  # It does fail after we passed the logic that we are testing on >=3.11, otherwise from another error
+        PydanticSchemaGenerationError
+    ):  # It does fail after we passed the logic that we are testing
         make_response_paginated(LimitOffsetPagination, operation)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -427,7 +427,7 @@ def test_config_error_NOT_SET():
         def invalid2(request):
             pass
 
-@pytest.mark.skipif(sys.version_info < (3, 11), "Not needed at this Python version")
+@pytest.mark.skipif(version_info < (3, 11), "Not needed at this Python version")
 def test_pagination_works_with_unnamed_classes():
     """
     This test lets you check that the typing.Any case handled in `ninja.pagination.make_response_paginated`

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -428,11 +428,11 @@ def test_config_error_NOT_SET():
             pass
 
 
-@pytest.mark.skipif(version_info < (3, 11), reason="Not needed at this Python version")
+@pytest.mark.skipif(version_info < (3, 10), reason="Not needed at this Python version")
 def test_pagination_works_with_unnamed_classes():
     """
     This test lets you check that the typing.Any case handled in `ninja.pagination.make_response_paginated`
-    works for Python>=3.11, as a typing.Any does possess the __name__ atribute past that version
+    works for Python>=3.10, as a typing.Any does possess the __name__ atribute past that version
     """
     operation = Operation("/whatever", ["GET"], lambda: None, response=List[int])
     operation.response_models[200].__annotations__["response"] = List[object()]

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -433,7 +433,6 @@ def test_pagination_works_with_unnamed_classes():
     This test lets you check that the typing.Any case handled in `ninja.pagination.make_response_paginated`
     works for Python>=3.11, as a typing.Any does possess the __name__ atribute past that version
     """
-    PydanticSchemaGenerationError if  else TypeError
     operation = Operation("/whatever", ["GET"], lambda: None, response=List[int])
     operation.response_models[200].__annotations__["response"] = List[object()]
     with pytest.raises(

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -427,6 +427,7 @@ def test_config_error_NOT_SET():
         def invalid2(request):
             pass
 
+
 @pytest.mark.skipif(version_info < (3, 11), reason="Not needed at this Python version")
 def test_pagination_works_with_unnamed_classes():
     """

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -427,7 +427,7 @@ def test_config_error_NOT_SET():
         def invalid2(request):
             pass
 
-@pytest.mark.skipif(version_info < (3, 11), "Not needed at this Python version")
+@pytest.mark.skipif(version_info < (3, 11), reason="Not needed at this Python version")
 def test_pagination_works_with_unnamed_classes():
     """
     This test lets you check that the typing.Any case handled in `ninja.pagination.make_response_paginated`

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,4 +1,5 @@
 import importlib
+from sys import version_info
 from typing import Any, List
 
 import pytest
@@ -435,6 +436,6 @@ def test_pagination_works_with_unnamed_classes():
     operation = Operation("/whatever", ["GET"], lambda: None, response=List[int])
     operation.response_models[200].__annotations__["response"] = List[object()]
     with pytest.raises(
-        PydanticSchemaGenerationError
-    ):  # It does fail after we passed the logic that we are testing
+        PydanticSchemaGenerationError if sys.version_info >= (3, 11) else TypeError
+    ):  # It does fail after we passed the logic that we are testing on >=3.11, otherwise from another error
         make_response_paginated(LimitOffsetPagination, operation)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -428,11 +428,11 @@ def test_config_error_NOT_SET():
             pass
 
 
-@pytest.mark.skipif(version_info < (3, 10), reason="Not needed at this Python version")
+@pytest.mark.skipif(version_info < (3, 11), reason="Not needed at this Python version")
 def test_pagination_works_with_unnamed_classes():
     """
     This test lets you check that the typing.Any case handled in `ninja.pagination.make_response_paginated`
-    works for Python>=3.10, as a typing.Any does possess the __name__ atribute past that version
+    works for Python>=3.11, as a typing.Any does possess the __name__ atribute past that version
     """
     operation = Operation("/whatever", ["GET"], lambda: None, response=List[int])
     operation.response_models[200].__annotations__["response"] = List[object()]


### PR DESCRIPTION
`make test-cov` is not at 100% on Python>=3.11 when executed locally.
Nothing is wrong with the pipeline as it is still using Python 3.9 but it is a minor incovenience during development.

It is due to the fact that the handling of `typing.Any` becomes unnecessary with this change in cpython: python/cpython#88690

This PR resolves this situation by adding a quick UT that is not so useful for Python<3.11 but covers that specific `try` - `except` block.

We may (or may not) also add support for Python>=3.11 in the coverage pipeline, in this PR or another one.