### PR TITLE
Added courses section within Other Tutorials section of docs

### DIFF
--- a/docs/docs/tutorial/other/course.md
+++ b/docs/docs/tutorial/other/course.md
@@ -1,0 +1,7 @@
+# Courses
+
+## REST API Design with Python and Django Ninja
+
+[codeling.dev/courses/rest-api-design/](https://codeling.dev/courses/rest-api-design/)
+
+Learn how to create a full featured API from scratch using Django Ninja.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
       - Other Tutorials:
           - tutorial/other/video.md
           - tutorial/other/crud.md
+          - tutorial/other/course.md
   - How-to Guides:
       - Parsing input:
           - guides/input/operations.md


### PR DESCRIPTION
I have added a Courses menu item within the Other Tutorials section of the docs. This includes a free course on REST API design using Django Ninja.

Alternatively we could change the existing "Video Tutorials" menu option to instead be "Tutorials". This could then be used for text based as well as video based courses and tutorials. Let me know if you would prefer this, in which case I will update the PR.