### PR TITLE
Update CI and packaging for Django 5.2 and Python 3.13 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install Flit
-        run: pip install flit "django>=5.0"
+        run: pip install flit "django>=5.1"
       - name: Install Dependencies
         run: flit install --symlink
       - name: Test

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-        django-version: ['<3.2', '<3.3', '<4.2', '<4.3', '<5.1', '<5.2']
+        django-version: ['<3.2', '<3.3', '<4.2', '<4.3', '<5.1', '<5.2', '<5.3']
         exclude:
           - python-version: '3.7'
             django-version: '<5.1'
@@ -51,7 +51,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install Flit
-        run: pip install flit "django>=5.0"
+        run: pip install flit "django>=5.2"
       - name: Install Dependencies
         run: flit install --symlink
       - name: Test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Framework :: Django",
     "Framework :: Django :: 3.1",
@@ -37,12 +38,13 @@ classifiers = [
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Framework :: AsyncIO",
     "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
     "Topic :: Internet :: WWW/HTTP",
 ]
 
-requires = ["Django >=3.1", "pydantic >=2.0,<3.0.0"]
+requires = ["Django >=3.1, <6.0", "pydantic >=2.0,<3.0.0"]
 description-file = "README.md"
 requires-python = ">=3.7"
 


### PR DESCRIPTION
## Description

This PR adds support for Django 5.2 and Python 3.13:

- Updated GitHub Actions test matrix:
  - Added Python 3.13
  - Added Django `<5.3`
- Set default installed Django version to `>=5.2` in CI workflows
- Updated `pyproject.toml`:
  - Added Python 3.13 and Django 5.2 to classifiers
  - Set Django version range to `>=3.1, <6.0`

Keeps the project up to date with the latest stable versions of Python and Django.
