### PR TITLE
Allow to disable unnecessary API registry checks via Django settings

### DIFF
--- a/ninja/main.py
+++ b/ninja/main.py
@@ -1,4 +1,3 @@
-import os
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -13,6 +12,7 @@ from typing import (
     Union,
 )
 
+from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.urls import URLPattern, URLResolver, reverse
 from django.utils.module_loading import import_string
@@ -561,7 +561,7 @@ class NinjaAPI:
 
     def _validate(self) -> None:
         # urls namespacing validation
-        skip_registry = os.environ.get("NINJA_SKIP_REGISTRY", False)
+        skip_registry = getattr(settings, "NINJA_SKIP_REGISTRY", False)
         if (
             not skip_registry
             and self.urls_namespace in NinjaAPI._registry

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,10 @@ sys.path.insert(0, str(ROOT / "tests/demo_project"))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "demo.settings")
 
 import django  # noqa
+from django.conf import settings  # noqa
 
 django.setup()
 
 
 def pytest_generate_tests(metafunc):
-    os.environ["NINJA_SKIP_REGISTRY"] = "yes"
+    settings.NINJA_SKIP_REGISTRY = True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,4 @@
 import contextlib
-import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
@@ -102,10 +101,7 @@ def test_method(method, path, expected_status, expected_data, expected_streaming
     assert data == expected_data
 
 
-def test_validates():
-    try:
-        os.environ["NINJA_SKIP_REGISTRY"] = ""
-        with pytest.raises(ConfigError):
-            _urls = NinjaAPI().urls
-    finally:
-        os.environ["NINJA_SKIP_REGISTRY"] = "yes"
+def test_validates(settings):
+    delattr(settings, "NINJA_SKIP_REGISTRY")
+    with pytest.raises(ConfigError):
+        _urls = NinjaAPI().urls


### PR DESCRIPTION
A minimal change to achieve what I needed in https://github.com/vitalik/django-ninja/issues/1615 without changing any core functionality

I have tried this in my project and seems to work fine, I am able to do:

```python
    path("app-a/", include("apps.a.urls", namespace="a")),
    path("app-b/", include("apps.b.urls", namespace="b")),
```
where `apps.a.urls` and `apps.b.urls` both look like:
```python
api = NinjaAPI(urls_namespace="reports")
...
urlpatterns = [
    path("other", other.view, name="other"),
    path("", api.urls),
]
```
and then I can reverse url names like `a:reports:api-view`, `b:reports:api-view`, or non-ninja views like `a:other`

(I feel like the registry could probably just be removed entirely, AFAICT it's not doing anything useful)