### PR TITLE
fix: async pagination evaluate fix for queryset object

### DIFF
--- a/ninja/conf.py
+++ b/ninja/conf.py
@@ -11,6 +11,7 @@ class Settings(BaseModel):
         "ninja.pagination.LimitOffsetPagination", alias="NINJA_PAGINATION_CLASS"
     )
     PAGINATION_PER_PAGE: int = Field(100, alias="NINJA_PAGINATION_PER_PAGE")
+    PAGINATION_MAX_PER_PAGE: int = Field(100, alias="NINJA_PAGINATION_MAX_PER_PAGE")
     PAGINATION_MAX_LIMIT: int = Field(inf, alias="NINJA_PAGINATION_MAX_LIMIT")  # type: ignore
 
     # Throttling

--- a/tests/test_pagination_async.py
+++ b/tests/test_pagination_async.py
@@ -9,8 +9,8 @@ from ninja.errors import ConfigError
 from ninja.pagination import (
     AsyncPaginationBase,
     PageNumberPagination,
-    PaginationBase,
     paginate,
+    PaginationBase,
 )
 from ninja.testing import TestAsyncClient
 
@@ -113,11 +113,15 @@ async def test_async_page_number():
     api = NinjaAPI()
 
     @api.get("/items_page_number", response=List[Any])
-    @paginate(PageNumberPagination, page_size=10, pass_parameter="page_info")
+    @paginate(PageNumberPagination, pass_parameter="page_info")
     async def items_page_number(request, **kwargs):
         return ITEMS + [kwargs["page_info"]]
 
     client = TestAsyncClient(api)
-
-    response = await client.get("/items_page_number?page=11")
-    assert response.json() == {"items": [{"page": 11}], "count": 101}
+    page = 11
+    page_size = 10
+    response = await client.get(f"/items_page_number?page={page}&page_size={page_size}")
+    assert response.json() == {
+        "items": [{"page": page, "page_size": page_size}],
+        "count": 101,
+    }


### PR DESCRIPTION
Hello guys, you are doing a great job! 

I found a problem using default `PageNumberPagination` with async endpoint returning a queryset like this:

```python
    @route.get("/", response=list[TodoListSchema])
    @paginate(PageNumberPagination)
    async def list_todos(self, filters: TodoFilterSchema = Query()):
        todos = filters.filter(
            Todo.objects.filter(user=self.context.request.user).values("id", "title")
        )
        return todos
```

I was getting that error about calling sync method, so I made a small change in your `PageNumberPagination` and `LimitOffsetPagination`.
It was not a big change, I also adjusted your tests and everything is working just fine.

The reason why the error was being raised is the same as if count was called in async loop, so that change was really needed. 

I don't hope you to merge my pull request, but that change is really needed and you should merge it to properly work with`QuerySet` object.