### PR TITLE
Add parser support to Operation and Router classes

### DIFF
--- a/ninja/router.py
+++ b/ninja/router.py
@@ -18,6 +18,7 @@ from ninja.constants import NOT_SET, NOT_SET_TYPE
 from ninja.errors import ConfigError
 from ninja.operation import PathView
 from ninja.throttling import BaseThrottle
+from ninja.parser import Parser
 from ninja.types import TCallable
 from ninja.utils import normalize_path, replace_path_param_notation
 
@@ -71,6 +72,7 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        parser: Optional[Parser] = None,
     ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["GET"],
@@ -90,6 +92,7 @@ class Router:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            parser=parser,
         )
 
     def post(
@@ -111,6 +114,7 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        parser: Optional[Parser] = None,
     ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["POST"],
@@ -130,6 +134,7 @@ class Router:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            parser=parser,
         )
 
     def delete(
@@ -151,6 +156,7 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        parser: Optional[Parser] = None,
     ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["DELETE"],
@@ -170,6 +176,7 @@ class Router:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            parser=parser,
         )
 
     def patch(
@@ -191,6 +198,7 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        parser: Optional[Parser] = None,
     ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["PATCH"],
@@ -210,6 +218,7 @@ class Router:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            parser=parser,
         )
 
     def put(
@@ -231,6 +240,7 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        parser: Optional[Parser] = None,
     ) -> Callable[[TCallable], TCallable]:
         return self.api_operation(
             ["PUT"],
@@ -250,6 +260,7 @@ class Router:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            parser=parser,
         )
 
     def api_operation(
@@ -272,6 +283,7 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        parser: Optional[Parser] = None,
     ) -> Callable[[TCallable], TCallable]:
         def decorator(view_func: TCallable) -> TCallable:
             self.add_api_operation(
@@ -293,6 +305,7 @@ class Router:
                 url_name=url_name,
                 include_in_schema=include_in_schema,
                 openapi_extra=openapi_extra,
+                parser=parser,
             )
             return view_func
 
@@ -319,6 +332,7 @@ class Router:
         url_name: Optional[str] = None,
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
+        parser: Optional[Parser] = None,
     ) -> None:
         if path not in self.path_operations:
             path_view = PathView()
@@ -352,6 +366,7 @@ class Router:
             url_name=url_name,
             include_in_schema=include_in_schema,
             openapi_extra=openapi_extra,
+            parser=parser,
         )
         if self.api:
             path_view.set_api_instance(self.api, self)


### PR DESCRIPTION
- Introduced a new optional `parser` parameter in the `Operation` and `Router` classes to allow for customizable request body parsing.
- Updated the `run` method in `Operation` to utilize the parser for handling request bodies.
- Modified various HTTP method decorators in `Router` to accept and pass the parser parameter to the associated operations.

#1391 