### PR TITLE
pass-through for Schema-based results

### DIFF
--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -275,26 +275,33 @@ class Operation:
             # Empty response.
             return temporal_response
 
-        resp_object = ResponseObject(result)
-        # ^ we need object because getter_dict seems work only with model_validate
-        validated_object = response_model.model_validate(
-            resp_object, context={"request": request, "response_status": status}
+        model_dump_kwargs: Dict[str, Any] = dict(
+            by_alias=self.by_alias,
+            exclude_unset=self.exclude_unset,
+            exclude_defaults=self.exclude_defaults,
+            exclude_none=self.exclude_none,
         )
-
-        model_dump_kwargs: Dict[str, Any] = {}
         if pydantic_version >= [2, 7]:
             # pydantic added support for serialization context at 2.7
             model_dump_kwargs.update(
                 context={"request": request, "response_status": status}
             )
 
-        result = validated_object.model_dump(
-            by_alias=self.by_alias,
-            exclude_unset=self.exclude_unset,
-            exclude_defaults=self.exclude_defaults,
-            exclude_none=self.exclude_none,
-            **model_dump_kwargs,
-        )["response"]
+        if isinstance(result, Schema):
+            # if the result is already a Schema, just return it
+            return self.api.create_response(
+                request,
+                result.model_dump(**model_dump_kwargs),
+                temporal_response=temporal_response,
+            )
+
+        resp_object = ResponseObject(result)
+        # ^ we need object because getter_dict seems work only with model_validate
+        validated_object = response_model.model_validate(
+            resp_object, context={"request": request, "response_status": status}
+        )
+
+        result = validated_object.model_dump(**model_dump_kwargs)["response"]
         return self.api.create_response(
             request, result, temporal_response=temporal_response
         )


### PR DESCRIPTION
When the response-parameter is filled and the result is already a Schema we don't need to verify it again.


Brief reasoning for the situation:
Wagtail has a [new guide how to integrate Ninja](based on https://docs.wagtail.org/en/v7.0/advanced_topics/api/django-ninja.html).
In it they use this
```python
@api.get("/pages/{page_id}/", response=BlogPageSchema | HomePageSchema)
def get_page(request: "HttpRequest", page_id: int):
    return get_object_or_404(Page, id=page_id).specific
```

This works but has its issues since basically the returned Page type (the django Model) is tried to be fitted against all different `response`-Schemata. Obviously that's a performance issue but it brings other problems too, which I dont want to go too deep into.

So my solution would be:
```python
@api.get("/pages/{page_id}/", response=BlogPageSchema | HomePageSchema)
def get_page(request: "HttpRequest", page_id: int):
    page = get_object_or_404(Page, id=page_id).specific
    if isinstance(page,BlogPage):
        return BlogPageSchema.from_orm(page,context={"request":request})
    return HomePageSchema.from_orm(page,context={"request":request})
```

this does currently not work, because the result is being re-parsed, because I have `response` set in the decorator. Obviously I could remove that but then I'd lose the types.

This PR allows Schemas to be directly returned, assuming that the validation already has happened.


Thanks so much