### PR TITLE
fix: Merge openapi_extra list elements instead of overwrite

### DIFF
--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -99,6 +99,12 @@ class OpenAPISchema(dict):
                 self.deep_dict_update(
                     main_dict[key], update_dict[key]
                 )  # pragma: no cover
+            elif (
+                key in main_dict
+                and isinstance(main_dict[key], list)
+                and isinstance(update_dict[key], list)
+            ):
+                main_dict[key].extend(update_dict[key])
             else:
                 main_dict[key] = update_dict[key]
 


### PR DESCRIPTION
Fixes https://github.com/vitalik/django-ninja/issues/1505

Also helps with similar issues encountered in https://github.com/vitalik/django-ninja/issues/1192 and https://github.com/vitalik/django-ninja/issues/1515.

This ensures that when `openapi_extra` is set on an API route, and the dict contents conflict with a list element already assigned by Ninja's own generation, the list elements are combined.

Previously, whatever Ninja set got overwritten. This meant that in examples like my test case, the path parameter would be missing from the API spec.