### PR TITLE
Fix/issue 1634 union type model fields

### DIFF
--- a/ninja/signature/details.py
+++ b/ninja/signature/details.py
@@ -211,9 +211,8 @@ class ViewSignature:
     def _model_flatten_map(self, model: TModel, prefix: str) -> Generator:
         # Handle Union types by extracting the Pydantic model
         if get_origin(model) in UNION_TYPES:
-            if actual_model := extract_pydantic_model_from_union(
-                model
-            ):  # pragma: no branch
+            actual_model = extract_pydantic_model_from_union(model)
+            if actual_model:  # pragma: no branch
                 yield from self._model_flatten_map(actual_model, prefix)  # type: ignore[type-var]
             return
 
@@ -332,7 +331,7 @@ def is_pydantic_model(cls: Any) -> bool:
         return False
 
 
-def extract_pydantic_model_from_union(annotation: Any) -> type | None:
+def extract_pydantic_model_from_union(annotation: Any) -> Optional[type]:
     """Extract Pydantic model from Union type annotation, or None if not found."""
     if get_origin(annotation) not in UNION_TYPES:
         return None
@@ -382,8 +381,11 @@ def detect_collection_fields(
                     annotation_or_field = annotation_or_field.annotation
                 # Handle Union types by extracting the Pydantic model
                 if get_origin(annotation_or_field) in UNION_TYPES:
-                    if model := extract_pydantic_model_from_union(annotation_or_field):
-                        annotation_or_field = model
+                    extracted_model = extract_pydantic_model_from_union(
+                        annotation_or_field
+                    )
+                    if extracted_model:
+                        annotation_or_field = extracted_model
                     else:
                         break  # pragma: no cover
                 annotation_or_field = next(

--- a/tests/test_signature_details.py
+++ b/tests/test_signature_details.py
@@ -65,16 +65,6 @@ def test_is_collection_type_returns(annotation: typing.Any, expected: bool):
     ("annotation", "expected"),
     [
         pytest.param(
-            SampleModel | None,
-            SampleModel,
-            id="returns_model_from_union_with_none",
-        ),
-        pytest.param(
-            str | None,
-            None,
-            id="returns_none_when_no_model_in_union",
-        ),
-        pytest.param(
             SampleModel,
             None,
             id="returns_none_for_non_union_type",
@@ -84,14 +74,31 @@ def test_is_collection_type_returns(annotation: typing.Any, expected: bool):
             SampleModel,
             id="returns_model_from_optional_syntax",
         ),
-        pytest.param(
-            str | int,
-            None,
-            id="returns_none_for_union_without_model",
+        # PEP 604 Union syntax (X | Y) requires Python 3.10+
+        *(
+            (
+                pytest.param(
+                    SampleModel | None,
+                    SampleModel,
+                    id="returns_model_from_union_with_none",
+                ),
+                pytest.param(
+                    str | None,
+                    None,
+                    id="returns_none_when_no_model_in_union",
+                ),
+                pytest.param(
+                    str | int,
+                    None,
+                    id="returns_none_for_union_without_model",
+                ),
+            )
+            if version_info >= (3, 10)
+            else ()
         ),
     ],
 )
 def test_extract_pydantic_model_from_union_returns(
-    annotation: typing.Any, expected: type | None
+    annotation: typing.Any, expected: typing.Optional[type]
 ):
     assert extract_pydantic_model_from_union(annotation) is expected


### PR DESCRIPTION
Fix #1634 

## Summary

Fix `AttributeError: 'types.UnionType' object has no attribute 'model_fields'` when using Python 3.10+ Union syntax (`Model | None`) in Query parameters with nested Pydantic models.

## Problem

When a Schema field uses Python 3.10+ Union type syntax with a Pydantic model (e.g., `InnerModel | None`), endpoint registration fails:

```python
class InnerModel(Schema):
    value: int

class OuterModel(Schema):
    inner: InnerModel | None = None  # Python 3.10+ Union syntax

@api.get("/test")
def endpoint(request, data: OuterModel = Query(...)):
    return {"ok": True}
```
```shell
Error:
AttributeError: 'types.UnionType' object has no attribute 'model_fields'
```

### Root Cause

1. `is_pydantic_model(InnerModel | None)` returns `True` (correctly detects model inside Union)
2. `_model_flatten_map()` then receives `InnerModel | None` (a types.UnionType)
3. It tries to access `.model_fields` on UnionType, which doesn't exist

### Solution

Added `extract_pydantic_model_from_union()` helper function to extract the actual Pydantic model from Union types before accessing model_fields.

### Changes

| File | Function | Change |
|------|----------|--------|
| `ninja/signature/details.py` | `extract_pydantic_model_from_union` | New helper function |
| `ninja/signature/details.py` | `_model_flatten_map` | Handle Union types before accessing `model_fields` |
| `ninja/signature/details.py` | `detect_collection_fields` | Handle Union types before accessing `model_fields` |

### Backward Compatibility

Fully maintained. Both syntaxes work identically:
- `Model | None` (Python 3.10+ syntax) → types.UnionType
- `Optional[Model]` (typing syntax) → typing.Union

Both are handled by `UNION_TYPES = (Union, UnionType)`.

### Test Plan
- Unit tests for `extract_pydantic_model_from_union` (5 parametrized cases)
- Integration test: Query param with Union type model
- Regression test: `Optional[Model]` syntax compatibility
- Integration test: Nested Union types (Top -> Middle | None -> Inner | None)
- All 678 tests passing, 100% code coverage maintained
- ruff format / ruff check / mypy all passing