### PR TITLE
Centralize "preview: true" config for ruff

### DIFF
--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -89,8 +89,8 @@ jobs:
       - name: Install Dependencies
         run: flit install --symlink
       - name: Ruff format
-        run: ruff format --preview --check ninja tests
+        run: ruff format --check ninja tests
       - name: Ruff lint
-        run: ruff check --preview ninja tests
+        run: ruff check ninja tests
       - name: mypy
         run: mypy ninja tests/mypy_test.py

--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,14 @@ install: ## Install dependencies
 
 .PHONY: lint
 lint: ## Run code linters
-	ruff format --preview --check ninja tests
-	ruff check --preview ninja tests
+	ruff format --check ninja tests
+	ruff check ninja tests
 	mypy ninja
 
 .PHONY: fmt format
 fmt format: ## Run code formatters
-	ruff format --preview ninja tests
-	ruff check --preview --fix ninja tests 
+	ruff format ninja tests
+	ruff check --fix ninja tests
 
 .PHONY: test
 test: ## Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,11 @@ dev = ["pre-commit"]
 [tool.ruff]
 target-version = "py37"
 
+[tool.ruff.format]
+preview = true
+
 [tool.ruff.lint]
+preview = true
 select = [
     "B",    # flake8-bugbear
     "C",    # flake8-comprehensions


### PR DESCRIPTION
So that CI and makefile won't need to pass it with every ruff call and pre-commit hooks / manual calls will also make use of it