### PR TITLE
Added mode to decorate_view

### DIFF
--- a/ninja/router.py
+++ b/ninja/router.py
@@ -16,7 +16,7 @@ from django.urls import path as django_path
 from django.utils.module_loading import import_string
 
 from ninja.constants import NOT_SET, NOT_SET_TYPE
-from ninja.decorators import DecoratorMode
+from ninja.decorators import DecoratorMode, apply_decorator
 from ninja.errors import ConfigError
 from ninja.operation import PathView
 from ninja.throttling import BaseThrottle
@@ -482,14 +482,7 @@ class Router:
                 # Apply decorators that haven't been applied yet
                 for decorator, mode in self._decorators:
                     if (decorator, mode) not in applied_decorators:
-                        if mode == "view":
-                            operation.run = decorator(operation.run)  # type: ignore
-                        elif mode == "operation":
-                            operation.view_func = decorator(operation.view_func)
-                        else:
-                            raise ValueError(
-                                f"Invalid decorator mode: {mode}"
-                            )  # pragma: no cover
+                        apply_decorator(decorator, mode, operation)
                         applied_decorators.append((decorator, mode))
 
                 # Store what decorators have been applied

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,18 +1,50 @@
 from functools import wraps
 from typing import List
 
+import pytest
+
 from ninja import NinjaAPI
 from ninja.decorators import decorate_view
 from ninja.pagination import paginate
 from ninja.testing import TestClient
 
 
-def some_decorator(view_func):
-    @wraps(view_func)
+# Test decorators
+def operation_decorator(func):
+    """Decorator that adds a header after validation (operation level)"""
+
+    @wraps(func)
     def wrapper(request, *args, **kwargs):
-        response = view_func(request, *args)
-        response["X-Decorator"] = "some_decorator"
+        result = func(request, *args, **kwargs)
+        if isinstance(result, dict):
+            result["operation_decorated"] = True
+        return result
+
+    return wrapper
+
+
+def view_decorator(func):
+    """Decorator that adds a header before validation (view level)"""
+
+    @wraps(func)
+    def wrapper(request, *args, **kwargs):
+        response = func(request, *args, **kwargs)
+        response["X-View-Decorator"] = "view_decorator"
         return response
+
+    return wrapper
+
+
+def counter_decorator(func):
+    """Decorator that counts calls"""
+
+    @wraps(func)
+    def wrapper(request, *args, **kwargs):
+        wrapper.call_count = getattr(wrapper, "call_count", 0) + 1
+        result = func(request, *args, **kwargs)
+        if isinstance(result, dict):
+            result["call_count"] = wrapper.call_count
+        return result
 
     return wrapper
 
@@ -20,7 +52,7 @@ def some_decorator(view_func):
 def test_decorator_before():
     api = NinjaAPI()
 
-    @decorate_view(some_decorator)
+    @decorate_view(view_decorator)
     @api.get("/before")
     def dec_before(request):
         return 1
@@ -28,28 +60,28 @@ def test_decorator_before():
     client = TestClient(api)
     response = client.get("/before")
     assert response.status_code == 200
-    assert response["X-Decorator"] == "some_decorator"
+    assert response["X-View-Decorator"] == "view_decorator"
 
 
 def test_decorator_after():
     api = NinjaAPI()
 
     @api.get("/after")
-    @decorate_view(some_decorator)
+    @decorate_view(view_decorator)
     def dec_after(request):
         return 1
 
     client = TestClient(api)
     response = client.get("/after")
     assert response.status_code == 200
-    assert response["X-Decorator"] == "some_decorator"
+    assert response["X-View-Decorator"] == "view_decorator"
 
 
 def test_decorator_multiple():
     api = NinjaAPI()
 
     @api.get("/multi", response=List[int])
-    @decorate_view(some_decorator)
+    @decorate_view(view_decorator)
     @paginate
     def dec_multi(request):
         return [1, 2, 3, 4]
@@ -58,4 +90,130 @@ def test_decorator_multiple():
     response = client.get("/multi")
     assert response.status_code == 200
     assert response.json() == {"count": 4, "items": [1, 2, 3, 4]}
