### PR TITLE
fix: Off-by-one parsing client IP from X-Forwarded-For with NUM_PROXIES 

### DIFF
--- a/ninja/throttling.py
+++ b/ninja/throttling.py
@@ -34,7 +34,7 @@ class BaseThrottle:
             if num_proxies == 0 or xff is None:
                 return remote_addr
             addrs: List[str] = xff.split(",")
-            client_addr = addrs[-min(num_proxies, len(addrs))]
+            client_addr = addrs[-min(num_proxies + 1, len(addrs))]
             return client_addr.strip()
 
         return "".join(xff.split()) if xff else remote_addr

--- a/tests/test_throttling.py
+++ b/tests/test_throttling.py
@@ -285,7 +285,16 @@ def test_proxy_throttle():
     assert th.get_ident(request) == "8.8.8.8"
 
     settings.NUM_PROXIES = 1
-    assert th.get_ident(request) == "127.0.0.1"
+    assert th.get_ident(request) == "8.8.8.8"
+
+    request = build_request(x_forwarded_for="8.8.8.8, 89.212.66.133, 127.0.0.1")
+    settings.NUM_PROXIES = 2
+    assert th.get_ident(request) == "8.8.8.8"
+
+    # Protect against client-supplied X-Forwarded-For header (client is really 8.8.8.8)
+    request = build_request(x_forwarded_for="1.2.3.4,8.8.8.8,89.212.66.133,127.0.0.1")
+    settings.NUM_PROXIES = 2
+    assert th.get_ident(request) == "8.8.8.8"
 
     settings.NUM_PROXIES = None
 


### PR DESCRIPTION
Closes https://github.com/vitalik/django-ninja/issues/1670

Potentially a breaking change if someone had tuned NUM_PROXIES to accommodate for the prior mishandling.