### PR TITLE
Add option to exclude Django Field blank option from determination of 'nullable'

### DIFF
--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -41,6 +41,7 @@ class SchemaFactory:
         fields: Optional[List[str]] = None,
         exclude: Optional[List[str]] = None,
         optional_fields: Optional[List[str]] = None,
+        is_blank_nullable: bool = True,
         custom_fields: Optional[List[Tuple[str, Any, Any]]] = None,
         base_class: Type[Schema] = Schema,
     ) -> Type[Schema]:
@@ -66,6 +67,7 @@ class SchemaFactory:
                 fld,
                 depth=depth,
                 optional=optional_fields and (fld.name in optional_fields),
+                is_blank_nullable=is_blank_nullable,
             )
             definitions[fld.name] = (python_type, field_info)
 

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -115,7 +115,11 @@ def create_m2m_link_type(type_: Type[TModel]) -> Type[TModel]:
 
 @no_type_check
 def get_schema_field(
-    field: DjangoField, *, depth: int = 0, optional: bool = False
+    field: DjangoField,
+    *,
+    depth: int = 0,
+    optional: bool = False,
+    is_blank_nullable: bool = True,
 ) -> Tuple:
     "Returns pydantic field from django's model field"
     alias = None
@@ -163,7 +167,7 @@ def get_schema_field(
             ]
             raise ConfigError("\n".join(msg)) from e
 
-        if field.primary_key or blank or null or optional:
+        if field.primary_key or (is_blank_nullable and blank) or null or optional:
             default = None
             nullable = True
 

--- a/ninja/orm/metaclass.py
+++ b/ninja/orm/metaclass.py
@@ -17,6 +17,7 @@ class MetaConf:
     fields: Optional[List[str]] = None
     exclude: Union[List[str], str, None] = None
     fields_optional: Union[List[str], str, None] = None
+    is_blank_nullable: bool = True
 
     @staticmethod
     def from_schema_class(name: str, namespace: dict) -> "MetaConf":
@@ -26,6 +27,7 @@ class MetaConf:
             fields = getattr(meta, "fields", None)
             exclude = getattr(meta, "exclude", None)
             optional_fields = getattr(meta, "fields_optional", None)
+            is_blank_nullable = getattr(meta, "is_blank_nullable", True)
 
         elif "Config" in namespace:
             config = namespace["Config"]
@@ -33,6 +35,7 @@ class MetaConf:
             fields = getattr(config, "model_fields", None)
             exclude = getattr(config, "model_exclude", None)
             optional_fields = getattr(config, "model_fields_optional", None)
+            is_blank_nullable = getattr(config, "is_blank_nullable", True)
 
             warnings.warn(
                 "The use of `Config` class is deprecated for ModelSchema, use 'Meta' instead",
@@ -62,6 +65,7 @@ class MetaConf:
             fields=fields,
             exclude=exclude,
             fields_optional=optional_fields,
+            is_blank_nullable=is_blank_nullable,
         )
 
 
@@ -109,6 +113,7 @@ class ModelSchemaMetaclass(ResolverMetaclass):
                     fields=meta_conf.fields,
                     exclude=meta_conf.exclude,
                     optional_fields=meta_conf.fields_optional,
+                    is_blank_nullable=meta_conf.is_blank_nullable,
                     custom_fields=custom_fields,
                     base_class=cls,
                 )

--- a/tests/test_orm_metaclass.py
+++ b/tests/test_orm_metaclass.py
@@ -192,6 +192,13 @@ def test_blank_nullable():
             fields = "__all__"
             fields_optional = ["field5"]
 
+    class BlankTestSchema2(ModelSchema):
+        class Meta:
+            model = BlankTestModel
+            fields = "__all__"
+            fields_optional = ["field5"]
+            is_blank_nullable = False
+
     assert BlankTestSchema1.json_schema() == {
         "title": "BlankTestSchema1",
         "type": "object",
@@ -216,6 +223,29 @@ def test_blank_nullable():
             },
         },
         "required": ["field2"],
+    }
+
+    assert BlankTestSchema2.json_schema() == {
+        "title": "BlankTestSchema2",
+        "type": "object",
+        "properties": {
+            "id": {"title": "ID", "anyOf": [{"type": "integer"}, {"type": "null"}]},
+            "field1": {"title": "Field1", "type": "string"},
+            "field2": {"title": "Field2", "type": "integer"},
+            "field3": {
+                "title": "Field3",
+                "anyOf": [{"type": "string", "format": "date"}, {"type": "null"}],
+            },
+            "field4": {
+                "title": "Field4",
+                "anyOf": [{"type": "string"}, {"type": "null"}],
+            },
+            "field5": {
+                "title": "Field5",
+                "anyOf": [{"type": "boolean"}, {"type": "null"}],
+            },
+        },
+        "required": ["field1", "field2"],
     }
 
 

--- a/tests/test_orm_metaclass.py
+++ b/tests/test_orm_metaclass.py
@@ -175,6 +175,50 @@ def test_fields_all():
     }
 
 
+def test_blank_nullable():
+    class BlankTestModel(models.Model):
+        field1 = models.CharField(blank=True, null=False)
+        field2 = models.IntegerField(blank=False)
+        field3 = models.DateField(blank=True, null=True)
+        field4 = models.FileField(blank=False, null=True)
+        field5 = models.BooleanField(blank=True, null=False)
+
+        class Meta:
+            app_label = "tests"
+
+    class BlankTestSchema1(ModelSchema):
+        class Meta:
+            model = BlankTestModel
+            fields = "__all__"
+            fields_optional = ["field5"]
+
+    assert BlankTestSchema1.json_schema() == {
+        "title": "BlankTestSchema1",
+        "type": "object",
+        "properties": {
+            "id": {"title": "ID", "anyOf": [{"type": "integer"}, {"type": "null"}]},
+            "field1": {
+                "title": "Field1",
+                "anyOf": [{"type": "string"}, {"type": "null"}],
+            },
+            "field2": {"title": "Field2", "type": "integer"},
+            "field3": {
+                "title": "Field3",
+                "anyOf": [{"type": "string", "format": "date"}, {"type": "null"}],
+            },
+            "field4": {
+                "title": "Field4",
+                "anyOf": [{"type": "string"}, {"type": "null"}],
+            },
+            "field5": {
+                "title": "Field5",
+                "anyOf": [{"type": "boolean"}, {"type": "null"}],
+            },
+        },
+        "required": ["field2"],
+    }
+
+
 def test_model_schema_without_config():
     with pytest.raises(
         ConfigError,


### PR DESCRIPTION
# Summary
This is related to #1446. I added an option (is_blank_nullable) as an attribute to ModelSchema, which will be used to determine whether a blank value is considered when deciding a field's nullability.

I have taken compatibility with previous implementations into consideration. The default behavior remains unchanged unless is_blank_nullable is explicitly set to False.

To ensure compatibility, I first added tests that check the current behavior in the first commit. Then, in the second commit, I introduced the new option.

# Note
I read CONTRIBUTING.md and run the commands (make test, make lint, etc.), but make test-cov is failed. It seems to has been already failed from previous release, so I ignored for now. Off course, the coverage of the new parts of this PR is checked.

I'll be glad to have any suggestions. If there are many points that should be considered and fixed, I can remake this PR anew.

Thanks,