-    assert response["X-Decorator"] == "some_decorator"
+    assert response["X-View-Decorator"] == "view_decorator"
+
+
+def test_decorator_operation_mode_on_top_of_api_method():
+    """
+    Test decorate_view in OPERATION mode when decorate_view() on top of @api.method
+    """
+    api = NinjaAPI()
+
+    @decorate_view(operation_decorator, mode="operation")
+    @api.get("/before")
+    def dec_before(request):
+        return {"message": "test"}
+
+    client = TestClient(api)
+    response = client.get("/before")
+    assert response.status_code == 200
+    assert response.json() == {"message": "test", "operation_decorated": True}
+
+
+def test_decorator_operation_mode_after_api_method():
+    """
+    Test decorate_view in OPERATION mode when decorate_view() after @api.method
+    """
+    api = NinjaAPI()
+
+    @api.get("/after")
+    @decorate_view(operation_decorator, mode="operation")
+    def dec_after(request):
+        return {"message": "test"}
+
+    client = TestClient(api)
+    response = client.get("/after")
+    assert response.status_code == 200
+    assert response.json() == {"message": "test", "operation_decorated": True}
+
+
+def test_decorator_view_mode_on_top_of_api_method():
+    """
+    Test decorate_view in VIEW mode when decorate_view() on top of @api.method
+    """
+    api = NinjaAPI()
+
+    @decorate_view(view_decorator, mode="view")
+    @api.get("/before")
+    def dec_before(request):
+        return {"message": "test"}
+
+    client = TestClient(api)
+    response = client.get("/before")
+    assert response.status_code == 200
+    assert response["X-View-Decorator"] == "view_decorator"
+    assert response.json() == {"message": "test"}
+
+
+def test_decorator_view_mode_after_api_method():
+    """
+    Test decorate_view in VIEW mode when decorate_view() after @api.method
+    """
+    api = NinjaAPI()
+
+    @api.get("/after")
+    @decorate_view(view_decorator, mode="view")
+    def dec_after(request):
+        return {"message": "test"}
+
+    client = TestClient(api)
+    response = client.get("/after")
+    assert response.status_code == 200
+    assert response["X-View-Decorator"] == "view_decorator"
+    assert response.json() == {"message": "test"}
+
+
+def test_multiple_decorators():
+    """Test multiple decorators with the same mode"""
+    api = NinjaAPI()
+
+    @api.get("/test")
+    @decorate_view(operation_decorator, mode="operation")
+    @decorate_view(counter_decorator, mode="operation")
+    def endpoint(request):
+        return {"message": "test"}
+
+    client = TestClient(api)
+
+    response = client.get("/test")
+    assert response.status_code == 200
+    result = response.json()
+    assert result["message"] == "test"
+    assert result["operation_decorated"] is True
+    assert result["call_count"] == 1
+
+    # Second call should increment counter
+    response = client.get("/test")
+    result = response.json()
+    assert result["operation_decorated"] is True
+    assert result["call_count"] == 2
+
+
+def test_mix_view_and_operation_decorators():
+    """Test mixing VIEW and OPERATION mode decorators"""
+    api = NinjaAPI()
+
+    @api.get("/test")
+    @decorate_view(view_decorator, mode="view")
+    @decorate_view(operation_decorator, mode="operation")
+    def endpoint(request):
+        return {"message": "test"}
+
+    client = TestClient(api)
+
+    response = client.get("/test")
+    assert response.status_code == 200
+    assert response["X-View-Decorator"] == "view_decorator"
+    assert response.json() == {"message": "test", "operation_decorated": True}
+
+
+def test_invalid_decorator_mode():
+    """Test that invalid decorator mode raises ValueError"""
+    api = NinjaAPI()
+
+    with pytest.raises(ValueError, match="Invalid decorator mode"):
+
+        @api.get("/test")
+        @decorate_view(operation_decorator, mode="invalid")  # type: ignore
+        def endpoint(request):
+            return {"message": "test"}


### PR DESCRIPTION
Hello. 

I added mode (operation, view) to the `@decorate_view`. 

```python
@api.get("/cached")
@decorate_view(cache_page(60 * 15), mode="view") 
def cached_endpoint(request):
    return {"data": "This response is cached"}

def require_feature_flag(flag_name):  # example from the doc about `router.add_decorator(..., mode="operation")`
    def decorator(func):
        @wraps(func)
        def wrapper(request, *args, **kwargs):
            if not request.user.has_feature(flag_name):
                return {"error": f"Feature {flag_name} not enabled"}
            return func(request, *args, **kwargs)
        return wrapper
    return decorator

@api.get("/new-feature")
@decorate_view(require_feature_flag("new_api"), mode="operation") 
def new_feature(request):
    return {"feature": "enabled"}
```

It allows to add decorators to individual endpoints that can do some code after validation. Especially when a developer needs to perform some validation over request, validated path parameters and validated body parameters together.
It's common enough that there is a router with a lot of endpoints, but only a few of them require an "operation" decorator so that they couldn't use `router.add_decorator`.

As well, it looks more consistent with `api.add_decorator` and `router.add_decorator` that make the same sense as `@decorate_view`

P.S. I would like to mark usage `add_decorator` and `decorate_view` without explicit `mode` parameter deprecated, and made them mandatory from 1.6.0 or any other following version.