### PR TITLE
support schema union in query

### DIFF
--- a/tests/test_discriminator.py
+++ b/tests/test_discriminator.py
@@ -3,7 +3,7 @@ from typing import Union
 from pydantic import Field
 from typing_extensions import Annotated, Literal
 
-from ninja import NinjaAPI, Schema
+from ninja import NinjaAPI, Query, Schema
 from ninja.testing import TestClient
 
 
@@ -37,21 +37,43 @@ def create_example_regular(request, payload: RegularUnion):
     return {"data": payload.model_dump(), "type": payload.__class__.__name__}
 
 
+@api.get("/descr-union")
+def get_example(request, payload: UnionDiscriminator = Query(...)):
+    return {}
+
+
+@api.get("/regular-union")
+def get_example_regular(request, payload: RegularUnion = Query(...)):
+    return {}
+
+
 client = TestClient(api)
 
 
 def test_schema():
     schema = api.get_openapi_schema()
-    detail1 = schema["paths"]["/api/descr-union"]["post"]["requestBody"]["content"][
-        "application/json"
-    ]["schema"]
-    detail2 = schema["paths"]["/api/regular-union"]["post"]["requestBody"]["content"][
-        "application/json"
-    ]["schema"]
+    post_detail1 = schema["paths"]["/api/descr-union"]["post"]["requestBody"][
+        "content"
+    ]["application/json"]["schema"]
+    post_detail2 = schema["paths"]["/api/regular-union"]["post"]["requestBody"][
+        "content"
+    ]["application/json"]["schema"]
+    get_detail1 = schema["paths"]["/api/descr-union"]["get"]["parameters"][0]["schema"]
+    get_detail2 = schema["paths"]["/api/regular-union"]["get"]["parameters"][0][
+        "schema"
+    ]
 
     # First method should have 'discriminator' in OpenAPI api
-    assert "discriminator" in detail1
-    assert detail1["discriminator"] == {
+    assert "discriminator" in post_detail1
+    assert "discriminator" in get_detail1
+    assert post_detail1["discriminator"] == {
+        "mapping": {
+            "ONE": "#/components/schemas/Example1",
+            "TWO": "#/components/schemas/Example2",
+        },
+        "propertyName": "label",
+    }
+    assert get_detail1["discriminator"] == {
         "mapping": {
             "ONE": "#/components/schemas/Example1",
             "TWO": "#/components/schemas/Example2",
@@ -60,7 +82,8 @@ def test_schema():
     }
 
     # Second method should NOT have 'discriminator'
-    assert "discriminator" not in detail2
+    assert "discriminator" not in post_detail2
+    assert "discriminator" not in get_detail2
 
 
 def test_annotated_union_with_discriminator():
@@ -108,3 +131,34 @@ def test_regular_union():
         "data": {"label": "TWO", "value": 123},
         "type": "Example2",
     }
+
+
+def test_annotated_union_with_discriminator_get():
+    # Test Example1
+    response = client.get(
+        "/descr-union",
+        query_params={"label": "ONE", "value": "42"},
+    )
+    assert response.status_code == 200
+
+    # Test Example2
+    response = client.get(
+        "/descr-union",
+        query_params={"label": "TWO", "value": "42"},
+    )
+    assert response.status_code == 200
+
+
+def test_regular_union_get():
+    # Test that regular unions still work
+    response = client.get(
+        "/regular-union",
+        query_params={"label": "ONE", "value": "2025"},
+    )
+    assert response.status_code == 200
+
+    response = client.get(
+        "/regular-union",
+        query_params={"label": "TWO", "value": 123},
+    )
+    assert response.status_code == 200


### PR DESCRIPTION
Allows query parameters to be defined as the union of schemas. For example:

```python
class Rect(Schema):
    type: Literal["RECT"]
    width: float
    height: float

class Circle(Schema):
    type: Literal["CIRCLE"]
    redius: float
    x_center: float
    y_center: float

class QueryParams(Schema):
    q: Annotated[Rect | Circle, Field(discriminator="type")]

@api.get("/")
def handler(request, query: QueryParams = Query(...)):
    pass
```

