### PR TITLE
Add strict_null option for ModelSchema to decide nullability of a field from Django field's null option

### DIFF
--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -41,6 +41,7 @@ class SchemaFactory:
         fields: Optional[List[str]] = None,
         exclude: Optional[List[str]] = None,
         optional_fields: Optional[List[str]] = None,
+        fields_strict_null: bool = False,
         custom_fields: Optional[List[Tuple[str, Any, Any]]] = None,
         base_class: Type[Schema] = Schema,
     ) -> Type[Schema]:
@@ -66,6 +67,7 @@ class SchemaFactory:
                 fld,
                 depth=depth,
                 optional=optional_fields and (fld.name in optional_fields),
+                strict_null=fields_strict_null,
             )
             definitions[fld.name] = (python_type, field_info)
 

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -115,7 +115,11 @@ def create_m2m_link_type(type_: Type[TModel]) -> Type[TModel]:
 
 @no_type_check
 def get_schema_field(
-    field: DjangoField, *, depth: int = 0, optional: bool = False
+    field: DjangoField,
+    *,
+    depth: int = 0,
+    optional: bool = False,
+    strict_null: bool = False,
 ) -> Tuple:
     "Returns pydantic field from django's model field"
     alias = None
@@ -163,7 +167,11 @@ def get_schema_field(
             ]
             raise ConfigError("\n".join(msg)) from e
 
-        if field.primary_key or blank or null or optional:
+        if strict_null:
+            if optional or null:
+                default = None
+                nullable = True
+        elif field.primary_key or blank or null or optional:
             default = None
             nullable = True
 

--- a/ninja/orm/metaclass.py
+++ b/ninja/orm/metaclass.py
@@ -17,6 +17,7 @@ class MetaConf:
     fields: Optional[List[str]] = None
     exclude: Union[List[str], str, None] = None
     fields_optional: Union[List[str], str, None] = None
+    fields_strict_null: bool = False
 
     @staticmethod
     def from_schema_class(name: str, namespace: dict) -> "MetaConf":
@@ -26,6 +27,7 @@ class MetaConf:
             fields = getattr(meta, "fields", None)
             exclude = getattr(meta, "exclude", None)
             optional_fields = getattr(meta, "fields_optional", None)
+            fields_strict_null = getattr(meta, "fields_strict_null", False)
 
         elif "Config" in namespace:
             config = namespace["Config"]
@@ -33,6 +35,7 @@ class MetaConf:
             fields = getattr(config, "model_fields", None)
             exclude = getattr(config, "model_exclude", None)
             optional_fields = getattr(config, "model_fields_optional", None)
+            fields_strict_null = getattr(config, "fields_strict_null", False)
 
             warnings.warn(
                 "The use of `Config` class is deprecated for ModelSchema, use 'Meta' instead",
@@ -62,6 +65,7 @@ class MetaConf:
             fields=fields,
             exclude=exclude,
             fields_optional=optional_fields,
+            fields_strict_null=fields_strict_null,
         )
 
 
@@ -109,6 +113,7 @@ class ModelSchemaMetaclass(ResolverMetaclass):
                     fields=meta_conf.fields,
                     exclude=meta_conf.exclude,
                     optional_fields=meta_conf.fields_optional,
+                    fields_strict_null=meta_conf.fields_strict_null,
                     custom_fields=custom_fields,
                     base_class=cls,
                 )


### PR DESCRIPTION
# Summary
Thank you for this great API framework. It's very useful to develop Django applications with obvious interfaces between frontend and backend.

This PR is for an issue https://github.com/vitalik/django-ninja/issues/1446 I raised about Schema's fields accepting null if their model field's blank option is True.

When this option is set to True, ModelSchema simply decides an field's nullability according to the Django model field's null option. I think this simple option is useful for many users considering the number of thumb up in the https://github.com/vitalik/django-ninja/issues/1446#issuecomment-2800178614

If you have some good ideas, advices or naming,  I'll be happy to know it and improve my PR.

Also, similarly previous PR https://github.com/vitalik/django-ninja/pull/1460 will be closed because I think this PR is better than it (sorry for making similar PR, but I think resolving this issue is useful. Also, this PR will be my last idea).

# What I considered
- For compatibility, the option is set to False by default and will not change current behavior without explicitly setting it to True.
- If a ModelSchema's field is defined with Optional type hint, It's considered as allowing null.
- Primary key isn't considered as allowing null by default for the following reason.
  - In case of describing (GET), id (meaning primary key) isn't probably be null.
  - In case of creating or updating, I think id will not be set in many patterns.

# What I'm facing on (as an example)
I'll share one of the issues I'm facing on due to Django field's blank=True considered as allowing null on Schema. I think some other user may have same issues.

In case of creating or updating, ModelSchema is looser to null than its Model, so an issue 'Schema accepts null but Model denies null' is frequently raised without client considering the background between the schema and the model. If the client side generate API client from the OpenAPI schema automatically, the client may sets null to the field and call the API because literally the field defined as accepting null.

For these issues, we can override the automatically generated fields by ModelSchema, but it takes not a few cost and sometimes makes mistakes (typos etc.). Also, we can fundamentally change the Django's model field's options but I think it's not easy.

Thanks, 