### PR TITLE
Use a UserWarning instead of print()

### DIFF
--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -1,5 +1,7 @@
+import inspect
 import itertools
 import re
+import warnings
 from http.client import responses
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Set, Tuple
 
@@ -113,10 +115,14 @@ class OpenAPISchema(dict):
     def operation_details(self, operation: Operation) -> DictStrAny:
         op_id = operation.operation_id or self.api.get_openapi_operation_id(operation)
         if op_id in self.all_operation_ids:
-            print(
-                bold_red_style(
-                    f'Warning: operation_id "{op_id}" is already used (Try giving a different name to: {operation.view_func.__module__}.{operation.view_func.__name__})'
-                )
+            warnings.warn_explicit(
+                UserWarning(
+                    f'operation_id "{op_id}" is already used (Try giving a different name to: {operation.view_func.__module__}.{operation.view_func.__name__})'
+                ),
+                category=None,
+                filename=inspect.getfile(operation.view_func),
+                lineno=inspect.getsourcelines(operation.view_func)[1],
+                source=None,
             )
         self.all_operation_ids.add(op_id)
         result = {

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -892,7 +892,7 @@ def test_get_openapi_urls():
         get_openapi_urls(api)
 
 
-def test_unique_operation_ids(capsys):
+def test_unique_operation_ids():
     api = NinjaAPI()
 
     @api.get("/1")
@@ -903,9 +903,10 @@ def test_unique_operation_ids(capsys):
     def same_name(request):  # noqa: F811
         pass
 
-    api.get_openapi_schema()
-    captured = capsys.readouterr()
-    assert '"test_openapi_schema_same_name" is already used ' in captured.out
+    with pytest.warns(
+        UserWarning, match='"test_openapi_schema_same_name" is already used'
+    ):
+        api.get_openapi_schema()
 
 
 def test_docs_decorator():


### PR DESCRIPTION
I noticed while updating our internal API to set an explicit `operation_id`, that the error of a duplicate `operation_id` is a regular print-statement and not a warning (so we can monitor easily for errors).