### PR TITLE
Handle empty sequence as auth

### DIFF
--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -176,7 +176,13 @@ class Operation:
         self, auth: Optional[Union[Sequence[Callable], Callable, object]]
     ) -> None:
         if auth is not None and auth is not NOT_SET:
-            self.auth_callbacks = isinstance(auth, Sequence) and auth or [auth]
+            if isinstance(auth, Sequence):
+                if not auth:
+                    return
+                auth = auth
+            else:
+                auth = [auth]
+            self.auth_callbacks = auth  # type: ignore[assignment]
 
     def _run_checks(self, request: HttpRequest) -> Optional[HttpResponse]:
         "Runs security/throttle checks for each operation"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -104,6 +104,8 @@ for path, auth in [
     ("bearer", BearerAuth()),
     ("async_bearer", AsyncBearerAuth()),
     ("customexception", KeyHeaderCustomException()),
+    ("none", None),
+    ("empty_sequence", []),
 ]:
     api.get(f"/{path}", auth=auth, operation_id=path)(demo_operation)
 
@@ -257,6 +259,8 @@ BODY_FORBIDDEN_DEFAULT = dict(detail="Forbidden")
             200,
             dict(auth="keyheadersecret"),
         ),
+        ("/none", {}, 200, dict(auth=None)),
+        ("/empty_sequence", {}, 200, dict(auth=None)),
     ],
 )
 def test_auth(path, kwargs, expected_code, expected_body, settings):


### PR DESCRIPTION
Allow `auth` to be set to an empty sequence and act as if it was set to `None`.