### PR TITLE
enable MISSING and NoDefault sentinel

### DIFF
--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         django-version: ['<3.2', '<3.3', '<4.2', '<4.3', '<5.1', '<5.2', '<5.3', '<6.1']
+        pydantic-version: ['']
         exclude:
           - python-version: '3.7'
             django-version: '<5.1'
@@ -46,7 +47,18 @@ jobs:
             django-version: '<5.1'
           - python-version: '3.14'
             django-version: '<5.2'
-    
+
+        include:
+          - python-version: '3.7'
+            django-version: '<6.1'
+            pydantic-version: '<2.11'
+          - python-version: '3.13'
+            django-version: '<6.1'
+            pydantic-version: '<2.11'
+          - python-version: '3.14'
+            django-version: '<6.1'
+            pydantic-version: '<2.11'
+
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python

--- a/ninja/conf.py
+++ b/ninja/conf.py
@@ -1,9 +1,8 @@
 from math import inf
-from typing import Any, Dict, Optional, Set, Tuple, Union
+from typing import Any, Dict, Optional, Set, Tuple
 
 from django.conf import settings as django_settings
 from pydantic import BaseModel, ConfigDict, Field
-from pydantic.experimental.missing_sentinel import MISSING
 
 
 class Settings(BaseModel):
@@ -37,7 +36,7 @@ class Settings(BaseModel):
     NULLABLE_FIELD_DEFAULT_VALUE: Any = Field(
         None, alias="NINJA_NULLABLE_FIELD_DEFAULT_VALUE"
     )
-    NULLABLE_FIELD_UNION_TYPE: Union[None, MISSING] = Field(
+    NULLABLE_FIELD_UNION_TYPE: Any = Field(
         None, alias="NINJA_NULLABLE_FIELD_UNION_TYPE"
     )
 

--- a/ninja/conf.py
+++ b/ninja/conf.py
@@ -1,8 +1,9 @@
 from math import inf
-from typing import Dict, Optional, Set, Tuple
+from typing import Any, Dict, Optional, Set, Tuple, Union
 
 from django.conf import settings as django_settings
 from pydantic import BaseModel, ConfigDict, Field
+from pydantic.experimental.missing_sentinel import MISSING
 
 
 class Settings(BaseModel):
@@ -32,6 +33,12 @@ class Settings(BaseModel):
 
     FIX_REQUEST_FILES_METHODS: Set[str] = Field(
         {"PUT", "PATCH", "DELETE"}, alias="NINJA_FIX_REQUEST_FILES_METHODS"
+    )
+    NULLABLE_FIELD_DEFAULT_VALUE: Any = Field(
+        None, alias="NINJA_NULLABLE_FIELD_DEFAULT_VALUE"
+    )
+    NULLABLE_FIELD_UNION_TYPE: Union[None, MISSING] = Field(
+        None, alias="NINJA_NULLABLE_FIELD_UNION_TYPE"
     )
 
 

--- a/ninja/conf.py
+++ b/ninja/conf.py
@@ -39,6 +39,7 @@ class Settings(BaseModel):
     NULLABLE_FIELD_UNION_TYPE: Any = Field(
         None, alias="NINJA_NULLABLE_FIELD_UNION_TYPE"
     )
+    PK_OPTIONAL: bool = Field(True, alias="NINJA_PK_OPTIONAL")
 
 
 settings = Settings.model_validate(django_settings)

--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Type, Union,
 from django.db.models import Field as DjangoField
 from django.db.models import ManyToManyRel, ManyToOneRel, Model
 from pydantic import create_model as create_pydantic_model
+from pydantic.experimental.missing_sentinel import MISSING
 
 from ninja.errors import ConfigError
 from ninja.orm.fields import get_schema_field
@@ -43,6 +44,8 @@ class SchemaFactory:
         optional_fields: Optional[List[str]] = None,
         custom_fields: Optional[List[Tuple[str, Any, Any]]] = None,
         base_class: Type[Schema] = Schema,
+        nullable_type: Union[None, MISSING] = None,
+        nullable_value: Any = None,
     ) -> Type[Schema]:
         name = name or model.__name__
 
@@ -66,6 +69,8 @@ class SchemaFactory:
                 fld,
                 depth=depth,
                 optional=optional_fields and (fld.name in optional_fields),
+                nullable_type=nullable_type,
+                nullable_value=nullable_value,
             )
             definitions[fld.name] = (python_type, field_info)
 

--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -6,6 +6,7 @@ from django.db.models import ManyToManyRel, ManyToOneRel, Model
 from pydantic import create_model as create_pydantic_model
 from pydantic.experimental.missing_sentinel import MISSING
 
+from ninja.conf import settings
 from ninja.errors import ConfigError
 from ninja.orm.fields import get_schema_field
 from ninja.schema import Schema
