### PR TITLE
Add blank_nullable option to Model Schema

### DIFF
--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -41,6 +41,7 @@ class SchemaFactory:
         fields: Optional[List[str]] = None,
         exclude: Optional[List[str]] = None,
         optional_fields: Optional[List[str]] = None,
+        blank_nullable: bool = True,
         custom_fields: Optional[List[Tuple[str, Any, Any]]] = None,
         base_class: Type[Schema] = Schema,
     ) -> Type[Schema]:
@@ -66,6 +67,7 @@ class SchemaFactory:
                 fld,
                 depth=depth,
                 optional=optional_fields and (fld.name in optional_fields),
+                blank_nullable=blank_nullable,
             )
             definitions[fld.name] = (python_type, field_info)
 

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -115,7 +115,11 @@ def create_m2m_link_type(type_: Type[TModel]) -> Type[TModel]:
 
 @no_type_check
 def get_schema_field(
-    field: DjangoField, *, depth: int = 0, optional: bool = False
+    field: DjangoField,
+    *,
+    depth: int = 0,
+    optional: bool = False,
+    blank_nullable: bool = True,
 ) -> Tuple:
     "Returns pydantic field from django's model field"
     alias = None
@@ -163,7 +167,7 @@ def get_schema_field(
             ]
             raise ConfigError("\n".join(msg)) from e
 
-        if field.primary_key or blank or null or optional:
+        if field.primary_key or (blank_nullable and blank) or null or optional:
             default = None
             nullable = True
 

--- a/ninja/orm/metaclass.py
+++ b/ninja/orm/metaclass.py
@@ -17,6 +17,7 @@ class MetaConf:
     fields: Optional[List[str]] = None
     exclude: Union[List[str], str, None] = None
     fields_optional: Union[List[str], str, None] = None
+    blank_nullable: bool = True
 
     @staticmethod
     def from_schema_class(name: str, namespace: dict) -> "MetaConf":
@@ -26,6 +27,7 @@ class MetaConf:
             fields = getattr(meta, "fields", None)
             exclude = getattr(meta, "exclude", None)
             optional_fields = getattr(meta, "fields_optional", None)
+            blank_nullable = getattr(meta, "blank_nullable", True)
 
         elif "Config" in namespace:
             config = namespace["Config"]
@@ -33,6 +35,7 @@ class MetaConf:
             fields = getattr(config, "model_fields", None)
             exclude = getattr(config, "model_exclude", None)
             optional_fields = getattr(config, "model_fields_optional", None)
+            blank_nullable = getattr(config, "blank_nullable", True)
 
             warnings.warn(
                 "The use of `Config` class is deprecated for ModelSchema, use 'Meta' instead",
@@ -62,6 +65,7 @@ class MetaConf:
             fields=fields,
             exclude=exclude,
             fields_optional=optional_fields,
+            blank_nullable=blank_nullable,
         )
 
 
@@ -109,6 +113,7 @@ class ModelSchemaMetaclass(ResolverMetaclass):
                     fields=meta_conf.fields,
                     exclude=meta_conf.exclude,
                     optional_fields=meta_conf.fields_optional,
+                    blank_nullable=meta_conf.blank_nullable,
                     custom_fields=custom_fields,
                     base_class=cls,
                 )

--- a/tests/test_orm_metaclass.py
+++ b/tests/test_orm_metaclass.py
@@ -175,6 +175,50 @@ def test_fields_all():
     }
 
 
