### PR TITLE
chore: Refactor async pagination

### DIFF
--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -2,7 +2,7 @@ import inspect
 from abc import ABC, abstractmethod
 from functools import partial, wraps
 from math import inf
-from typing import Any, AsyncGenerator, Callable, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, List, Optional, Tuple, Type, Union
 
 from django.db.models import QuerySet
 from django.http import HttpRequest
@@ -53,7 +53,7 @@ class PaginationBase(ABC):
         """
         try:
             # forcing to find queryset.count instead of list.count:
-            return queryset.all().count()
+            return queryset.count()
         except AttributeError:
             return len(queryset)
 
@@ -70,7 +70,7 @@ class AsyncPaginationBase(PaginationBase):
 
     async def _aitems_count(self, queryset: QuerySet) -> int:
         try:
-            return await queryset.all().acount()
+            return await queryset.acount()
         except AttributeError:
             return len(queryset)
 
@@ -203,14 +203,10 @@ def _inject_pagination(
                 items, pagination=pagination_params, request=request, **kwargs
             )
 
-            async def evaluate(results: Union[List, QuerySet]) -> AsyncGenerator:
-                for result in results:
-                    yield result
-
             if paginator.Output:  # type: ignore
                 result[paginator.items_attribute] = [
                     result
-                    async for result in evaluate(result[paginator.items_attribute])
+                    async for result in result[paginator.items_attribute]
                 ]
             return result
 


### PR DESCRIPTION
## Async Paginator

The evaluate AsyncGenerator causes:

`django.core.exceptions.SynchronousOnlyOperation: You cannot call this from an async context - use a thread or sync_to_async`

This part of the code is the reason:
![Screenshot_1](https://github.com/user-attachments/assets/7b741cdc-8caf-40f4-a0e1-2ba872e81b2d)

### **In fact,** it's unnecessary at all as django already handles the queryset and evaluates it as an AsyncGenerator once you call it with `async for`

---

Similarly with the `count()` and `acount()` methods, you can directly call them on the queryset and no need to call `all()` first.

![Screenshot_2](https://github.com/user-attachments/assets/71bc165c-bb10-45bd-ad8f-fdae903ab808)
