### PR TITLE
docs: optional file input type annotation using `Optional`

### DIFF
--- a/docs/docs/guides/input/file-params.md
+++ b/docs/docs/guides/input/file-params.md
@@ -77,7 +77,7 @@ def create_user(request, details: UserDetails, file: File[UploadedFile]):
 ```
 
 this will expect from the client side to send data as `multipart/form-data with 2 fields:
-  
+
   - details: JSON as string
   - file: file
 
@@ -96,7 +96,7 @@ If you would like the file input to be optional, all that you have to do is to p
 
 ```python
 @api.post('/users')
-def create_user(request, details: Form[UserDetails], avatar: File[UploadedFile] = None):
+def create_user(request, details: Form[UserDetails], avatar: Optional[File[UploadedFile]] = None):
     user = add_user_to_database(details)
     if avatar is not None:
         set_user_avatar(user)
@@ -141,5 +141,3 @@ When Django Ninja detects a PUT or PATCH  etc methods with multipart/form-data a
 
 
 Note: This middleware does not interfere with normal POST behavior or any other methods.
-
-


### PR DESCRIPTION
Refines existing docs by adding Optional to file input type annotations. This improves type hint guidance and helps avoid common type checker errors.