### PR TITLE
Improve Performance for Async Pagination

### DIFF
--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -6,7 +6,6 @@ from typing import Any, AsyncGenerator, Callable, List, Optional, Tuple, Type, U
 
 from django.db.models import QuerySet
 from django.http import HttpRequest
-from django.shortcuts import aget_list_or_404
 from django.utils.module_loading import import_string
 from typing_extensions import get_args as get_collection_args
 
@@ -109,7 +108,7 @@ class LimitOffsetPagination(AsyncPaginationBase):
         offset = pagination.offset
         limit: int = min(pagination.limit, settings.PAGINATION_MAX_LIMIT)
         return {
-            "items": await aget_list_or_404(queryset[offset : offset + limit]),
+            "items": [obj async for obj in queryset[offset : offset + page_size]],
             "count": await self._aitems_count(queryset),
         }  # noqa: E203
 
@@ -144,7 +143,7 @@ class PageNumberPagination(AsyncPaginationBase):
     ) -> Any:
         offset = (pagination.page - 1) * self.page_size
         return {
-            "items": await aget_list_or_404(queryset[offset: offset + self.page_size]),
+            "items": [obj async for obj in queryset[offset : offset + page_size]],
             "count": await self._aitems_count(queryset),
         }  # noqa: E203
 

--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -107,8 +107,12 @@ class LimitOffsetPagination(AsyncPaginationBase):
     ) -> Any:
         offset = pagination.offset
         limit: int = min(pagination.limit, settings.PAGINATION_MAX_LIMIT)
+        if isinstance(queryset, list):
+            items = queryset[offset : offset + limit]
+        else:
+            items = [obj async for obj in queryset[offset : offset + limit]]
         return {
-            "items": [obj async for obj in queryset[offset : offset + limit]],
+            "items": items,
             "count": await self._aitems_count(queryset),
         }  # noqa: E203
 
@@ -142,8 +146,12 @@ class PageNumberPagination(AsyncPaginationBase):
         **params: Any,
     ) -> Any:
         offset = (pagination.page - 1) * self.page_size
+        if isinstance(queryset, list):
+            items = queryset[offset : offset + self.page_size]
+        else:
+            items = [obj async for obj in queryset[offset : offset + self.page_size]]
         return {
-            "items": [obj async for obj in queryset[offset : offset + limit]],
+            "items": items,
             "count": await self._aitems_count(queryset),
         }  # noqa: E203
 

--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -108,7 +108,7 @@ class LimitOffsetPagination(AsyncPaginationBase):
         offset = pagination.offset
         limit: int = min(pagination.limit, settings.PAGINATION_MAX_LIMIT)
         return {
-            "items": [obj async for obj in queryset[offset : offset + page_size]],
+            "items": [obj async for obj in queryset[offset : offset + limit]],
             "count": await self._aitems_count(queryset),
         }  # noqa: E203
 
@@ -143,7 +143,7 @@ class PageNumberPagination(AsyncPaginationBase):
     ) -> Any:
         offset = (pagination.page - 1) * self.page_size
         return {
-            "items": [obj async for obj in queryset[offset : offset + page_size]],
+            "items": [obj async for obj in queryset[offset : offset + limit]],
             "count": await self._aitems_count(queryset),
         }  # noqa: E203
 

--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -107,10 +107,10 @@ class LimitOffsetPagination(AsyncPaginationBase):
     ) -> Any:
         offset = pagination.offset
         limit: int = min(pagination.limit, settings.PAGINATION_MAX_LIMIT)
-        if isinstance(queryset, list):
-            items = queryset[offset : offset + limit]
-        else:
+        if isinstance(queryset, QuerySet):
             items = [obj async for obj in queryset[offset : offset + limit]]
+        else:
+            items = queryset[offset : offset + limit]
         return {
             "items": items,
             "count": await self._aitems_count(queryset),
@@ -146,10 +146,10 @@ class PageNumberPagination(AsyncPaginationBase):
         **params: Any,
     ) -> Any:
         offset = (pagination.page - 1) * self.page_size
-        if isinstance(queryset, list):
-            items = queryset[offset : offset + self.page_size]
-        else:
+        if isinstance(queryset, QuerySet):
             items = [obj async for obj in queryset[offset : offset + self.page_size]]
+        else:
+            items = queryset[offset : offset + self.page_size]
         return {
             "items": items,
             "count": await self._aitems_count(queryset),

--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -6,6 +6,7 @@ from typing import Any, AsyncGenerator, Callable, List, Optional, Tuple, Type, U
 
 from django.db.models import QuerySet
 from django.http import HttpRequest
+from django.shortcuts import aget_list_or_404
 from django.utils.module_loading import import_string
 from typing_extensions import get_args as get_collection_args
 
@@ -108,7 +109,7 @@ class LimitOffsetPagination(AsyncPaginationBase):
         offset = pagination.offset
         limit: int = min(pagination.limit, settings.PAGINATION_MAX_LIMIT)
         return {
-            "items": queryset[offset : offset + limit],
+            "items": await aget_list_or_404(queryset[offset : offset + limit]),
             "count": await self._aitems_count(queryset),
         }  # noqa: E203
 
@@ -143,7 +144,7 @@ class PageNumberPagination(AsyncPaginationBase):
     ) -> Any:
         offset = (pagination.page - 1) * self.page_size
         return {
-            "items": queryset[offset : offset + self.page_size],
+            "items": await aget_list_or_404(queryset[offset: offset + self.page_size]),
             "count": await self._aitems_count(queryset),
         }  # noqa: E203
 


### PR DESCRIPTION
django ninja is a good framework, when I work on the project, I found the pagination on async view is much lower than sync view for performance wise, like row 1 and row 3, so I have made some update for the pagination class.

| Type | Name                 | # Requests | # Fails | Average (ms) | Min (ms) | Max (ms) | Average size (bytes) | RPS  | Failures/s |
| ---- | -------------------- | ---------- | ------- | ------------ | -------- | -------- | -------------------- | ---- | ---------- |
| async with origin pagination  | /api/bff/trade       | 108        | 12      | 11294.07     | 5764     | 23045    | 38551.11             | 0.86 | 0.1        |
| async with new pagination change  | /api/bff/trade/async | 108        | 0       | 75.9         | 25       | 475      | 43370                | 0.86 | 0          |
| sync pagination  | /api/bff/trade/sync  | 108        | 0       | 193.67       | 24       | 2175     | 43370                | 0.86 | 0          |


In another word, if use the origin pagination on async view, it is actually does not bring any befenits for performance but slow it down. This PR is to resolve this.