### PR TITLE
Allow Customizing Validation Errors

### DIFF
--- a/docs/docs/guides/errors.md
+++ b/docs/docs/guides/errors.md
@@ -52,8 +52,8 @@ function must return http response
 
 ## Override the default exception handlers
 
-By default, **Django Ninja** initialized the following exception handlers:
-
+**Django Ninja** registers default exception handlers for the types shown below.
+You can register your own handlers with `@api.exception_handler` to override the default handlers.
 
 #### `ninja.errors.AuthenticationError`
 
@@ -85,10 +85,17 @@ Default behavior
   - **else** - default django exception handler mechanism is used (error logging, email to ADMINS)
 
 
-### Override default handler
+## Customizing request validation errors
 
-If you need to change default output for validation errors - override ValidationError exception handler:
+Requests that fail validation raise `ninja.errors.ValidationError` (not to be confused with `pydantic.ValidationError`).
+`ValidationError`s have a default exception handler that returns a 422 (Unprocessable Content) JSON response of the form:
+```json
+{
+    "detail": [ ... ]
+}
+```
 
+You can change this behavior by overriding the default handler for `ValidationError`s:
 
 ```python hl_lines="1 4"
 from ninja.errors import ValidationError
@@ -98,6 +105,36 @@ from ninja.errors import ValidationError
 def validation_errors(request, exc):
     return HttpResponse("Invalid input", status=422)
 ```
+
+If you need even more control over validation errors (for example, if you need to reference the schema associated with
+the model that failed validation), you can supply your own `validation_error_from_error_contexts` in a `NinjaAPI` subclass:
+
+```python hl_lines="4"
+from ninja.errors import ValidationError, ValidationErrorContext
+from typing import Any, Dict, List
+
+class CustomNinjaAPI(NinjaAPI):
+    def validation_error_from_error_contexts(
+        self, error_contexts: List[ValidationErrorContext],
+    ) -> ValidationError:
+        custom_error_infos: List[Dict[str, Any]] = []
+        for context in error_contexts:
+            model = context.model
+            pydantic_schema = model.__pydantic_core_schema__
+            param_source = model.__ninja_param_source__
+            for e in context.pydantic_validation_error.errors(
+                include_url=False, include_context=False, include_input=False
+            ):
+                custom_error_info = {
+                # TODO: use `e`, `param_source`, and `pydantic_schema` as desired
+                }
+                custom_error_infos.append(custom_error_info)
+        return ValidationError(custom_error_infos)
+
+api = CustomNinjaAPI()
+```
+
+Now each `ValidationError` raised during request validation will contain data from your `validation_error_from_error_contexts`.
 
 
 ## Throwing HTTP responses with exceptions

--- a/ninja/errors.py
+++ b/ninja/errors.py
@@ -1,8 +1,9 @@
 import logging
 import traceback
 from functools import partial
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Generic, List, Optional, TypeVar
 
+import pydantic
 from django.conf import settings
 from django.http import Http404, HttpRequest, HttpResponse
 
@@ -10,6 +11,7 @@ from ninja.types import DictStrAny
 
 if TYPE_CHECKING:
     from ninja import NinjaAPI  # pragma: no cover
