### PR TITLE
Ignore TextField max_length in model validation

### DIFF
--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -153,6 +153,9 @@ def get_schema_field(
         max_length = field_options.get("max_length")
 
         internal_type = field.get_internal_type()
+        if internal_type == "TextField":
+            # Django uses TextField.max_length for forms only, not validation.
+            max_length = None
         try:
             python_type = TYPES[internal_type]
         except KeyError as e:

--- a/tests/test_orm_schemas.py
+++ b/tests/test_orm_schemas.py
@@ -371,6 +371,24 @@ def test_default():
     }
 
 
+def test_textfield_max_length_is_not_enforced():
+    class MyModel(models.Model):
+        text = models.TextField(max_length=5)
+
+        class Meta:
+            app_label = "tests"
+
+    Schema = create_schema(MyModel)
+
+    assert Schema.json_schema()["properties"]["text"] == {
+        "title": "Text",
+        "type": "string",
+    }
+
+    obj = type("Obj", (), {"text": "123456"})()
+    assert Schema.from_orm(obj).dict() == {"id": None, "text": "123456"}
+
+
 def test_fields_exclude():
     class SampleModel(models.Model):
         f1 = models.CharField()


### PR DESCRIPTION
`TextField.max_length` only affects Django forms, not model/database validation.

This PR stops ModelSchema generation from passing `max_length` through to Pydantic for `TextField`, so long text values are accepted again. I also added a regression test covering a `TextField(max_length=5)` instance serialized through `create_schema()`.

Validation:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -c /dev/null tests/test_orm_schemas.py -k "textfield_max_length_is_not_enforced or all_fields or default" -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -c /dev/null tests/test_orm_schemas.py -q`
- `ruff check ninja/orm/fields.py tests/test_orm_schemas.py`
