### PR TITLE
Use json_schema_extra to add FilterSchema options to Field

### DIFF
--- a/docs/docs/guides/input/filtering.md
+++ b/docs/docs/guides/input/filtering.md
@@ -22,7 +22,7 @@ class BookFilterSchema(FilterSchema):
 Next, use this schema in conjunction with `Query` in your API handler:
 ```python hl_lines="2"
 @api.get("/books")
-def list_books(request, filters: BookFilterSchema = Query(...)):
+def list_books(request, filters: Query[BookFilterSchema]):
     books = Book.objects.all()
     books = filters.filter(books)
     return books
@@ -34,7 +34,7 @@ defined in `BookFilterSchema` into query parameters.
 You can use a shorthand one-liner `.filter()` to apply those filters to your queryset:
 ```python hl_lines="4"
 @api.get("/books")
-def list_books(request, filters: BookFilterSchema = Query(...)):
+def list_books(request, filters: Query[BookFilterSchema]):
     books = Book.objects.all()
     books = filters.filter(books)
     return books
@@ -47,7 +47,7 @@ Alternatively to using the `.filter` method, you can get the prepared `Q`-expres
 That can be useful, when you have some additional queryset filtering on top of what you expose to the user through the API:
 ```python hl_lines="5 8"
 @api.get("/books")
-def list_books(request, filters: BookFilterSchema = Query(...)):
+def list_books(request, filters: Query[BookFilterSchema]):
 
     # Never serve books from inactive publishers and authors
     q = Q(author__is_active=True) | Q(publisher__is_active=True)
@@ -75,18 +75,18 @@ The `name` field will be converted into `Q(name=...)` expression.
 When your database lookups are more complicated than that, you can explicitly specify them in the field definition using a `"q"` kwarg:
 ```python hl_lines="2"
 class BookFilterSchema(FilterSchema):
-    name: Optional[str] = Field(None, q='name__icontains')
+    name: Optional[str] = Field(None, json_schema_extra={'q': 'name__icontains'})
 ```
 You can even specify multiple lookup keyword argument names as a list:
 ```python hl_lines="2 3 4"
 class BookFilterSchema(FilterSchema):
-    search: Optional[str] = Field(None, q=['name__icontains',
-                                     'author__name__icontains',
-                                     'publisher__name__icontains'])
+    search: Optional[str] = Field(None, json_schema_extra={'q': ['name__icontains',
+                                                                 'author__name__icontains',
+                                                                 'publisher__name__icontains']})
 ```
 And to make generic fields, you can make the field name implicit by skipping it:
 ```python hl_lines="2"
-IContainsField = Annotated[Optional[str], Field(None, q='__icontains')]
+IContainsField = Annotated[Optional[str], Field(None, json_schema_extra={'q': '__icontains'})]
 
 class BookFilterSchema(FilterSchema):
     name: IContainsField
@@ -103,7 +103,7 @@ By default,
 So, with the following `FilterSchema`...
 ```python
 class BookFilterSchema(FilterSchema):
-    search: Optional[str] = Field(None, q=['name__icontains', 'author__name__icontains'])
+    search: Optional[str] = Field(None, json_schema_extra={'q': ['name__icontains', 'author__name__icontains']})
     popular: Optional[bool] = None
 ```
 ...and the following query parameters from the user
@@ -116,9 +116,14 @@ the `FilterSchema` instance will look for popular books that have `harry` in the
 You can customize this behavior using an `expression_connector` argument in field-level and class-level definition:
 ```python hl_lines="3 7"
 class BookFilterSchema(FilterSchema):
-    active: Optional[bool] = Field(None, q=['is_active', 'publisher__is_active'],
-                                   expression_connector='AND')
-    name: Optional[str] = Field(None, q='name__icontains')
+    active: Optional[bool] = Field(
+        None,
+        json_schema_extra={
+            'q': ['is_active', 'publisher__is_active'],
+            'expression_connector': 'AND',
+        }
+    )
+    name: Optional[str] = Field(None, json_schema_extra={'q': 'name__icontains'})
     
     class Config:
         expression_connector = 'OR'
@@ -139,8 +144,8 @@ You can make the `FilterSchema` treat `None` as a valid value that should be fil
 This can be done on a field level with a `ignore_none` kwarg:
 ```python hl_lines="3"
 class BookFilterSchema(FilterSchema):
-    name: Optional[str] = Field(None, q='name__icontains')
-    tag: Optional[str] = Field(None, q='tag', ignore_none=False)
+    name: Optional[str] = Field(None, json_schema_extra={'q': 'name__icontains'})
+    tag: Optional[str] = Field(None, json_schema_extra={'ignore_none': False, 'q': 'tag'})
 ```
 
 This way when no other value for `"tag"` is provided by the user, the filtering will always include a condition `tag=None`.
@@ -148,8 +153,8 @@ This way when no other value for `"tag"` is provided by the user, the filtering 
 You can also specify this settings for all fields at the same time in the Config:
 ```python hl_lines="6"
 class BookFilterSchema(FilterSchema):
-    name: Optional[str] = Field(None, q='name__icontains')
-    tag: Optional[str] = Field(None, q='tag', ignore_none=False)
+    name: Optional[str] = Field(None, json_schema_extra={'q': 'name__icontains'})
+    tag: Optional[str] = Field(None, json_schema_extra={'q': 'tag'})
     
     class Config:
         ignore_none = False


### PR DESCRIPTION
As documented in https://github.com/vitalik/django-ninja/issues/1335, Pydantic is restricting use of additional parameters to `Field`. See https://docs.pydantic.dev/2.9/migration/#changes-to-pydanticfield for more details.

Move `q` and `ignore_none` into `json_extra_schema` as dictionary arguments.

Also, `Query(...)` does not get along with type checkers so refresh to use the v1 `Query[]` style to be consistent.