### PR TITLE
Fixed pagination override in case of RouterPaginated

### DIFF
--- a/ninja/pagination.py
+++ b/ninja/pagination.py
@@ -219,6 +219,9 @@ def _inject_pagination(
     paginator_class: Type[Union[PaginationBase, AsyncPaginationBase]],
     **paginator_params: Any,
 ) -> Callable[..., Any]:
+    if getattr(func, "_is_paginated", False):
+        return func
+
     paginator = paginator_class(**paginator_params)
 
     # Check if Input schema has any fields
@@ -292,6 +295,7 @@ def _inject_pagination(
             partial(make_response_paginated, paginator),
         )
 
+    view_with_pagination._is_paginated = True  # type: ignore
     return view_with_pagination
 
 

--- a/tests/test_pagination_router.py
+++ b/tests/test_pagination_router.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 
 from ninja import NinjaAPI, Schema
-from ninja.pagination import RouterPaginated
+from ninja.pagination import PageNumberPagination, RouterPaginated, paginate
 from ninja.testing import TestAsyncClient, TestClient
 
 api = NinjaAPI(default_router=RouterPaginated())
@@ -21,6 +21,18 @@ def items(request):
 @api.get("/items_nolist", response=ItemSchema)
 def items_nolist(request):
     return {"id": 1}
+
+
+@api.get("/items_extra_layer", response=List[ItemSchema])
+@paginate  # has not to break down
+def items_extra_layer(request):
+    return [{"id": i} for i in range(1, 51)]
+
+
+@api.get("/items_overridden", response=List[ItemSchema])
+@paginate(PageNumberPagination, page_size=3)  # has precedence over router pagination
+def items_overridden_pagination(request):
+    return [{"id": i} for i in range(1, 51)]
 
 
 client = TestClient(api)
@@ -64,6 +76,70 @@ def test_for_NON_list_reponse():
     ]
     # print(parameters)
     assert parameters == []
+
+
+def test_extra_pagination_layer_does_not_crash():
+    parameters = api.get_openapi_schema()["paths"]["/api/items_extra_layer"]["get"][
+        "parameters"
+    ]
+    assert parameters == [
+        {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+                "title": "Limit",
+                "default": 100,
+                "minimum": 1,
+                "type": "integer",
+            },
+            "required": False,
+        },
+        {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+                "title": "Offset",
+                "default": 0,
+                "minimum": 0,
+                "type": "integer",
+            },
+            "required": False,
+        },
+    ]
+
+    response = client.get("/items_extra_layer?offset=5&limit=1").json()
+    assert response == {"items": [{"id": 6}], "count": 50}
+
+
+def test_for_list_with_overridden_pagination_reponse():
+    parameters = api.get_openapi_schema()["paths"]["/api/items_overridden"]["get"][
+        "parameters"
+    ]
+    assert parameters == [
+        {
+            "in": "query",
+            "name": "page",
+            "schema": {
+                "title": "Page",
+                "default": 1,
+                "minimum": 1,
+                "type": "integer",
+            },
+            "required": False,
+        },
+        {
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+                "anyOf": [{"minimum": 1, "type": "integer"}, {"type": "null"}],
+                "title": "Page Size",
+            },
+            "required": False,
+        },
+    ]
+
+    response = client.get("/items_overridden?page=5").json()
+    assert response == {"items": [{"id": 13}, {"id": 14}, {"id": 15}], "count": 50}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR fixes errors that happen when RouterPaginated is used. The system crashes when a user overrides the pagination. 

```python
router = RouterPaginated()

@router.get('/items', response=List[int])
@paginate                      #  ninja.errors.ConfigError: Duplicated name: 'limit' in params: 'ninja_pagination' & 'ninja_pagination'
def items(self):
    return ITEMS

# More relevant case where a developer needs to override default pagination
@router.get('/items', response=List[int])
@paginate(PageNumberPagination)     # AttributeError: 'NoneType' object has no attribute 'annotation'  
def items(self):
    return ITEMS
```

The first view:
<img width="831" height="382" alt="image" src="https://github.com/user-attachments/assets/ff46889d-c482-4c71-9690-6daae281c32f" />


The second view:
<img width="595" height="387" alt="image" src="https://github.com/user-attachments/assets/c63d5a95-52df-4c01-b66d-2f47dfece25a" />

Solution: Every view can be wrapped into `_inject_pagination` at most once. When RouterPaginated wraps the paginated view, it will skip silently.
