### PR TITLE
Add type annotations for `request` in `paginate_queryset`

### DIFF
--- a/docs/docs/guides/response/pagination.md
+++ b/docs/docs/guides/response/pagination.md
@@ -118,6 +118,7 @@ To create a custom pagination class you should subclass `ninja.pagination.Pagina
 Example:
 
 ```python hl_lines="7 11 16 26"
+from django.http import HttpRequest
 from ninja.pagination import paginate, PaginationBase
 from ninja import Schema
 
@@ -133,7 +134,7 @@ class CustomPagination(PaginationBase):
         total: int
         per_page: int
 
-    def paginate_queryset(self, queryset, pagination: Input, **params):
+    def paginate_queryset(self, queryset, *, pagination: Input, request: HttpRequest, **params):
         skip = pagination.skip
         return {
             'items': queryset[skip : skip + 5],
@@ -146,13 +147,6 @@ class CustomPagination(PaginationBase):
 @paginate(CustomPagination)
 def list_users(request):
     return User.objects.all()
-```
-
-Tip: You can access request object from params:
-
-```python
-def paginate_queryset(self, queryset, pagination: Input, **params):
-    request = params["request"]
 ```
 
 #### Async Pagination

--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -41,7 +41,9 @@ class PaginationBase(ABC):
     def paginate_queryset(
         self,
         queryset: QuerySet,
+        *,
         pagination: Any,
+        request: HttpRequest,
         **params: Any,
     ) -> Any:
         pass  # pragma: no cover
@@ -63,7 +65,9 @@ class AsyncPaginationBase(PaginationBase):
     async def apaginate_queryset(
         self,
         queryset: QuerySet,
+        *,
         pagination: Any,
+        request: HttpRequest,
         **params: Any,
     ) -> Any:
         pass  # pragma: no cover
@@ -91,7 +95,9 @@ class LimitOffsetPagination(AsyncPaginationBase):
     def paginate_queryset(
         self,
         queryset: QuerySet,
+        *,
         pagination: Input,
+        request: HttpRequest,
         **params: Any,
     ) -> Any:
         offset = pagination.offset
@@ -104,7 +110,9 @@ class LimitOffsetPagination(AsyncPaginationBase):
     async def apaginate_queryset(
         self,
         queryset: QuerySet,
+        *,
         pagination: Input,
+        request: HttpRequest,
         **params: Any,
     ) -> Any:
         offset = pagination.offset
@@ -143,7 +151,9 @@ class PageNumberPagination(AsyncPaginationBase):
     def paginate_queryset(
         self,
         queryset: QuerySet,
+        *,
         pagination: Input,
+        request: HttpRequest,
         **params: Any,
     ) -> Any:
         page_size = self._get_page_size(pagination.page_size)
@@ -156,7 +166,9 @@ class PageNumberPagination(AsyncPaginationBase):
     async def apaginate_queryset(
         self,
         queryset: QuerySet,
+        *,
         pagination: Input,
+        request: HttpRequest,
         **params: Any,
     ) -> Any:
         page_size = self._get_page_size(pagination.page_size)

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -926,7 +926,7 @@ def test_no_default_for_custom_items_attribute():
 
         items_attribute: str = "data"
 
-        def paginate_queryset(self, queryset, pagination, **params):
+        def paginate_queryset(self, queryset, *, pagination, request, **params):
             pass
 
     @api.get(

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -3,6 +3,7 @@ from sys import version_info
 from typing import Any, List
 
 import pytest
+from django.http import HttpRequest
 from django.test import override_settings
 from pydantic.errors import PydanticSchemaGenerationError
 
@@ -34,6 +35,7 @@ class CustomPagination(PaginationBase):
         count: str
         skip: int
 
+    # Explicitly exclude "request", as the previous signature didn't guarantee it
     def paginate_queryset(self, items, pagination: Input, **params):
         skip = pagination.skip
         return {
@@ -50,7 +52,7 @@ class NoOutputPagination(PaginationBase):
 
     Output = None
 
-    def paginate_queryset(self, items, pagination: Input, **params):
+    def paginate_queryset(self, items, *, pagination: Input, request: HttpRequest, **params):
         skip = pagination.skip
         return items[skip : skip + 5]
 
@@ -68,7 +70,7 @@ class ResultsPaginator(PaginationBase):
 
     items_attribute: str = "results"
 
-    def paginate_queryset(self, items, pagination: Input, **params):
+    def paginate_queryset(self, items, *, pagination: Input, request: HttpRequest, **params):
         skip = pagination.skip
         return {
             "results": items[skip : skip + 5],
@@ -87,7 +89,7 @@ class NextPrevPagination(PaginationBase):
         next: str = None
         prev: str = None
 
-    def paginate_queryset(self, items, pagination: Input, request, **params):
+    def paginate_queryset(self, items, *, pagination: Input, request: HttpRequest, **params):
         skip = pagination.skip
         prev_skip = skip - 5
         if prev_skip < 0:

--- a/tests/test_pagination_async.py
+++ b/tests/test_pagination_async.py
@@ -3,6 +3,7 @@ from typing import Any, List
 
 import django
 import pytest
+from django.http import HttpRequest
 from django.db.models import QuerySet
 from someapp.models import Category
 
@@ -31,7 +32,7 @@ class NoAsyncPagination(PaginationBase):
         count: str
         skip: int
 
-    def paginate_queryset(self, items, pagination: Input, **params):
+    def paginate_queryset(self, items, *, pagination: Input, request: HttpRequest, **params):
         skip = pagination.skip
         return {
             "items": items[skip : skip + 5],
@@ -47,7 +48,7 @@ class AsyncNoOutputPagination(AsyncPaginationBase):
 
     Output = None
 
-    def paginate_queryset(self, items, pagination: Input, **params):
+    def paginate_queryset(self, items, *, pagination: Input, request: HttpRequest, **params):
         skip = pagination.skip
         return items[skip : skip + 5]
 


### PR DESCRIPTION
This updates the docs and internal code to expect that `request` is always available, which now allows downstreams to rely on this fact.

This is fully backwards-compatible with existing code which does not explicitly expect a `request` argument to `paginate_queryset`; since `request` is annotated (and invoked) as keyword-only, it will always be captured in `**params` as a fallback.

The test case with `CustomPagination` now explicitly tests this backwards-compatibility by using the old-style signature.