### PR TITLE
Add _ninja_ignore_args support for dependency injection

### DIFF
--- a/ninja/signature/details.py
+++ b/ninja/signature/details.py
@@ -52,11 +52,19 @@ class ViewSignature:
         self.has_kwargs = False
 
         self.params = []
+
+        # Get list of arguments to ignore if _ninja_ignore_args is set
+        ignore_args = getattr(view_func, "_ninja_ignore_args", [])
+
         for name, arg in self.signature.parameters.items():
             if name == "request":
                 # TODO: maybe better assert that 1st param is request or check by type?
                 # maybe even have attribute like `has_request`
                 # so that users can ignore passing request if not needed
+                continue
+
+            if name in ignore_args:
+                # Skip arguments that should be ignored
                 continue
 
             if arg.kind == arg.VAR_KEYWORD:

--- a/ninja/utils.py
+++ b/ninja/utils.py
@@ -10,6 +10,7 @@ __all__ = [
     "is_debug_server",
     "normalize_path",
     "contribute_operation_callback",
+    "ignore_args",
 ]
 
 
@@ -71,3 +72,9 @@ def contribute_operation_args(
     if not hasattr(func, "_ninja_contribute_args"):
         func._ninja_contribute_args = []  # type: ignore
     func._ninja_contribute_args.append((arg_name, arg_type, arg_source))  # type: ignore
+
+
+def ignore_args(func: Callable[..., Any], *arg_names: str) -> None:
+    if not hasattr(func, "_ninja_ignore_args"):
+        func._ninja_ignore_args = []  # type: ignore
+    func._ninja_ignore_args.extend(arg_names)  # type: ignore

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -59,3 +59,51 @@ def test_decorator_multiple():
     assert response.status_code == 200
     assert response.json() == {"count": 4, "items": [1, 2, 3, 4]}
     assert response["X-Decorator"] == "some_decorator"
+
+
+class DependencyService:
+    def get_data(self):
+        return "injected_data"
+
+
+def inject_dependency(view_func):
+    @wraps(view_func)
+    def wrapper(request, *args, **kwargs):
+        kwargs["injected_service"] = DependencyService()
+        return view_func(request, *args, **kwargs)
+
+    wrapper._ninja_ignore_args = ["injected_service"]
+    return wrapper
+
+
+def test_ninja_ignore_args_integration():
+    """Integration test for _ninja_ignore_args functionality."""
+    api = NinjaAPI()
+
+    @api.get("/test-ignore/{item_id}")
+    @inject_dependency
+    def test_view(
+        request, item_id: int, query_param: str, injected_service: DependencyService
+    ):
+        data = injected_service.get_data()
+        return {"item_id": item_id, "query_param": query_param, "injected_data": data}
+
+    # Test that the endpoint works correctly
+    client = TestClient(api)
+    response = client.get("/test-ignore/123?query_param=test")
+    assert response.status_code == 200
+    assert response.json() == {
+        "item_id": 123,
+        "query_param": "test",
+        "injected_data": "injected_data",
+    }
+
+    # Test that injected_service is not in the OpenAPI schema
+    schema = api.get_openapi_schema()
+    parameters = schema["paths"]["/api/test-ignore/{item_id}"]["get"]["parameters"]
+
+    # Should have item_id (path) and query_param (query), but not injected_service
+    param_names = [p["name"] for p in parameters]
+    assert "item_id" in param_names
+    assert "query_param" in param_names
+    assert "injected_service" not in param_names


### PR DESCRIPTION
## Summary

Adds support for `_ninja_ignore_args` attribute to enable dependency injection patterns in Django Ninja view functions.

## Problem

When using decorators that inject dependencies as function arguments, Django Ninja tries to process these injected arguments as API parameters, causing them to appear in the OpenAPI schema and parameter validation. This breaks clean dependency injection patterns.

## Solution

- Add `_ninja_ignore_args` attribute support in `ViewSignature` processing
- Arguments listed in this attribute are skipped during signature analysis
- Add `ignore_args()` utility function for convenience
- Maintains full backward compatibility

## Example Usage

```python
def inject_service(func):
    @wraps(func)
    def wrapper(*args, **kwargs):
        kwargs["service"] = MyService()
        return func(*args, **kwargs)
    
    wrapper._ninja_ignore_args = ["service"]
    return wrapper

@api.get("/endpoint")
@inject_service  
def my_view(request, param: str, service: MyService):
    return service.process(param)
```

The `service` parameter is injected by the decorator but ignored by Django Ninja's parameter processing.

## Testing

Added integration test `test_ninja_ignore_args_integration()` that demonstrates the complete flow including dependency injection, runtime functionality, and OpenAPI schema validation.