### PR TITLE
Fix `SynchronousOnlyOperation` error when `paginate` is used with async views returning Django querysets.

### DIFF
--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -171,69 +171,45 @@ def paginate(func_or_pgn_class: Any = NOT_SET, **paginator_params: Any) -> Calla
     )
 
     if isfunction:
-        return _inject_pagination(func_or_pgn_class, pagination_class)
+        if is_async_callable(func_or_pgn_class):
+            return _inject_async_pagination(func_or_pgn_class, pagination_class)
+        else:
+            return _inject_pagination(func_or_pgn_class, pagination_class)
 
     if not isnotset:
         pagination_class = func_or_pgn_class
 
     def wrapper(func: Callable) -> Any:
-        return _inject_pagination(func, pagination_class, **paginator_params)
+        if is_async_callable(func):
+            return _inject_async_pagination(func, pagination_class, **paginator_params)
+        else:
+            return _inject_pagination(func, pagination_class, **paginator_params)
 
     return wrapper
 
 
 def _inject_pagination(
     func: Callable,
-    paginator_class: Type[Union[PaginationBase, AsyncPaginationBase]],
+    paginator_class: Type[PaginationBase],
     **paginator_params: Any,
 ) -> Callable:
     paginator = paginator_class(**paginator_params)
-    if is_async_callable(func):
-        if not hasattr(paginator, "apaginate_queryset"):
-            raise ConfigError("Pagination class not configured for async requests")
 
-        @wraps(func)
-        async def view_with_pagination(request: HttpRequest, **kwargs: Any) -> Any:
-            pagination_params = kwargs.pop("ninja_pagination")
-            if paginator.pass_parameter:
-                kwargs[paginator.pass_parameter] = pagination_params
+    @wraps(func)
+    def view_with_pagination(request: HttpRequest, **kwargs: Any) -> Any:
+        pagination_params = kwargs.pop("ninja_pagination")
+        if paginator.pass_parameter:
+            kwargs[paginator.pass_parameter] = pagination_params
 
-            items = await func(request, **kwargs)
+        items = func(request, **kwargs)
 
-            result = await paginator.apaginate_queryset(
-                items, pagination=pagination_params, request=request, **kwargs
-            )
-
-            async def evaluate(results: Union[List, QuerySet]) -> AsyncGenerator:
-                for result in results:
-                    yield result
-
-            if paginator.Output:  # type: ignore
-                result[paginator.items_attribute] = [
-                    result
-                    async for result in evaluate(result[paginator.items_attribute])
-                ]
-            return result
-
-    else:
-
-        @wraps(func)
-        def view_with_pagination(request: HttpRequest, **kwargs: Any) -> Any:
-            pagination_params = kwargs.pop("ninja_pagination")
-            if paginator.pass_parameter:
-                kwargs[paginator.pass_parameter] = pagination_params
-
-            items = func(request, **kwargs)
-
-            result = paginator.paginate_queryset(
-                items, pagination=pagination_params, request=request, **kwargs
-            )
-            if paginator.Output:  # type: ignore
-                result[paginator.items_attribute] = list(
-                    result[paginator.items_attribute]
-                )
-                # ^ forcing queryset evaluation #TODO: check why pydantic did not do it here
-            return result
+        result = paginator.paginate_queryset(
+            items, pagination=pagination_params, request=request, **kwargs
+        )
+        if paginator.Output:  # type: ignore
+            result[paginator.items_attribute] = list(result[paginator.items_attribute])
+            # ^ forcing queryset evaluation #TODO: check why pydantic did not do it here
+        return result
 
     contribute_operation_args(
         view_with_pagination,
@@ -310,7 +286,10 @@ class RouterPaginated(Router):
     ) -> None:
         response = kwargs["response"]
         if is_collection_type(response):
-            view_func = _inject_pagination(view_func, self.pagination_class)
+            if is_async_callable(view_func):
+                view_func = _inject_async_pagination(view_func, self.pagination_class)
+            else:
+                view_func = _inject_pagination(view_func, self.pagination_class)
         return super().add_api_operation(path, methods, view_func, **kwargs)
 
 

--- a/tests/test_async_paginate.py
+++ b/tests/test_async_paginate.py
@@ -1,0 +1,42 @@
+from typing import List
+
+import pytest
+
+from ninja import NinjaAPI, Schema
+from ninja.pagination import paginate
+from ninja.testing import TestAsyncClient
+
+from someapp.models import Event
+
+api = NinjaAPI()
+
+
+class DummySchema(Schema):
+    id: int
+    name: str
+
+
+@api.get("/async_view_return_queryset/", response=List[DummySchema])
+@paginate
+async def async_view_return_queryset(request, **kwargs) -> None:
+    return Event.objects.all()
+
+
+@api.get("/async_view_return_list/", response=List[DummySchema])
+@paginate
+async def async_view_return_list(request, **kwargs) -> None:
+    return []
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_success__async_paginated_async_view_return_queryset() -> None:
+    client = TestAsyncClient(api)
+    await client.get("/async_view_return_queryset/")  # not raising any exception
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_success__async_paginated_async_view_return_list() -> None:
+    client = TestAsyncClient(api)
+    await client.get("/async_view_return_list/")  # not raising any exception


### PR DESCRIPTION
When applying the `paginate` decorator to an async view that returns a Django queryset, a `SynchronousOnlyOperation` error occurs.

To resolve this, I've added `_inject_async_pagination` within the `paginate` and `RouterPaginated` and differentiated the behavior based on the view type.