### PR TITLE
Add IPNetwork and Url serialisation

### DIFF
--- a/ninja/responses.py
+++ b/ninja/responses.py
@@ -1,10 +1,11 @@
 from enum import Enum
-from ipaddress import IPv4Address, IPv6Address
+from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
 from typing import Any, FrozenSet
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import JsonResponse
 from pydantic import BaseModel
+from pydantic_core import Url
 
 __all__ = [
     "NinjaJSONEncoder",
@@ -21,7 +22,9 @@ class NinjaJSONEncoder(DjangoJSONEncoder):
     def default(self, o: Any) -> Any:
         if isinstance(o, BaseModel):
             return o.model_dump()
-        if isinstance(o, (IPv4Address, IPv6Address)):
+        if isinstance(o, Url):
+            return str(o)
+        if isinstance(o, (IPv4Address, IPv4Network, IPv6Address, IPv6Network)):
             return str(o)
         if isinstance(o, Enum):
             return str(o)


### PR DESCRIPTION
Should resolve #1334, validates #717 and add IPNetwork as serialisable.

We have been migrating an app from FastAPI to Django-Ninja and have been running into these serialisation issues.