### PR TITLE
Add path_params to context in ParamModel resolve

### DIFF
--- a/docs/docs/whatsnew_v1.md
+++ b/docs/docs/whatsnew_v1.md
@@ -32,9 +32,9 @@ Some features that are made possible with pydantic2
 
 ### pydantic context
 
-Pydantic now supports context during validation and serialization and Django ninja passes "request" object during request and response work
+Pydantic now supports context during validation and serialization and Django ninja passes "request" object and "path\_params" dict during request and response work
 
-```Python hl_lines="6 7"
+```Python hl_lines="6 7 11 12"
 class Payload(Schema):
     id: int
     name: str
@@ -44,6 +44,11 @@ class Payload(Schema):
     def resolve_request_path(data, context):
         request = context["request"]
         return request.get_full_path()
+
+    @model_validator(mode="wrap")
+    def validate_item_id(cls, values, handler, info):
+        item_id = info.context["path_params"].get("item_id")
+        assert item_id is not None, "Item ID is required"
 
 ```
 

--- a/ninja/params/models.py
+++ b/ninja/params/models.py
@@ -60,7 +60,9 @@ class ParamModel(BaseModel, ABC):
             return cls()
 
         data = cls._map_data_paths(data)
-        return cls.model_validate(data, context={"request": request})
+        return cls.model_validate(
+            data, context={"request": request, "path_params": path_params}
+        )
 
     @classmethod
     def _map_data_paths(cls, data: DictStrAny) -> DictStrAny:

--- a/tests/test_schema_context.py
+++ b/tests/test_schema_context.py
@@ -57,6 +57,9 @@ def test_request_context():
     resp = client.post("/resolve_ctx", json={})
     assert resp.status_code == 200, resp.content
     assert resp.json() == {
-        "other": {"value": {"request": "<request>"}, "other": None},
+        "other": {
+            "value": {"path_params": "{}", "request": "<request>"},
+            "other": None,
+        },
         "value": {"request": "<request>", "response_status": "200"},
     }


### PR DESCRIPTION
When validating, it's convenient to get `path_params` as part of context. For example, `PATCH /items/<item id>/` might want to validate that `item id`, if supplied, references a record of a specific type. Obviously this could be done after validation, but it feels like it should be part of the validation process.

This PR adds `path_params` to the context for model validation.