### PR TITLE
Configurable Throttling Client IP Callable

### DIFF
--- a/docs/docs/guides/throttling.md
+++ b/docs/docs/guides/throttling.md
@@ -105,3 +105,21 @@ class NoReadsThrottle(AnonRateThrottle):
             return True
         return super().allow_request(request)
 ```
+
+## Customizing Client IP Address Lookups
+
+To use custom client IP address lookup logic, change the `NINJA_CLIENT_IP_CALLABLE` setting to a suitable callable path.
+
+Example
+
+```Python
+from django.http import HttpRequest
+
+def get_client_ip(request: HttpRequest) -> str:
+    return request.META.get("REMOTE_ADDR")
+```
+
+`settings.py`:
+```python
+NINJA_CLIENT_IP_CALLABLE = "example.utils.get_client_ip"
+```

--- a/ninja/conf.py
+++ b/ninja/conf.py
@@ -21,6 +21,9 @@ class Settings(BaseModel):
 
     # Throttling
     NUM_PROXIES: Optional[int] = Field(None, alias="NINJA_NUM_PROXIES")
+    CLIENT_IP_CALLABLE: str = Field(
+        "ninja.throttling.get_client_ip", alias="NINJA_CLIENT_IP_CALLABLE"
+    )
     DEFAULT_THROTTLE_RATES: Dict[str, Optional[str]] = Field(
         {
             "auth": "10000/day",


### PR DESCRIPTION
Closes https://github.com/vitalik/django-ninja/issues/1674

Makes the function to lookup the end-user's client IP a configurable callable.

* The default behaviour is to preserve the current behaviour
* Deprecate the `get_ident` function in favour of `client_ip`, but keep the function behaving the same