### PR TITLE
feat(openapi): extended `schema.py` to be able to add a websocket json schema

### DIFF
--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -54,6 +54,7 @@ class OpenAPISchema(dict):
                 ),
                 ("paths", self.get_paths()),
                 ("components", self.get_components()),
+                ("channels", api.openapi_extra.get("channels", {})),
                 ("servers", api.servers),
             ]
         )


### PR DESCRIPTION
### Use Case
To be able to document websocket endpoints, I added "channels" as an attribute in `NinjaAPI.openai_extra`, as it is currently working for `extra_info = api.openapi_extra.get("info", {})`.

```python
api_v1 = NinjaAPI(
    version="1.0.0",
    urls_namespace="public_api",
    title="CleonAPI",
    openapi_extra={
        "channels": {
            "/ws/chat": {
                "description": "WebSocket connection for real-time chat messages.",
                "subscribe": {
                    "summary": "Receives chat messages.",
                    "message": {}
                },
                "publish": {
                    "summary": "Sends chat messages.",
                    "message": {}
                }
            }
        }
    }
)
```

### References
* https://django-ninja.dev/guides/api-docs/?h=openapi#extending-openapi-spec-with-custom-attributes
* https://django-ninja.dev/reference/operations-parameters/?h=openapi#openapi_extra
