### PR TITLE
Small typo fixes and doc mention router import

### DIFF
--- a/docs/docs/guides/testing.md
+++ b/docs/docs/guides/testing.md
@@ -26,6 +26,7 @@ from ninja.testing import TestClient
 
 class HelloTest(TestCase):
     def test_hello(self):
+        # don't forget to import router from code above
         client = TestClient(router)
         response = client.get("/hello")
         
@@ -49,7 +50,7 @@ class HelloTest(TestCase):
 ```
 
 ### Headers
-It is also possible to specify headers, both from the TestCase instanciation and the actual request:
+It is also possible to specify headers, both from the TestCase instantiation and the actual request:
 ```python
     client = TestClient(router, headers={"A": "a", "B": "b"})
     # The request will be made with {"A": "na", "B": "b", "C": "nc"} headers
@@ -57,7 +58,7 @@ It is also possible to specify headers, both from the TestCase instanciation and
 ```
 
 ### Cookies
-It is also possible to specify cookies, both from the TestCase instanciation and the actual request:
+It is also possible to specify cookies, both from the TestCase instantiation and the actual request:
 ```python
     client = TestClient(router, COOKIES={"A": "a", "B": "b"})
     # The request will be made with {"A": "na", "B": "b", "C": "nc"} cookies

--- a/tests/env-matrix/README.md
+++ b/tests/env-matrix/README.md
@@ -1,4 +1,4 @@
-This `env-matrix` speeds up test execution across all environments (Pytho 3.[6,7,8],  Django2.0,...,3.1)
+This `env-matrix` speeds up test execution across all environments (Python 3.[6,7,8],  Django2.0,...,3.1)
 
 To execute
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -56,7 +56,7 @@ class NoOutputPagination(PaginationBase):
 
 
 class ResultsPaginator(PaginationBase):
-    "Use 'results' insted of 'items' for the output"
+    "Use 'results' instead of 'items' for the output"
 
     class Input(Schema):
         skip: int
@@ -432,7 +432,7 @@ def test_config_error_NOT_SET():
 def test_pagination_works_with_unnamed_classes():
     """
     This test lets you check that the typing.Any case handled in `ninja.pagination.make_response_paginated`
-    works for Python>=3.11, as a typing.Any does possess the __name__ atribute past that version
+    works for Python>=3.11, as a typing.Any does possess the __name__ attribute past that version
     """
     operation = Operation("/whatever", ["GET"], lambda: None, response=List[int])
     operation.response_models[200].__annotations__["response"] = List[object()]

--- a/tests/test_router_defaults.py
+++ b/tests/test_router_defaults.py
@@ -43,7 +43,7 @@ class SomeResponse(Schema):
     ],
 )
 def test_router_defaults(oparg, retdict, assertone, asserttwo):
-    """Test that the router level settings work and can be overriden at the op level"""
+    """Test that the router level settings work and can be overridden at the op level"""
     api = NinjaAPI()
     router = Router(**{oparg: True})
     api.add_router("/", router)


### PR DESCRIPTION
Added a small comment in the testing doc to call out to the user to import the router. Then just some other typo fixes I saw.