@@ -44,8 +45,8 @@ class SchemaFactory:
         optional_fields: Optional[List[str]] = None,
         custom_fields: Optional[List[Tuple[str, Any, Any]]] = None,
         base_class: Type[Schema] = Schema,
-        nullable_type: Union[None, MISSING] = None,
-        nullable_value: Any = None,
+        nullable_type: Union[None, MISSING] = settings.NULLABLE_FIELD_UNION_TYPE,
+        nullable_value: Any = settings.NULLABLE_FIELD_DEFAULT_VALUE,
     ) -> Type[Schema]:
         name = name or model.__name__
 

--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -25,7 +25,7 @@ from ninja.schema import Schema
 
 __all__ = ["SchemaFactory", "factory", "create_schema"]
 
-SchemaKey = Tuple[Type[Model], str, int, str, str, str, str]
+SchemaKey = Tuple[Type[Model], str, int, str, str, str, str, str, str]
 
 
 class SchemaFactory:
@@ -53,7 +53,15 @@ class SchemaFactory:
             raise ConfigError("Only one of 'fields' or 'exclude' should be set.")
 
         key = self.get_key(
-            model, name, depth, fields, exclude, optional_fields, custom_fields
+            model,
+            name,
+            depth,
+            fields,
+            exclude,
+            optional_fields,
+            custom_fields,
+            nullable_type,
+            nullable_value,
         )
         if key in self.schemas:
             return self.schemas[key]
@@ -112,6 +120,8 @@ class SchemaFactory:
         exclude: Optional[List[str]],
         optional_fields: Optional[Union[List[str], str]],
         custom_fields: Optional[List[Tuple[str, str, Any]]],
+        nullable_type: Any,
+        nullable_value: Any,
     ) -> SchemaKey:
         "returns a hashable value for all given parameters"
         # TODO: must be a test that compares all kwargs from init to get_key
@@ -123,6 +133,8 @@ class SchemaFactory:
             str(exclude),
             str(optional_fields),
             str(custom_fields),
+            str(nullable_type),
+            str(nullable_value),
         )
 
     def _get_unique_name(self, name: str) -> str:

--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Type, Union,
 from django.db.models import Field as DjangoField
 from django.db.models import ManyToManyRel, ManyToOneRel, Model
 from pydantic import create_model as create_pydantic_model
-from pydantic.experimental.missing_sentinel import MISSING
 
 from ninja.conf import settings
 from ninja.errors import ConfigError
@@ -45,7 +44,7 @@ class SchemaFactory:
         optional_fields: Optional[List[str]] = None,
         custom_fields: Optional[List[Tuple[str, Any, Any]]] = None,
         base_class: Type[Schema] = Schema,
-        nullable_type: Union[None, MISSING] = settings.NULLABLE_FIELD_UNION_TYPE,
+        nullable_type: Any = settings.NULLABLE_FIELD_UNION_TYPE,
         nullable_value: Any = settings.NULLABLE_FIELD_DEFAULT_VALUE,
     ) -> Type[Schema]:
         name = name or model.__name__

--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -46,6 +46,7 @@ class SchemaFactory:
         base_class: Type[Schema] = Schema,
         nullable_type: Any = settings.NULLABLE_FIELD_UNION_TYPE,
         nullable_value: Any = settings.NULLABLE_FIELD_DEFAULT_VALUE,
+        pk_optional: bool = settings.PK_OPTIONAL,
     ) -> Type[Schema]:
         name = name or model.__name__
 
@@ -79,6 +80,7 @@ class SchemaFactory:
                 optional=optional_fields and (fld.name in optional_fields),
                 nullable_type=nullable_type,
                 nullable_value=nullable_value,
+                pk_optional=pk_optional,
             )
             definitions[fld.name] = (python_type, field_info)
 

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from django.db.models import ManyToManyField
 from django.db.models.fields import Field as DjangoField
 from pydantic import IPvAnyAddress
+from pydantic.experimental.missing_sentinel import MISSING
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined, core_schema
 
@@ -115,7 +116,12 @@ def create_m2m_link_type(type_: Type[TModel]) -> Type[TModel]:
 
 @no_type_check
 def get_schema_field(
-    field: DjangoField, *, depth: int = 0, optional: bool = False
+    field: DjangoField,
+    *,
+    depth: int = 0,
+    optional: bool = False,
+    nullable_type: None | MISSING = None,
+    nullable_value: Any = None,
 ) -> Tuple:
     "Returns pydantic field from django's model field"
     alias = None
