### PR TITLE
Made TestClient accept COOKIES + documentation

### DIFF
--- a/docs/docs/guides/testing.md
+++ b/docs/docs/guides/testing.md
@@ -38,6 +38,7 @@ It is also possible to access the deserialized data using the `data` property:
     self.assertEqual(response.data, {"msg": "Hello World"})
 ```
 
+## Attributes
 Arbitrary attributes can be added to the request object by passing keyword arguments to the client request methods:
 ```python
 class HelloTest(TestCase):
@@ -47,9 +48,18 @@ class HelloTest(TestCase):
         response = client.get("/hello", company_id=1)
 ```
 
+### Headers
 It is also possible to specify headers, both from the TestCase instanciation and the actual request:
 ```python
     client = TestClient(router, headers={"A": "a", "B": "b"})
     # The request will be made with {"A": "na", "B": "b", "C": "nc"} headers
     response = client.get("/test-headers", headers={"A": "na", "C": "nc"})
+```
+
+### Cookies
+It is also possible to specify cookies, both from the TestCase instanciation and the actual request:
+```python
+    client = TestClient(router, COOKIES={"A": "a", "B": "b"})
+    # The request will be made with {"A": "na", "B": "b", "C": "nc"} cookies
+    response = client.get("/test-cookies", COOKIES={"A": "na", "C": "nc"})
 ```

--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -30,8 +30,10 @@ class NinjaClientBase:
         self,
         router_or_app: Union[NinjaAPI, Router],
         headers: Optional[Dict[str, str]] = None,
+        COOKIES: Optional[Dict[str, str]] = None,
     ) -> None:
         self.headers = headers or {}
+        self.cookies = COOKIES or {}
         self.router_or_app = router_or_app
 
     def get(
@@ -91,6 +93,11 @@ class NinjaClientBase:
             request_params["headers"] = {
                 **self.headers,
                 **request_params.get("headers", {}),
+            }
+        if self.cookies or request_params.get("COOKIES"):
+            request_params["COOKIES"] = {
+                **self.cookies,
+                **request_params.get("COOKIES", {}),
             }
         func, request, kwargs = self._resolve(method, path, data, request_params)
         return self._call(func, request, kwargs)  # type: ignore

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -32,6 +32,11 @@ def get_headers(request):
     return dict(request.headers)
 
 
+@router.get("/test-cookies")
+def get_cookies(request):
+    return dict(request.COOKIES)
+
+
 client = TestClient(router)
 
 
@@ -100,4 +105,22 @@ def test_headered_client_request_with_default_headers():
 
 def test_headered_client_request_with_overwritten_and_additional_headers():
     r = headered_client.get("/test-headers", headers={"A": "na", "C": "nc"})
+    assert r.json() == {"A": "na", "B": "b", "C": "nc"}
+
+
+cookied_client = TestClient(router, COOKIES={"A": "a", "B": "b"})
+
+
+def test_client_request_only_cookies():
+    r = client.get("/test-cookies", COOKIES={"A": "na"})
+    assert r.json() == {"A": "na"}
+
+
+def test_headered_client_request_with_default_cookies():
+    r = cookied_client.get("/test-cookies")
+    assert r.json() == {"A": "a", "B": "b"}
+
+
+def test_headered_client_request_with_overwritten_and_additional_cookies():
+    r = cookied_client.get("/test-cookies", COOKIES={"A": "na", "C": "nc"})
     assert r.json() == {"A": "na", "B": "b", "C": "nc"}


### PR DESCRIPTION
Hello,

I just made the `TestClient` accept an optional `COOKIES` parameter, just like it was already possible to pass `headers`.
I also updated the documentation.

Thanks!