### PR TITLE
updated FilterSchema to support ManyToMany field

### DIFF
--- a/ninja/filter_schema.py
+++ b/ninja/filter_schema.py
@@ -66,7 +66,9 @@ class FilterSchema(Schema):
 
         q_expression = field_extra.get("q", None)  # type: ignore
         if not q_expression:
-            return Q(**{field_name: field_value})
+            if isinstance(field_value, list):
+                return Q(**{f"{field_name}__in": field_value})
+            return Q(**{f"{field_name}": field_value})
         elif isinstance(q_expression, str):
             if q_expression.startswith("__"):
                 q_expression = f"{field_name}{q_expression}"


### PR DESCRIPTION
This line: `Q(**{field_name: field_value})` fails when `field_value` is a list (ManyToMany field). So I added `__in` if the value is a `list` so `Q` doesn't throw any error. It's now working as expected. Please, run yourr tests before merging, if necessary.

Thanks for the django-ninja framework! 