### PR TITLE
fix: to_camel implementation in docs and tests

### DIFF
--- a/docs/docs/guides/response/config-pydantic.md
+++ b/docs/docs/guides/response/config-pydantic.md
@@ -19,8 +19,8 @@ from ninja import Schema
 
 
 def to_camel(string: str) -> str:
-    return ''.join(word.capitalize() for word in string.split('_'))
-
+    words = string.split('_')
+    return words[0].lower() + ''.join(word.capitalize() for word in words[1:])
 
 class CamelModelSchema(Schema):
     str_field_name: str
@@ -39,7 +39,7 @@ Keep in mind that when you want modify output for field names (like camel case) 
 class UserSchema(ModelSchema):
     class Config:
         model = User
-        model_fields = ["id", "email"]
+        model_fields = ["id", "email", "is_staff"]
         alias_generator = to_camel
         populate_by_name = True  # !!!!!! <--------
 
@@ -55,12 +55,14 @@ results:
 ```JSON
 [
   {
-    "Id": 1,
-    "Email": "tim@apple.com"
+    "id": 1,
+    "email": "tim@apple.com",
+    "isStaff": true
   },
   {
-    "Id": 2,
-    "Email": "sarah@smith.com"
+    "id": 2,
+    "email": "sarah@smith.com",
+    "isStaff": false
   }
   ...
 ]

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -28,7 +28,8 @@ class TypeB(Schema):
 
 
 def to_camel(string: str) -> str:
-    return "".join(word.capitalize() for word in string.split("_"))
+    words = string.split("_")
+    return words[0].lower() + "".join(word.capitalize() for word in words[1:])
 
 
 class Response(Schema):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -38,7 +38,8 @@ class MyEnum(Enum):
 
 
 def to_camel(string: str) -> str:
-    return "".join(word.capitalize() for word in string.split("_"))
+    words = string.split("_")
+    return words[0].lower() + "".join(word.capitalize() for word in words[1:])
 
 
 class UserModel(BaseModel):
@@ -109,7 +110,7 @@ client = TestClient(router)
             [{"id": 1, "user_name": "John"}],
         ),  # the password is skipped
         ("/check_model", {"id": 1, "user_name": "John"}),  # the password is skipped
-        ("/check_model_alias", {"Id": 1, "UserName": "John"}),  # result is Camal Case
+        ("/check_model_alias", {"id": 1, "userName": "John"}),  # result is camelCase
         ("/check_union?q=0", 1),
         ("/check_union?q=1", {"id": 1, "user_name": "John"}),
     ],


### PR DESCRIPTION
The original `to_camel` implementation converts the `snake_case` string to `PascalCase` instead of `camelCase`.

This PR has been modified to correctly convert it to `camelCase`.

Since this function is for documentation purposes, I have implemented it as concise as possible without considering edge cases (such as acronym, numbers etc.).

- [x] I have read the contributing guidelines.
- [x] I have passed tests and lints in local.

I am unable to run just `make docs` due to an error related to `mkdocs-autorefs` (refs https://github.com/mkdocstrings/autorefs/issues/68). I tried to deal with this problem by changing the version, but could not solve it.
