### PR TITLE
Have API home redirect to docs

### DIFF
--- a/ninja/openapi/urls.py
+++ b/ninja/openapi/urls.py
@@ -1,4 +1,3 @@
-from functools import partial
 from typing import TYPE_CHECKING, Any, List
 
 from django.urls import path
@@ -15,11 +14,11 @@ def get_openapi_urls(api: "NinjaAPI") -> List[Any]:
     result = []
 
     if api.openapi_url:
-        view = partial(openapi_json, api=api)
+        view = openapi_json
         if api.docs_decorator:
             view = api.docs_decorator(view)  # type: ignore
         result.append(
-            path(api.openapi_url.lstrip("/"), view, name="openapi-json"),
+            path(api.openapi_url.lstrip("/"), view, {"api": api}, name="openapi-json"),
         )
 
         assert (
@@ -27,15 +26,15 @@ def get_openapi_urls(api: "NinjaAPI") -> List[Any]:
         ), "Please use different urls for openapi_url and docs_url"
 
         if api.docs_url:
-            view = partial(openapi_view, api=api)
+            view = openapi_view
             if api.docs_decorator:
                 view = api.docs_decorator(view)  # type: ignore
             result.append(
-                path(api.docs_url.lstrip("/"), view, name="openapi-view"),
+                path(api.docs_url.lstrip("/"), view, {"api": api}, name="openapi-view"),
             )
 
     return result
 
 
 def get_root_url(api: "NinjaAPI") -> Any:
-    return path("", partial(default_home, api=api), name="api-root")
+    return path("", default_home, {"api": api}, name="api-root")

--- a/ninja/openapi/views.py
+++ b/ninja/openapi/views.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any, NoReturn
 
-from django.http import Http404, HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 
 from ninja.openapi.docs import DocsBase
 from ninja.responses import Response
@@ -12,8 +12,7 @@ if TYPE_CHECKING:
 
 def default_home(request: HttpRequest, api: "NinjaAPI", **kwargs: Any) -> NoReturn:
     "This view is mainly needed to determine the full path for API operations"
-    docs_url = f"{request.path}{api.docs_url}".replace("//", "/")
-    raise Http404(f"docs_url = {docs_url}")
+    return HttpResponseRedirect(f"{request.path}{api.docs_url}".replace("//", "/"))
 
 
 def openapi_json(request: HttpRequest, api: "NinjaAPI", **kwargs: Any) -> HttpResponse:


### PR DESCRIPTION
If the API is mounted at `/api`, visiting `/api` results in a 404. In debug, there's a message with the docs url, but not during deployment.

This PR changes the view to redirect to the docs instead. The redirect is intentionally not permanent. 

I've also removed `functools.partial`, and instead pass arguments directly with Django, which makes the stacktraces a little more readable.