+def test_blank_nullable():
+    class BlankTestModel(models.Model):
+        field1 = models.CharField(blank=True, null=False)
+        field2 = models.IntegerField(blank=False, null=False)
+        field3 = models.DateField(blank=True, null=True)
+        field4 = models.FileField(blank=False, null=True)
+        field5 = models.TextField(blank=False, null=False)
+
+        class Meta:
+            app_label = "tests"
+
+    class BlankTestSchema1(ModelSchema):
+        class Meta:
+            model = BlankTestModel
+            fields = "__all__"
+            fields_optional = ["field5"]
+
+    assert BlankTestSchema1.json_schema() == {
+        "title": "BlankTestSchema1",
+        "type": "object",
+        "properties": {
+            "id": {"title": "ID", "anyOf": [{"type": "integer"}, {"type": "null"}]},
+            "field1": {
+                "title": "Field1",
+                "anyOf": [{"type": "string"}, {"type": "null"}],
+            },
+            "field2": {"title": "Field2", "type": "integer"},
+            "field3": {
+                "title": "Field3",
+                "anyOf": [{"type": "string", "format": "date"}, {"type": "null"}],
+            },
+            "field4": {
+                "title": "Field4",
+                "anyOf": [{"type": "string"}, {"type": "null"}],
+            },
+            "field5": {
+                "title": "Field5",
+                "anyOf": [{"type": "string"}, {"type": "null"}],
+            },
+        },
+        "required": ["field2"],
+    }
+
+
 def test_model_schema_without_config():
     with pytest.raises(
         ConfigError,

--- a/tests/test_orm_metaclass.py
+++ b/tests/test_orm_metaclass.py
@@ -192,6 +192,13 @@ def test_blank_nullable():
             fields = "__all__"
             fields_optional = ["field5"]
 
+    class BlankTestSchema2(ModelSchema):
+        class Meta:
+            model = BlankTestModel
+            fields = "__all__"
+            fields_optional = ["field5"]
+            blank_nullable = False
+
     assert BlankTestSchema1.json_schema() == {
         "title": "BlankTestSchema1",
         "type": "object",
@@ -216,6 +223,29 @@ def test_blank_nullable():
             },
         },
         "required": ["field2"],
+    }
+
+    assert BlankTestSchema2.json_schema() == {
+        "title": "BlankTestSchema2",
+        "type": "object",
+        "properties": {
+            "id": {"title": "ID", "anyOf": [{"type": "integer"}, {"type": "null"}]},
+            "field1": {"title": "Field1", "type": "string"},
+            "field2": {"title": "Field2", "type": "integer"},
+            "field3": {
+                "title": "Field3",
+                "anyOf": [{"type": "string", "format": "date"}, {"type": "null"}],
+            },
+            "field4": {
+                "title": "Field4",
+                "anyOf": [{"type": "string"}, {"type": "null"}],
+            },
+            "field5": {
+                "title": "Field5",
+                "anyOf": [{"type": "string"}, {"type": "null"}],
+            },
+        },
+        "required": ["field1", "field2"],
     }
 
 


### PR DESCRIPTION
# Summary
Added the blank_nullable option to ModelSchema. The option specifies whether the original Django field's blank option is used to decide nullability.

This is related to the issue #1446. I withdrew the similar PR #1447 once but I thought it was appropriate, so I make this PR again.

By default, this option is True and doesn't change the current behavior considering the compatibility.

# Background
Currently, the ModelSchema field generated from a Django field with blank=True is treated as nullable. In this case, the ModelSchema field accept null but Django Model field with null=False may not accept it.

This issue primarily occurs with string-based fields because they have the pattern of blank=True and null=False as one of the general patterns. The pattern is mentioned at null and blank sections in [Django Model field Reference](https://docs.djangoproject.com/en/5.2/ref/models/fields/).

The null option of Django field is purely database-related according to the above reference. JSON can explicitly express null unlike the action with application/x-www-form-urlencoded content-type. I think as an option it would be good if ModelSchema could simply look only at the original Django field's null option because ModelSchema is literally generated from Model.

# Other implementation
I thought of other implementations as bellow.
- An similar option only for string-based field. But, the issue occurs not only with string-based field and this implementation will be a little complicated, so I think the option for all kinds of field is better.
- An change that can get to treat the Django blank option as required property of OpenAPI schema. I think the pattern of blank=True and null=False can be interpreted as "null cannot be used, but unspecifying is OK". Currently, nullable and required property of OpenAPI schema by django-ninja seem to be linked, meaning a field is required when a field is not nullable. But the behavior depends on Pydantic's base_model.model_json_schema() and changing it seems to be complicated.
- An option to set default string to string-based fields. I think this is also limited and not appropriate.

# About DRF
In Django Rest Framework, ModelSerializer convert blank and null option on a field of its original Django Model to allow_blank which decides to allow "" or not and allow_null which decides to allow null on its Serializer field.

So I think the users migrating their projects from DRF may also set blank=True and null=False to Django Model and have the same issue.