### PR TITLE
Clarify schema privacy settings in API docs

### DIFF
--- a/docs/docs/guides/api-docs.md
+++ b/docs/docs/guides/api-docs.md
@@ -53,6 +53,12 @@ In case you do not need to display interactive documentation - set `docs_url` ar
 api = NinjaAPI(docs_url=None)
 ```
 
+Note: Even if you set `docs_url` to `None`, your whole schema will still be public on `/api/openapi.json`. This is usually undesirable in production. To hide your schema set `openapi_url` argument to `None` as well
+
+```python
+api = NinjaAPI(docs_url=None, openapi_url=None)
+```
+
 ## Protecting docs
 
 To protect docs with authentication (or decorate for some other use case) use `docs_decorator` argument:


### PR DESCRIPTION
Added note about schema visibility when using docs_url and openapi_url.

This can be a security concern, specially in production. It's very important to let users know about the `openapi_url` parameter.