### PR TITLE
CI: Use Ubuntu 22 for 3.7 support in tests

### DIFF
--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']


### PR DESCRIPTION
`ubuntu-latest` just swapped to Ubuntu 24, which drops support for Python 3.7. There should probably be a separate discussion about dropping about 3.7, but this will fix the problem for now.