### PR TITLE
Fix OpenAPI schema with serialization_alias

### DIFF
--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -218,6 +218,7 @@ class OpenAPISchema(dict):
                 ref_template=REF_TEMPLATE,
                 by_alias=by_alias,
                 schema_generator=NinjaGenerateJsonSchema,
+                **(dict(mode='serialization') if by_alias else {})
             ).copy()
 
         # move Schemas from definitions


### PR DESCRIPTION
Fixes #1328 <!-- Needed for GitHub to link the issue to the PR -->

## Fix OpenAPI schema with serialization_alias
Fixed OpenAPI schema generation to properly handle `serialization_alias` in Field definitions when `by_alias=True`. 

- Added mode=&#39;serialization&#39; parameter when generating schema with `by_alias=True` to ensure aliases are respected
- This matches the behavior already seen in response serialization, making the API documentation consistent with actual response

Fixes inconsistency where schema showed original field names while responses used aliases for fields with `serialization_alias`.

---

This change was produced by **Harry Patcher** 🧙‍♂️, an autonomous & anonymous AI engineering agent. No human was involved in creating this pull request.

Learn more about Harry Patcher and how he came up with this fix [here](https://harry-patcher.ai/viewer?url=aHR0cHM6Ly9naXN0LmdpdGh1YnVzZXJjb250ZW50LmNvbS9oYXJyeS1wYXRjaGVyL2JjODEwZGIzZjc4Mjk4M2M3NDYyMjA5ZjI0M2U4ZDk0L3Jhdy9mNmRlNDFjOGQxMTlkZTBiNWEyZmIwMjc5YjZiMzZkYWY5MDg3NGRjL3N3ZWJlbmNoX3ZpdGFsaWtfX2RqYW5nby1uaW5qYS0xMzI4Lmpzb24) 🔍.

Harry cannot yet respond to review feedback. If the patch isn’t relevant, reject the PR and optionally [let us know](https://forms.office.com/Pages/ResponsePage.aspx?id=UjyyTqXzvEm1VQsGEmephKlyfnndRsBKt5Fmxu7iHWpUMEdIRzFTUU9LNkxYMDZWQlZWT0gwSFJUTCQlQCN0PWcu&r1e8e3930f96f400aa91b5105dbd09b7d=&rb85bea8de07843f9835f9d001f689f4c=&r034de175aef248b29aaf36f2a5e92912=&r9e0cc5d7ff8b484e81eb97531d4cefd7=) 📬.