+    from ninja.params.models import ParamModel  # pragma: no cover
 
 __all__ = [
     "ConfigError",
@@ -26,6 +28,22 @@ logger = logging.getLogger("django")
 
 class ConfigError(Exception):
     pass
+
+
+TModel = TypeVar("TModel", bound="ParamModel")
+
+
+class ValidationErrorContext(Generic[TModel]):
+    """
+    The full context of a `pydantic.ValidationError`, including all information
+    needed to produce a `ninja.errors.ValidationError`.
+    """
+
+    def __init__(
+        self, pydantic_validation_error: pydantic.ValidationError, model: TModel
+    ):
+        self.pydantic_validation_error = pydantic_validation_error
+        self.model = model
 
 
 class ValidationError(Exception):


### PR DESCRIPTION
# Summary
`ninja.errors.ValidationError`s have some fundamental bugs and discard crucial error context (see https://github.com/vitalik/django-ninja/issues/1381). I've been working around these problems with monkeypatching in my own project.

This PR allows developers to access the missing error context in order to make much friendlier error messages than is currently possible with Django Ninja. It solves Problem 1 from https://github.com/vitalik/django-ninja/issues/1381 and partially addresses Problem 2.
Fixing the other problems I found will take more PRs and a larger discussion, but I think this PR makes the situation better.

## Before
Prior to this PR, users had access to `ninja.errors.ValidationError`s via `@api.exception_handler(ValidationError)`, but this has some problems:
1. It discards error context needed for understanding the error (especially `model.__pydantic_core_schema__`)
2. It transforms the `loc` field in pydantic errors, which makes it impossible for downstream code to understand what each element of the `loc` means
3. (Not directly addressed in this PR) It sometimes produces incorrect `loc`s

## After
This PR allows users to control how `pydantic.ValidationError`s get turned into `ninja.errors.ValidationError`s, without breaking backwards compatibility with existing user code.
The PR:
1. Introduces an intermediate `ValidationErrorContext`
2. Adds an overridable method, `validation_error_from_error_contexts(self, error_contexts: List[ValidationErrorContext]) -> ValidationError`
3. Adds test code and usage documentation for this new functionality.

# Context
Consider the following example:
```python
# Example 1
# urls.py:
from __future__ import annotations

import ninja
from django.http import HttpRequest
from django.urls import path

class UserSchema(ninja.Schema):
    salutation: str
    short_name: str
    full_name: str
    friends: list[UserSchema] = []

class HelloSchema(ninja.Schema):
    user: str | UserSchema

demo_api = ninja.NinjaAPI()

@demo_api.post("/hello")
def hello(request: HttpRequest, data: HelloSchema) -> str:
    if isinstance(data.user, str):
        return f"Hello {data.user}"
    else:
        return f"{data.user.salutation} {data.user.short_name}"

urlpatterns = [
    path("demo/", demo_api.urls)
]
```

If you POST `{ "user": {} }` to `/demo/hello` (you can use "Try it out" at "/demo/docs"), the response (with whitespace changes for readability) is:
```json
{
  "detail": [
    { "type": "string_type", "loc": [ "body", "data", "user", "str" ],                                                "msg": "Input should be a valid string" }, 
    { "type": "missing",     "loc": [ "body", "data", "user", "function-wrap[_run_root_validator()]", "salutation" ], "msg": "Field required" },
    { "type": "missing",     "loc": [ "body", "data", "user", "function-wrap[_run_root_validator()]", "short_name" ], "msg": "Field required" },
    { "type": "missing",     "loc": [ "body", "data", "user", "function-wrap[_run_root_validator()]", "full_name" ],  "msg": "Field required" }
  ]
}
```

Note the confusing 4th value of each `"loc"` field: `"str"` or `"function-wrap[_run_root_validator()]"`.
Note also that the 2nd value of each `"loc"` field is `"data"`, which is the name of a parameter to the `hello` function.
These parts of `"loc"` are not meaningful to API callers and are brittle in the face of future changes (for example, they will change if the `data` function parameter gets renamed or if `UserSchema` gets a new `model_validator`).

A developer using Django Ninja should be able to produce user-friendly errors like the following instead of the errors in the example above:
```json
{ "message": "body.user: Should be a string or a UserSchema but was `{}`" }
```

This is usually possible with Pydantic by walking `model.__pydantic_core_schema__` with the error `loc` (see below), but Django Ninja discards `model.__pydantic_core_schema__` and transforms `loc`, so it's not possible in Django Ninja without user control of what makes it into `ValidationError`.

## Understanding Pydantic Errors and `model.__pydantic_core_schema__`

In Pydantic 2, the errors in `e.errors` relate not to the input data (the end-user's perspective) but to the schema against which the input data was validated.
To construct user-friendly errors, we can crawl the tree rooted in `model.__pydantic_core_schema__` using the original `"loc"` field of each error.
This allows us to, for example, identify whether a given `loc` element refers to a field, a dictionary key, a union discriminator, or something else.

For the `hello` endpoint in Example 1 above, the `model.__pydantic_core_schema__` of the body is:

```python
{'definitions': [{'function': {'function': <bound method Schema._run_root_validator of <class 'demo.urls.UserSchema'>>,
                               'type': 'with-info'},
                  'metadata': {'pydantic_js_functions': [<bound method BaseModel.__get_pydantic_json_schema__ of <class 'demo.urls.UserSchema'>>]},
                  'ref': 'demo.urls.UserSchema:5721087360',
                  'schema': {'cls': <class 'demo.urls.UserSchema'>,
                             'config': {'from_attributes': True,
                                        'title': 'UserSchema'},
                             'custom_init': False,
                             'root_model': False,
                             'schema': {'computed_fields': [],
                                        'fields': {'friends': {'metadata': {},
                                                               'schema': {'default': [],
                                                                          'schema': {'items_schema': {'schema_ref': 'demo.urls.UserSchema:5721087360',
                                                                                                      'type': 'definition-ref'},
                                                                                     'type': 'list'},
                                                                          'type': 'default'},
                                                               'type': 'model-field'},
                                                   'full_name': {'metadata': {},
                                                                 'schema': {'type': 'str'},
                                                                 'type': 'model-field'},
                                                   'salutation': {'metadata': {},
                                                                  'schema': {'type': 'str'},
                                                                  'type': 'model-field'},
                                                   'short_name': {'metadata': {},
                                                                  'schema': {'type': 'str'},
                                                                  'type': 'model-field'}},
                                        'model_name': 'UserSchema',
                                        'type': 'model-fields'},
                             'type': 'model'},
                  'type': 'function-wrap'}],
 'schema': {'cls': <class 'abc.BodyParams'>,
            'config': {'title': 'BodyParams'},
            'custom_init': False,
            'metadata': {'pydantic_js_functions': [<bound method BaseModel.__get_pydantic_json_schema__ of <class 'abc.BodyParams'>>]},
            'ref': 'abc.BodyParams:5721102816',
            'root_model': False,
            'schema': {'computed_fields': [],
                       'fields': {'data': {'metadata': {'pydantic_js_extra': {}},
                                           'schema': {'function': {'function': <bound method Schema._run_root_validator of <class 'demo.urls.HelloSchema'>>,
                                                                   'type': 'with-info'},
                                                      'metadata': {'pydantic_js_functions': [<bound method BaseModel.__get_pydantic_json_schema__ of <class 'demo.urls.HelloSchema'>>]},
                                                      'ref': 'demo.urls.HelloSchema:5721091792',
                                                      'schema': {'cls': <class 'demo.urls.HelloSchema'>,
                                                                 'config': {'from_attributes': True,
                                                                            'title': 'HelloSchema'},
                                                                 'custom_init': False,
                                                                 'root_model': False,
                                                                 'schema': {'computed_fields': [],
                                                                            'fields': {'user': {'metadata': {},
                                                                                                'schema': {'choices': [{'type': 'str'},
                                                                                                                       {'schema_ref': 'demo.urls.UserSchema:5721087360',
                                                                                                                        'type': 'definition-ref'}],
                                                                                                           'type': 'union'},
                                                                                                'type': 'model-field'}},
                                                                            'model_name': 'HelloSchema',
                                                                            'type': 'model-fields'},
                                                                 'type': 'model'},
                                                      'type': 'function-wrap'},
                                           'type': 'model-field'}},
                       'model_name': 'BodyParams',
                       'type': 'model-fields'},
            'type': 'model'},
 'type': 'definitions'}
```

and the first `e.errors()` error is:
```python
{'type': 'string_type', 'loc': ('data', 'user', 'str'), 'msg': 'Input should be a valid string', 'input': {}, 'url': 'https://errors.pydantic.dev/2.10/v/string_type'}
```
We can see that `'str'` isn't a field here because it's a discriminator for this `'union'` schema:
```python
{'choices': [{'type': 'str'},
            {'schema_ref': 'demo.urls.UserSchema:5721087360',
            'type': 'definition-ref'}],
'type': 'union'}
```

Moreover, we can see that the 3 other errors refer to a different union variant because the 3rd element of `"loc"` is `'function-wrap[_run_root_validator()]'` rather than `'str'`:
```python
    {'type': 'missing', 'loc': ('data', 'user', 'function-wrap[_run_root_validator()]', 'salutation'), 'msg': 'Field required', 'input': <DjangoGetter: {}>, 'url': 'https://errors.pydantic.dev/2.10/v/missing'} 
    {'type': 'missing', 'loc': ('data', 'user', 'function-wrap[_run_root_validator()]', 'short_name'), 'msg': 'Field required', 'input': <DjangoGetter: {}>, 'url': 'https://errors.pydantic.dev/2.10/v/missing'}
    {'type': 'missing', 'loc': ('data', 'user', 'function-wrap[_run_root_validator()]', 'full_name'), 'msg': 'Field required', 'input': <DjangoGetter: {}>, 'url': 'https://errors.pydantic.dev/2.10/v/missing'}
```



