### PR TITLE
Add query parameters in request_params for testing

### DIFF
--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -172,7 +172,11 @@ class NinjaClientBase:
             if query_params:
                 query_dict = QueryDict(mutable=True)
                 for k, v in query_params.items():
-                    query_dict[k] = v
+                    if isinstance(v, list):
+                        for item in v:
+                            query_dict.appendlist(k, item)
+                    else:
+                        query_dict[k] = v
                 request.GET = query_dict
             else:
                 request.GET = QueryDict()

--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -168,7 +168,14 @@ class NinjaClientBase:
         if "?" in path:
             request.GET = QueryDict(path.split("?")[1])
         else:
-            request.GET = QueryDict()
+            query_params = request_params.pop("query_params", None)
+            if query_params:
+                query_dict = QueryDict(mutable=True)
+                for k, v in query_params.items():
+                    query_dict[k] = v
+                request.GET = query_dict
+            else:
+                request.GET = QueryDict()
 
         for k, v in request_params.items():
             setattr(request, k, v)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -77,3 +77,45 @@ def test_get_path(path, expected_status, expected_response):
     print(resp)
     assert response.status_code == expected_status
     assert resp == expected_response
+
+
+@pytest.mark.parametrize(
+    "path,query_params,expected_status,expected_response",
+    [
+        ("/query", {}, 422, response_missing),
+        ("/query", {"query": "baz"}, 200, "foo bar baz"),
+        ("/query", {"not_declared": "baz"}, 422, response_missing),
+        ("/query/optional", {}, 200, "foo bar"),
+        ("/query/optional", {"query": "baz"}, 200, "foo bar baz"),
+        ("/query/optional", {"not_declared": "baz"}, 200, "foo bar"),
+        ("/query/int", {}, 422, response_missing),
+        ("/query/int", {"query": "42"}, 200, "foo bar 42"),
+        ("/query/int", {"query": "42.5"}, 422, response_not_valid_int_float),
+        ("/query/int", {"query": "baz"}, 422, response_not_valid_int),
+        ("/query/int", {"not_declared": "baz"}, 422, response_missing),
+        ("/query/int/optional", {}, 200, "foo bar"),
+        ("/query/int/optional", {"query": "50"}, 200, "foo bar 50"),
+        ("/query/int/optional", {"query": "foo"}, 422, response_not_valid_int),
+        ("/query/int/default", {}, 200, "foo bar 10"),
+        ("/query/int/default", {"query": "50"}, 200, "foo bar 50"),
+        ("/query/int/default", {"query": "foo"}, 422, response_not_valid_int),
+        ("/query/list", {"query": ["a", "b", "c"]}, 200, "a,b,c"),
+        ("/query/list-optional", {"query": ["a", "b", "c"]}, 200, "a,b,c"),
+        ("/query/list-optional", {"query": ["a"]}, 200, "a"),
+        ("/query/list-optional", {}, 200, None),
+        ("/query/param", {}, 200, "foo bar"),
+        ("/query/param", {"query": "50"}, 200, "foo bar 50"),
+        ("/query/param-required", {}, 422, response_missing),
+        ("/query/param-required", {"query": "50"}, 200, "foo bar 50"),
+        ("/query/param-required/int", {}, 422, response_missing),
+        ("/query/param-required/int", {"query": "50"}, 200, "foo bar 50"),
+        ("/query/param-required/int", {"query": "foo"}, 422, response_not_valid_int),
+        ("/query/aliased-name", {"aliased.-_~name": "foo"}, 200, "foo bar foo"),
+    ],
+)
+def test_get_query_params(path, query_params, expected_status, expected_response):
+    response = client.get(path, query_params=query_params)
+    resp = response.json()
+    print(resp)
+    assert response.status_code == expected_status
+    assert resp == expected_response


### PR DESCRIPTION
# Enhanced Support for Query Parameters in GET Requests
Currently, Django Ninja's client.get only supports query parameters directly embedded in the URL, such as `/customers/details/?name=fred&age=7` . 

However, it lacks support for passing query parameters as a separate dictionary like 
```python
c.get("/customers/details/", query_params={"name": "fred", "age": 7})
```

This pull request enhances the _build_request method to extract query parameters from the request_params dictionary, providing a more flexible and cleaner API for testing GET requests with query parameters. 

The implementation maintains backward compatibility with the existing URL-based approach while adding this new functionality.

Now we can implement code like this:

```python
from ninja.testing import TestClient

response = client.get("/customers/details/", query_params={"name": "fred", "age": 7})
```