### PR TITLE
fix: Use serialization_alias in OpenAPI spec when by_alias=True

### DIFF
--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -4,6 +4,7 @@ from http.client import responses
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Set, Tuple
 
 from django.utils.termcolors import make_style
+from pydantic.json_schema import JsonSchemaMode
 
 from ninja.constants import NOT_SET
 from ninja.operation import Operation
@@ -216,6 +217,7 @@ class OpenAPISchema(dict):
         model: TModel,
         by_alias: bool = True,
         remove_level: bool = True,
+        mode: JsonSchemaMode = "validation",
     ) -> Tuple[DictStrAny, bool]:
         if hasattr(model, "__ninja_flatten_map__"):
             schema = self._flatten_schema(model)
@@ -224,7 +226,7 @@ class OpenAPISchema(dict):
                 ref_template=REF_TEMPLATE,
                 by_alias=by_alias,
                 schema_generator=NinjaGenerateJsonSchema,
-                mode="serialization",
+                mode=mode,
             ).copy()
 
         # move Schemas from definitions
@@ -241,7 +243,9 @@ class OpenAPISchema(dict):
             return schema, True
 
     def _create_multipart_schema_from_models(
-        self, models: TModels
+        self,
+        models: TModels,
+        mode: JsonSchemaMode = "validation",
     ) -> Tuple[DictStrAny, str]:
         # We have File and Form or Body, so we need to use multipart (File)
         content_type = BODY_CONTENT_TYPES["file"]
@@ -268,10 +272,14 @@ class OpenAPISchema(dict):
             model = models[0]
             content_type = BODY_CONTENT_TYPES[model.__ninja_param_source__]
             schema, required = self._create_schema_from_model(
-                model, remove_level=model.__ninja_param_source__ == "body"
+                model,
+                remove_level=model.__ninja_param_source__ == "body",
+                mode="validation",
             )
         else:
-            schema, content_type = self._create_multipart_schema_from_models(models)
+            schema, content_type = self._create_multipart_schema_from_models(
+                models, mode="validation"
+            )
             required = True
 
         return {
@@ -292,7 +300,7 @@ class OpenAPISchema(dict):
             if model not in [None, NOT_SET]:
                 # ::TODO:: test this: by_alias == True
                 schema = self._create_schema_from_model(
-                    model, by_alias=operation.by_alias
+                    model, by_alias=operation.by_alias, mode="serialization"
                 )[0]
                 details[status]["content"] = {
                     self.api.renderer.media_type: {"schema": schema}

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -1069,6 +1069,31 @@ def test_by_alias_uses_serialization_alias_simple():
     }
 
 
+def test_by_alias_uses_validation_alias_simple():
+    """Test the serialization_alias on the Field is used when by_alias=True is set on the route"""
+    api = NinjaAPI()
+
+    class PersonIn(Schema):
+        uuid: str = Field(..., validation_alias="id")
+        name: str = Field(..., validation_alias="fullName")
+
+    @api.get("/person", by_alias=True)
+    def get_user(request, param: PersonIn):
+        return {"uuid": uuid4(), "fullname": "John Snow"}
+
+    schema = api.get_openapi_schema()
+    user_alias_schema = schema["components"]["schemas"]["PersonIn"]
+    assert user_alias_schema == {
+        "title": "PersonIn",
+        "type": "object",
+        "properties": {
+            "id": {"title": "Id", "type": "string"},
+            "fullName": {"type": "string", "title": "Fullname"},
+        },
+        "required": ["id", "fullName"],
+    }
+
+
 @pytest.mark.django_db
 def test_by_alias_uses_serialization_alias_model():
     """Test the serialization_alias on the Field is used when by_alias=True is set on the route"""


### PR DESCRIPTION
Reproduction and fix for https://github.com/vitalik/django-ninja/issues/1605.

Adding `mode="serialization"` to the OpenAPI code's usage of `model_json_schema` fixes the OpenAPI spec to match the actual API in this case.

I have added two cases, one when using ModelSchema, and one using a normal Schema. You can easily reproduce the issue I describe in #1605 by commenting out `mode="serialization"` and then running the tests.