### PR TITLE
chore: Remove a character in CSRF code example

### DIFF
--- a/docs/docs/reference/csrf.md
+++ b/docs/docs/reference/csrf.md
@@ -21,7 +21,7 @@ By default, **Django Ninja** has CSRF protection turned **OFF** for all operatio
 from ninja import NinjaAPI
 from ninja.security import APIKeyCookie
 
-class CookieAuth(APIKeyCookie):å
+class CookieAuth(APIKeyCookie):
     def authenticate(self, request, key):
         return key == "test"
 


### PR DESCRIPTION
Hi! I've noticed this typo in the CSRF code example.

On a side note, should there be some migration guide for users that prior to 1.5.0 have used `csrf` in their app config? (From what I see - it's enough to remove the parameter, and it'll _mostly_ work the same, except for anonymous requests where django_auth is required. Previously it returned code 401, and now it says that there's CSRF error, and returns error code 403)

I see that it's mentioned that this parameter is removed with 1.5.0 release (in beta release noes), however it doesn't clearly state that without removing it first, the app simply won't run.