@@ -129,12 +135,14 @@ def get_schema_field(
 
     if field.is_relation:
         if depth > 0:
-            return get_related_field_schema(field, depth=depth)
+            return get_related_field_schema(
+                field, depth=depth, nullable_value=nullable_value
+            )
 
         internal_type = field.related_model._meta.pk.get_internal_type()
 
         if not field.concrete and field.auto_created or field.null or optional:
-            default = None
+            default = nullable_value
             nullable = True
 
         alias = getattr(field, "get_attname", None) and field.get_attname()
@@ -164,7 +172,7 @@ def get_schema_field(
             raise ConfigError("\n".join(msg)) from e
 
         if field.primary_key or blank or null or optional:
-            default = None
+            default = nullable_value
             nullable = True
 
         if field.has_default():
@@ -177,7 +185,7 @@ def get_schema_field(
         default = PydanticUndefined
 
     if nullable:
-        python_type = Union[python_type, None]  # aka Optional in 3.7+
+        python_type = Union[python_type, nullable_type]  # aka Optional in 3.7+
 
     description = field.help_text or None
     title = title_if_lower(field.verbose_name)
@@ -198,14 +206,16 @@ def get_schema_field(
 
 
 @no_type_check
-def get_related_field_schema(field: DjangoField, *, depth: int) -> Tuple[OpenAPISchema]:
+def get_related_field_schema(
+    field: DjangoField, *, depth: int, nullable_value: Any
+) -> Tuple[OpenAPISchema]:
     from ninja.orm import create_schema
 
     model = field.related_model
     schema = create_schema(model, depth=depth - 1)
     default = ...
     if not field.concrete and field.auto_created or field.null:
-        default = None
+        default = nullable_value
     if isinstance(field, ManyToManyField):
         schema = List[schema]  # type: ignore
 

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -10,6 +10,7 @@ from pydantic.experimental.missing_sentinel import MISSING
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined, core_schema
 
+from ninja.conf import settings
 from ninja.errors import ConfigError
 from ninja.openapi.schema import OpenAPISchema
 from ninja.types import DictStrAny
@@ -120,8 +121,8 @@ def get_schema_field(
     *,
     depth: int = 0,
     optional: bool = False,
-    nullable_type: None | MISSING = None,
-    nullable_value: Any = None,
+    nullable_type: Union[None, MISSING] = settings.NULLABLE_FIELD_UNION_TYPE,
+    nullable_value: Any = settings.NULLABLE_FIELD_DEFAULT_VALUE,
 ) -> Tuple:
     "Returns pydantic field from django's model field"
     alias = None

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -5,9 +5,10 @@ from uuid import UUID
 
 from django.db.models import ManyToManyField
 from django.db.models.fields import Field as DjangoField
-from pydantic import IPvAnyAddress
+from pydantic import BeforeValidator, IPvAnyAddress
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined, core_schema
+from typing_extensions import Annotated
 
 from ninja.conf import settings
 from ninja.errors import ConfigError
@@ -83,6 +84,19 @@ TYPES = {
 TModel = TypeVar("TModel")
 
 
+def use_nullable_wrapper(nullable_value: Any) -> Callable[..., Any]:
+    def use_nullable_value(value: Any) -> Any:
+        """
+        When getting values from model instances by attr, we need to convert 'null'
+        `None` values to the currently configured `nullable_value` for proper validation
+        """
+        if value is nullable_value or value is None or value == []:
+            return nullable_value
+        return value
+
+    return use_nullable_value
+
+
 def register_field(django_field: str, python_type: Any) -> None:
     TYPES[django_field] = python_type
 
@@ -136,7 +150,10 @@ def get_schema_field(
     if field.is_relation:
         if depth > 0:
             return get_related_field_schema(
-                field, depth=depth, nullable_value=nullable_value
+                field,
+                depth=depth,
+                nullable_type=nullable_type,
+                nullable_value=nullable_value,
             )
 
         internal_type = field.related_model._meta.pk.get_internal_type()
@@ -184,35 +201,50 @@ def get_schema_field(
     if default_factory:
         default = PydanticUndefined
 
-    if nullable:
-        python_type = Union[python_type, nullable_type]  # aka Optional in 3.7+
-
     description = field.help_text or None
     title = title_if_lower(field.verbose_name)
+    fieldinfo = FieldInfo(
+        default=default,
+        alias=alias,
+        validation_alias=alias,
+        serialization_alias=alias,
+        default_factory=default_factory,
+        title=title,
+        description=description,
+    )
+    if nullable:
+        typeinfo = Annotated[
+            Union[
+                # attach python type specific constraints without constraining nullable_type
+                Annotated[python_type, FieldInfo(max_length=max_length)], nullable_type  # type: ignore
+            ],
+            fieldinfo,  # general field annotations
+            BeforeValidator(
+                use_nullable_wrapper(nullable_value)
+            ),  # convert null values
+        ]
+    else:
+        typeinfo = Annotated[python_type, fieldinfo, FieldInfo(max_length=max_length)]  # type: ignore
 
     return (
-        python_type,
-        FieldInfo(
-            default=default,
-            alias=alias,
-            validation_alias=alias,
-            serialization_alias=alias,
-            default_factory=default_factory,
-            title=title,
-            description=description,
-            max_length=max_length,
-        ),
+        typeinfo,
+        default,
     )
 
 
 @no_type_check
 def get_related_field_schema(
-    field: DjangoField, *, depth: int, nullable_value: Any
+    field: DjangoField, *, depth: int, nullable_type: Any, nullable_value: Any
 ) -> Tuple[OpenAPISchema]:
     from ninja.orm import create_schema
 
     model = field.related_model
-    schema = create_schema(model, depth=depth - 1)
+    schema = create_schema(
+        model,
+        depth=depth - 1,
+        nullable_type=nullable_type,
+        nullable_value=nullable_value,
+    )
     default = ...
     if not field.concrete and field.auto_created or field.null:
         default = nullable_value

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -6,7 +6,6 @@ from uuid import UUID
 from django.db.models import ManyToManyField
 from django.db.models.fields import Field as DjangoField
 from pydantic import IPvAnyAddress
-from pydantic.experimental.missing_sentinel import MISSING
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined, core_schema
 
@@ -121,7 +120,7 @@ def get_schema_field(
     *,
     depth: int = 0,
     optional: bool = False,
-    nullable_type: Union[None, MISSING] = settings.NULLABLE_FIELD_UNION_TYPE,
+    nullable_type: Any = settings.NULLABLE_FIELD_UNION_TYPE,
     nullable_value: Any = settings.NULLABLE_FIELD_DEFAULT_VALUE,
 ) -> Tuple:
     "Returns pydantic field from django's model field"

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -136,6 +136,7 @@ def get_schema_field(
     optional: bool = False,
     nullable_type: Any = settings.NULLABLE_FIELD_UNION_TYPE,
     nullable_value: Any = settings.NULLABLE_FIELD_DEFAULT_VALUE,
+    pk_optional: bool = settings.PK_OPTIONAL,
 ) -> Tuple:
     "Returns pydantic field from django's model field"
     alias = None
@@ -154,6 +155,7 @@ def get_schema_field(
                 depth=depth,
                 nullable_type=nullable_type,
                 nullable_value=nullable_value,
+                pk_optional=pk_optional,
             )
 
         internal_type = field.related_model._meta.pk.get_internal_type()
@@ -188,7 +190,7 @@ def get_schema_field(
             ]
             raise ConfigError("\n".join(msg)) from e
 
-        if field.primary_key or blank or null or optional:
+        if (field.primary_key and pk_optional) or blank or null or optional:
             default = nullable_value
             nullable = True
 
@@ -234,7 +236,12 @@ def get_schema_field(
 
 @no_type_check
 def get_related_field_schema(
-    field: DjangoField, *, depth: int, nullable_type: Any, nullable_value: Any
+    field: DjangoField,
+    *,
+    depth: int,
+    nullable_type: Any,
+    nullable_value: Any,
+    pk_optional: bool,
 ) -> Tuple[OpenAPISchema]:
     from ninja.orm import create_schema
 
@@ -244,6 +251,7 @@ def get_related_field_schema(
         depth=depth - 1,
         nullable_type=nullable_type,
         nullable_value=nullable_value,
+        pk_optional=pk_optional,
     )
     default = ...
     if not field.concrete and field.auto_created or field.null:

--- a/ninja/orm/metaclass.py
+++ b/ninja/orm/metaclass.py
@@ -21,6 +21,7 @@ class MetaConf:
     fields_optional: Union[List[str], str, None] = None
     nullable_type: Any = settings.NULLABLE_FIELD_UNION_TYPE
     nullable_value: Any = settings.NULLABLE_FIELD_DEFAULT_VALUE
+    pk_optional: bool = settings.PK_OPTIONAL
 
     @staticmethod
     def from_schema_class(name: str, namespace: dict) -> "MetaConf":
@@ -48,6 +49,7 @@ class MetaConf:
             nullable_value = getattr(
                 meta, "nullable_value", settings.NULLABLE_FIELD_DEFAULT_VALUE
             )
+            pk_optional = getattr(meta, "pk_optional", settings.PK_OPTIONAL)
 
         else:
             raise ConfigError(f"ModelSchema class '{name}' requires a 'Meta' subclass")
@@ -71,6 +73,7 @@ class MetaConf:
             fields_optional=optional_fields,
             nullable_type=nullable_type,
             nullable_value=nullable_value,
+            pk_optional=pk_optional,
         )
 
 
@@ -121,6 +124,7 @@ class ModelSchemaMetaclass(ResolverMetaclass):
                     custom_fields=custom_fields,
                     nullable_type=meta_conf.nullable_type,
                     nullable_value=meta_conf.nullable_value,
+                    pk_optional=meta_conf.pk_optional,
                     base_class=cls,
                 )
                 model_schema.__doc__ = cls.__doc__

--- a/ninja/orm/metaclass.py
+++ b/ninja/orm/metaclass.py
@@ -5,6 +5,7 @@ from django.db.models import Model as DjangoModel
 from pydantic.dataclasses import dataclass
 
 from ninja.compatibility.util import get_annotations_from_namespace
+from ninja.conf import settings
 from ninja.errors import ConfigError
 from ninja.orm.factory import create_schema
 from ninja.schema import ResolverMetaclass, Schema
@@ -18,6 +19,8 @@ class MetaConf:
     fields: Optional[List[str]] = None
     exclude: Union[List[str], str, None] = None
     fields_optional: Union[List[str], str, None] = None
+    nullable_type: Any = settings.NULLABLE_FIELD_UNION_TYPE
+    nullable_value: Any = settings.NULLABLE_FIELD_DEFAULT_VALUE
 
     @staticmethod
     def from_schema_class(name: str, namespace: dict) -> "MetaConf":
@@ -39,6 +42,12 @@ class MetaConf:
             fields = getattr(meta, "fields", None)
             exclude = getattr(meta, "exclude", None)
             optional_fields = getattr(meta, "fields_optional", None)
+            nullable_type = getattr(
+                meta, "nullable_type", settings.NULLABLE_FIELD_UNION_TYPE
+            )
+            nullable_value = getattr(
+                meta, "nullable_value", settings.NULLABLE_FIELD_DEFAULT_VALUE
+            )
 
         else:
             raise ConfigError(f"ModelSchema class '{name}' requires a 'Meta' subclass")
@@ -60,6 +69,8 @@ class MetaConf:
             fields=fields,
             exclude=exclude,
             fields_optional=optional_fields,
+            nullable_type=nullable_type,
+            nullable_value=nullable_value,
         )
 
 
@@ -108,6 +119,8 @@ class ModelSchemaMetaclass(ResolverMetaclass):
                     exclude=meta_conf.exclude,
                     optional_fields=meta_conf.fields_optional,
                     custom_fields=custom_fields,
+                    nullable_type=meta_conf.nullable_type,
+                    nullable_value=meta_conf.nullable_value,
                     base_class=cls,
                 )
                 model_schema.__doc__ = cls.__doc__

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -35,13 +35,17 @@ from django.db.models.fields.files import FieldFile
 from django.template import Variable, VariableDoesNotExist
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, model_validator
 from pydantic._internal._model_construction import ModelMetaclass
-from pydantic.experimental.missing_sentinel import MISSING
 from pydantic.functional_validators import ModelWrapValidatorHandler
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
 from typing_extensions import dataclass_transform
 
 from ninja.signature.utils import get_args_names, has_kwargs
 from ninja.types import DictStrAny
+
+try:
+    from pydantic.experimental.missing_sentinel import MISSING
+except ImportError:
+    MISSING = object()
 
 pydantic_version = list(map(int, pydantic.VERSION.split(".")[:2]))
 assert pydantic_version >= [2, 0], "Pydantic 2.0+ required"

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -44,7 +44,7 @@ from ninja.types import DictStrAny
 
 try:
     from pydantic.experimental.missing_sentinel import MISSING
-except ImportError:
+except ImportError:  # pragma: no cover
     MISSING = object()
 
 pydantic_version = list(map(int, pydantic.VERSION.split(".")[:2]))

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -35,6 +35,7 @@ from django.db.models.fields.files import FieldFile
 from django.template import Variable, VariableDoesNotExist
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, model_validator
 from pydantic._internal._model_construction import ModelMetaclass
+from pydantic.experimental.missing_sentinel import MISSING
 from pydantic.functional_validators import ModelWrapValidatorHandler
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
 from typing_extensions import dataclass_transform
@@ -191,7 +192,11 @@ class NinjaGenerateJsonSchema(GenerateJsonSchema):
         json_schema = self.generate_inner(schema["schema"])
 
         default = None
-        if "default" in schema and schema["default"] is not None:
+        if (
+            "default" in schema
+            and schema["default"] is not None
+            and schema["default"] is not MISSING
+        ):
             default = self.encode_default(schema["default"])
 
         if "$ref" in json_schema:
@@ -199,8 +204,7 @@ class NinjaGenerateJsonSchema(GenerateJsonSchema):
             result = {"allOf": [json_schema]}
         else:
             result = json_schema
-
-        if default is not None:
+        if default is not None and default is not MISSING:
             result["default"] = default
 
         return result

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -97,7 +97,7 @@ class DjangoGetter:
         elif isinstance(result, getattr(QuerySet, "__origin__", QuerySet)):
             return list(result)
 
-        if callable(result):
+        if result is not MISSING and callable(result):  # MISSING is callable in <3.11
             return result()
 
         elif isinstance(result, FieldFile):

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -45,6 +45,8 @@ from ninja.types import DictStrAny
 try:
     from pydantic.experimental.missing_sentinel import MISSING
 except ImportError:  # pragma: no cover
+    # pydantic <2.11 does not have the MISSING sentinel, and thus it cannot be used for many reasons.
+    # fake it here with object so it doesn't error
     MISSING = object()
 
 pydantic_version = list(map(int, pydantic.VERSION.split(".")[:2]))
@@ -101,7 +103,7 @@ class DjangoGetter:
         elif isinstance(result, getattr(QuerySet, "__origin__", QuerySet)):
             return list(result)
 
-        if result is not MISSING and callable(result):  # MISSING is callable in <3.11
+        if result is not MISSING and callable(result):
             return result()
 
         elif isinstance(result, FieldFile):

--- a/tests/test_missing_sentinel.py
+++ b/tests/test_missing_sentinel.py
@@ -1,7 +1,7 @@
 from django.db import models
 from pydantic.experimental.missing_sentinel import MISSING
 
-from ninja import Field, NinjaAPI, Schema
+from ninja import Field, ModelSchema, NinjaAPI, Schema
 from ninja.orm import create_schema
 
 
@@ -18,6 +18,14 @@ ProjectModelSchema = create_schema(
 )
 
 
+class ProjectModelSchemaClass(ModelSchema):
+    class Meta:
+        model = Project
+        fields = ["name", "missing"]
+        nullable_type = MISSING
+        nullable_value = MISSING
+
+
 class ProjectSchema(Schema):
     name: str = Field(..., max_length=10)
     missing: str | MISSING = Field(MISSING, max_length=10)
@@ -28,6 +36,11 @@ api = NinjaAPI()
 
 @api.get("/modelschema", response=ProjectModelSchema)
 def get_modelschema(request, input: ProjectModelSchema):
+    return Project(name="Name")
+
+
+@api.get("/modelschemameta", response=ProjectModelSchemaClass)
+def get_modelschemameta(request, input: ProjectModelSchemaClass):
     return Project(name="Name")
 
 
@@ -58,3 +71,16 @@ def test_missing_in_modelschema():
         "missing"
     ] == {"title": "Missing", "type": "string", "maxLength": 10}
     assert ProjectModelSchema(name="Name").model_dump() == {"name": "Name"}
+
+
+def test_missing_in_meta():
+    assert (
+        "missing"
+        not in openapi_schema["components"]["schemas"]["ProjectModelSchemaClass"][
+            "required"
+        ]
+    )
+    assert openapi_schema["components"]["schemas"]["ProjectModelSchemaClass"][
+        "properties"
+    ]["missing"] == {"title": "Missing", "type": "string", "maxLength": 10}
+    assert ProjectSchema(name="Name").model_dump() == {"name": "Name"}

--- a/tests/test_missing_sentinel.py
+++ b/tests/test_missing_sentinel.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import pytest
 from django.db import models
 
@@ -47,7 +49,7 @@ class ProjectModelSchemaClass(ModelSchema):
 
 class ProjectSchema(Schema):
     name: str = Field(..., max_length=10)
-    missing: str | MISSING = Field(MISSING, max_length=10)
+    missing: Union[str, MISSING] = Field(MISSING, max_length=10)
 
 
 api = NinjaAPI()

--- a/tests/test_missing_sentinel.py
+++ b/tests/test_missing_sentinel.py
@@ -1,0 +1,56 @@
+from django.db import models
+from pydantic.experimental.missing_sentinel import MISSING
+
+from ninja import Field, NinjaAPI, Schema
+from ninja.orm import create_schema
+
+
+class Project(models.Model):
+    name = models.CharField(max_length=10)
+    missing = models.CharField(max_length=10, blank=True, null=True)
+
+    class Meta:
+        app_label = "tests"
+
+
+ProjectModelSchema = create_schema(Project, fields=["name", "missing"])
+
+
+class ProjectSchema(Schema):
+    name: str = Field(..., max_length=10)
+    missing: str | MISSING = Field(MISSING, max_length=10)
+
+
+api = NinjaAPI()
+
+
+@api.get("/modelschema", response=ProjectModelSchema)
+def get_modelschema(request, input: ProjectModelSchema):
+    return Project(name="Name")
+
+
+@api.get("/schema", response=ProjectSchema)
+def get_schema(request, input: ProjectSchema):
+    return {"name": "Name"}
+
+
+openapi_schema = api.get_openapi_schema()
+
+
+def test_missing_in_schema():
+    assert (
+        "missing"
+        not in openapi_schema["components"]["schemas"]["ProjectSchema"]["required"]
+    )
+    assert openapi_schema["components"]["schemas"]["ProjectSchema"]["properties"][
+        "missing"
+    ] == {"title": "Missing", "type": "string", "maxLength": 10}
+
+
+def test_missing_in_modelschema():
+    assert (
+        "missing" not in openapi_schema["components"]["schemas"]["Project"]["required"]
+    )
+    assert openapi_schema["components"]["schemas"]["Project"]["properties"][
+        "missing"
+    ] == {"title": "Missing", "type": "string", "maxLength": 10}

--- a/tests/test_missing_sentinel.py
+++ b/tests/test_missing_sentinel.py
@@ -13,7 +13,9 @@ class Project(models.Model):
         app_label = "tests"
 
 
-ProjectModelSchema = create_schema(Project, fields=["name", "missing"])
+ProjectModelSchema = create_schema(
+    Project, fields=["name", "missing"], nullable_value=MISSING, nullable_type=MISSING
+)
 
 
 class ProjectSchema(Schema):
@@ -45,6 +47,7 @@ def test_missing_in_schema():
     assert openapi_schema["components"]["schemas"]["ProjectSchema"]["properties"][
         "missing"
     ] == {"title": "Missing", "type": "string", "maxLength": 10}
+    assert ProjectSchema(name="Name").model_dump() == {"name": "Name"}
 
 
 def test_missing_in_modelschema():
@@ -54,3 +57,4 @@ def test_missing_in_modelschema():
     assert openapi_schema["components"]["schemas"]["Project"]["properties"][
         "missing"
     ] == {"title": "Missing", "type": "string", "maxLength": 10}
+    assert ProjectModelSchema(name="Name").model_dump() == {"name": "Name"}

--- a/tests/test_missing_sentinel.py
+++ b/tests/test_missing_sentinel.py
@@ -5,16 +5,29 @@ from ninja import Field, ModelSchema, NinjaAPI, Schema
 from ninja.orm import create_schema
 
 
-class Project(models.Model):
-    name = models.CharField(max_length=10)
+class Status(models.Model):
+    label = models.CharField(max_length=10)
     missing = models.CharField(max_length=10, blank=True, null=True)
 
     class Meta:
         app_label = "tests"
 
 
+class Project(models.Model):
+    name = models.CharField(max_length=10)
+    missing = models.CharField(max_length=10, blank=True, null=True)
+    status = models.ForeignKey(Status, on_delete=models.SET_NULL, blank=True, null=True)
+
+    class Meta:
+        app_label = "tests"
+
+
 ProjectModelSchema = create_schema(
-    Project, fields=["name", "missing"], nullable_value=MISSING, nullable_type=MISSING
+    Project,
+    fields=["name", "missing", "status"],
+    nullable_value=MISSING,
+    nullable_type=MISSING,
+    depth=2,
 )
 
 
@@ -72,6 +85,15 @@ def test_missing_in_modelschema():
     ] == {"title": "Missing", "type": "string", "maxLength": 10}
     assert ProjectModelSchema(name="Name").model_dump() == {"name": "Name"}
 
+    # the configured `nullable_value`, `None`s, and empty lists should be converted to `nullable_value`
+    assert ProjectModelSchema(name="Name", missing=None).model_dump() == {
+        "name": "Name"
+    }
+    assert ProjectModelSchema(name="Name", missing=MISSING).model_dump() == {
+        "name": "Name"
+    }
+    assert ProjectModelSchema(name="Name", missing=[]).model_dump() == {"name": "Name"}
+
 
 def test_missing_in_meta():
     assert (
@@ -83,4 +105,38 @@ def test_missing_in_meta():
     assert openapi_schema["components"]["schemas"]["ProjectModelSchemaClass"][
         "properties"
     ]["missing"] == {"title": "Missing", "type": "string", "maxLength": 10}
-    assert ProjectSchema(name="Name").model_dump() == {"name": "Name"}
+
+    assert ProjectModelSchemaClass(name="Name").model_dump() == {"name": "Name"}
+
+    # the configured `nullable_value`, `None`s, and empty lists should be converted to `nullable_value`
+    assert ProjectModelSchemaClass(name="Name", missing=None).model_dump() == {
+        "name": "Name"
+    }
+    assert ProjectModelSchemaClass(name="Name", missing=MISSING).model_dump() == {
+        "name": "Name"
+    }
+    assert ProjectModelSchemaClass(name="Name", missing=[]).model_dump() == {
+        "name": "Name"
+    }
+
+
+def test_missing_in_child():
+    assert (
+        "missing" not in openapi_schema["components"]["schemas"]["Status"]["required"]
+    )
+    assert openapi_schema["components"]["schemas"]["Status"]["properties"][
+        "missing"
+    ] == {"title": "Missing", "type": "string", "maxLength": 10}
+
+    inst = ProjectModelSchema(name="Name", status=Status(label="Label"))
+    assert inst.model_dump() == {"name": "Name", "status": {"label": "Label"}}
+
+    # the configured `nullable_value`, `None`s, and empty lists should be converted to `nullable_value`
+    inst = ProjectModelSchema(name="Name", status=Status(label="Label", missing=None))
+    assert inst.model_dump() == {"name": "Name", "status": {"label": "Label"}}
+    inst = ProjectModelSchema(
+        name="Name", status=Status(label="Label", missing=MISSING)
+    )
+    assert inst.model_dump() == {"name": "Name", "status": {"label": "Label"}}
+    inst = ProjectModelSchema(name="Name", status=Status(label="Label", missing=[]))
+    assert inst.model_dump() == {"name": "Name", "status": {"label": "Label"}}

--- a/tests/test_missing_sentinel.py
+++ b/tests/test_missing_sentinel.py
@@ -1,8 +1,14 @@
+import pytest
 from django.db import models
-from pydantic.experimental.missing_sentinel import MISSING
 
 from ninja import Field, ModelSchema, NinjaAPI, Schema
 from ninja.orm import create_schema
+
+# skip file if can't import MISSING
+try:
+    from pydantic.experimental.missing_sentinel import MISSING
+except ImportError:
+    pytest.skip(reason="MISSING sentinel cannot be imported", allow_module_level=True)
 
 
 class Status(models.Model):

--- a/tests/test_missing_sentinel.py
+++ b/tests/test_missing_sentinel.py
@@ -10,6 +10,7 @@ from ninja.orm import create_schema
 try:
     from pydantic.experimental.missing_sentinel import MISSING
 except ImportError:
+    # if MISSING cannot be imported, it can't be used as a type/value for pydantic
     pytest.skip(reason="MISSING sentinel cannot be imported", allow_module_level=True)
 
 


### PR DESCRIPTION
#1655

I've been struggling with model schemas having `null` as an option for fields that I simply want to omit from the response. If the keys don't exist in the response, then there is no data. The current implementation does not allow changing how `create_schema` handles nullable fields and it always assigns a `type | None = None`. This causes all of my generated api clients to type hint incorrectly which is really annoying. `exclude_unset` also does not work for modelschemas since it's technically set since the model instance is interrogated via attributes and returns an explicit `None` for nullable fields and it does not help generate an accurate json schema.

The main feature of this PR is allowing modification to the type and value used when a field is "nullable". This allows [`MISSING`](https://docs.pydantic.dev/latest/concepts/experimental/#missing-sentinel) to be used, which will create the data schema I'm looking for, while also supporting other type/value combos.

```python
from typing import Literal

from django.db import models
from ninja.orm import create_schema
from ninja import NinjaAPI
from pydantic.experimental.missing_sentinel import MISSING

from devtools import debug


class Profile(models.Model):
    name = models.CharField(max_length=10)
    nullable = models.CharField(max_length=10, blank=True, null=True)

    class Meta:
        app_label = "tests"


ProfileModelSchema1 = create_schema(
    Profile,
    name="ProfileModelSchema1",
    fields=["name", "nullable"],
    nullable_type=MISSING,
    nullable_value=MISSING,
)


ProfileModelSchema2 = create_schema(
    Profile,
    name="ProfileModelSchema2",
    fields=["name", "nullable"],
    nullable_type=Literal["MyNullValue"],
    nullable_value="MyNullValue",
)

api = NinjaAPI()


@api.get("/profile1", response=ProfileModelSchema1)
def get_profile1(request):
    return Profile(name="Name")


@api.get("/profile2", response=ProfileModelSchema2)
def get_profile2(request):
    return Profile(name="Name")

api.get_openapi_json() == {
        ...
        'components': {
            'schemas': {
                'ProfileModelSchema1': {
                    'properties': {
                        'name': {
                            'maxLength': 10,
                            'title': 'Name',
                            'type': 'string',
                        },
                        'nullable': {
                            'maxLength': 10,
                            'title': 'Nullable',
                            'type': 'string',
                        },
                    },
                    'required': ['name'],
                    'title': 'ProfileModelSchema1',
                    'type': 'object',
                },
                'ProfileModelSchema2': {
                    'properties': {
                        'name': {
                            'maxLength': 10,
                            'title': 'Name',
                            'type': 'string',
                        },
                        'nullable': {
                            'anyOf': [
                                {
                                    'maxLength': 10,
                                    'type': 'string',
                                },
                                {
                                    'const': 'MyNullValue',
                                    'type': 'string',
                                },
                            ],
                            'default': 'MyNullValue',
                            'title': 'Nullable',
                        },
                    },
                    'required': ['name'],
                    'title': 'ProfileModelSchema2',
                    'type': 'object',
                },
            },
        },
        ...
    }
```