### PR TITLE
annotation fixes - python 3.14 compatibility

### DIFF
--- a/ninja/signature/utils.py
+++ b/ninja/signature/utils.py
@@ -18,10 +18,23 @@ __all__ = [
     "is_async",
 ]
 
+if version_info >= (3, 14):
+    import annotationlib
+
+    _FORWARDREF_KWARGS: dict[str, Any] = {
+        "annotation_format": annotationlib.Format.FORWARDREF
+    }
+    _STRING_KWARGS: dict[str, Any] = {
+        "annotation_format": annotationlib.Format.STRING
+    }
+else:
+    _FORWARDREF_KWARGS: dict[str, Any] = {}
+    _STRING_KWARGS: dict[str, Any] = {}
+
 
 def get_typed_signature(call: Callable[..., Any]) -> inspect.Signature:
     "Finds call signature and resolves all forwardrefs"
-    signature = inspect.signature(call)
+    signature = inspect.signature(call, **_FORWARDREF_KWARGS)
     globalns = getattr(call, "__globals__", {})
     typed_params = [
         inspect.Parameter(
@@ -66,7 +79,7 @@ def is_async(callable: Callable[..., Any]) -> bool:
 
 
 def has_kwargs(func: Callable[..., Any]) -> bool:
-    for param in inspect.signature(func).parameters.values():
+    for param in inspect.signature(func, **_STRING_KWARGS).parameters.values():
         if param.kind == param.VAR_KEYWORD:
             return True
     return False
@@ -74,7 +87,7 @@ def has_kwargs(func: Callable[..., Any]) -> bool:
 
 def get_args_names(func: Callable[..., Any]) -> List[str]:
     "returns list of function argument names"
-    return list(inspect.signature(func).parameters.keys())
+    return list(inspect.signature(func, **_STRING_KWARGS).parameters.keys())
 
 
 class UUIDStrConverter(UUIDConverter):

--- a/ninja/signature/utils.py
+++ b/ninja/signature/utils.py
@@ -2,7 +2,7 @@ import asyncio
 import inspect
 import re
 from sys import version_info
-from typing import Any, Callable, ForwardRef, List, Set
+from typing import Any, Callable, Dict, ForwardRef, List, Set
 
 from django.urls import register_converter
 from django.urls.converters import UUIDConverter
@@ -21,15 +21,15 @@ __all__ = [
 if version_info >= (3, 14):
     import annotationlib
 
-    _FORWARDREF_KWARGS: dict[str, Any] = {
-        "annotation_format": annotationlib.Format.FORWARDREF
+    _FORWARDREF_KWARGS: Dict[str, Any] = {
+        "annotation_format": annotationlib.Format.FORWARDREF,
     }
-    _STRING_KWARGS: dict[str, Any] = {
-        "annotation_format": annotationlib.Format.STRING
+    _STRING_KWARGS: Dict[str, Any] = {
+        "annotation_format": annotationlib.Format.STRING,
     }
 else:
-    _FORWARDREF_KWARGS: dict[str, Any] = {}
-    _STRING_KWARGS: dict[str, Any] = {}
+    _FORWARDREF_KWARGS: Dict[str, Any] = {}
+    _STRING_KWARGS: Dict[str, Any] = {}
 
 
 def get_typed_signature(call: Callable[..., Any]) -> inspect.Signature:

--- a/ninja/signature/utils.py
+++ b/ninja/signature/utils.py
@@ -18,18 +18,21 @@ __all__ = [
     "is_async",
 ]
 
-if version_info >= (3, 14):
+_FORWARDREF_KWARGS: Dict[str, Any]
+_STRING_KWARGS: Dict[str, Any]
+
+if version_info >= (3, 14):  # pragma: no cover
     import annotationlib
 
-    _FORWARDREF_KWARGS: Dict[str, Any] = {
+    _FORWARDREF_KWARGS = {
         "annotation_format": annotationlib.Format.FORWARDREF,
     }
-    _STRING_KWARGS: Dict[str, Any] = {
+    _STRING_KWARGS = {
         "annotation_format": annotationlib.Format.STRING,
     }
-else:
-    _FORWARDREF_KWARGS: Dict[str, Any] = {}
-    _STRING_KWARGS: Dict[str, Any] = {}
+else:  # pragma: no cover
+    _FORWARDREF_KWARGS = {}
+    _STRING_KWARGS = {}
 
 
 def get_typed_signature(call: Callable[..., Any]) -> inspect.Signature:

--- a/tests/test_annotations_py314.py
+++ b/tests/test_annotations_py314.py
@@ -1,0 +1,59 @@
+from sys import version_info
+from typing import List
+
+import pytest
+from django.http import HttpRequest
+
+from ninja import NinjaAPI, Query, Schema
+from ninja.pagination import PageNumberPagination, paginate
+from ninja.testing import TestClient
+
+pytestmark = pytest.mark.skipif(
+    version_info < (3, 14),
+    reason="requires Python 3.14 deferred annotations",
+)
+
+
+class DeferredQuerySchema(Schema):
+    foo: str
+
+
+class AuthenticatedNinjaRequest(HttpRequest):
+    auth: str
+
+
+if version_info >= (3, 14):
+
+    class ResolveWithSelfReference(Schema):
+        name: str
+
+        @staticmethod
+        def resolve_name(obj) -> ResolveWithSelfReference:  # noqa: F821
+            return obj.get("name", "default")
+
+else:
+    ResolveWithSelfReference = None
+
+
+def test_paginated_route_with_deferred_annotations():
+    api = NinjaAPI(urls_namespace="annotations_py314")
+
+    @api.get("/endpoint", response=List[int])
+    @paginate(PageNumberPagination)
+    def endpoint(
+        request: AuthenticatedNinjaRequest,
+        params: Query[DeferredQuerySchema],
+    ):
+        return []
+
+    client = TestClient(api)
+    response = client.get("/endpoint?foo=test")
+
+    assert response.status_code == 200, response.content
+    assert response.json() == {"items": [], "count": 0}
+
+
+def test_schema_with_self_referencing_resolver_annotation():
+    assert ResolveWithSelfReference is not None
+    obj = ResolveWithSelfReference.model_validate({"name": "test"})
+    assert obj.name == "test"

--- a/tests/test_schema_context.py
+++ b/tests/test_schema_context.py
@@ -60,3 +60,16 @@ def test_request_context():
         "other": {"value": {"request": "<request>"}, "other": None},
         "value": {"request": "<request>", "response_status": "200"},
     }
+
+
+class ResolveWithSelfReference(Schema):
+    name: str
+
+    @staticmethod
+    def resolve_name(obj) -> ResolveWithSelfReference:
+        return obj.get("name", "default")
+
+
+def test_schema_with_self_referencing_annotation():
+    obj = ResolveWithSelfReference.model_validate({"name": "test"})
+    assert obj.name == "test"

--- a/tests/test_schema_context.py
+++ b/tests/test_schema_context.py
@@ -60,16 +60,3 @@ def test_request_context():
         "other": {"value": {"request": "<request>"}, "other": None},
         "value": {"request": "<request>", "response_status": "200"},
     }
-
-
-class ResolveWithSelfReference(Schema):
-    name: str
-
-    @staticmethod
-    def resolve_name(obj) -> ResolveWithSelfReference:
-        return obj.get("name", "default")
-
-
-def test_schema_with_self_referencing_annotation():
-    obj = ResolveWithSelfReference.model_validate({"name": "test"})
-    assert obj.name == "test"


### PR DESCRIPTION
These changes allow me to enable the ruff rules TC001/TC002/TC003/UP037 + py314 for projects that use django-ninja.

---

Python 3.14 makes deferred annotation evaluation the default via PEP 649 / PEP 749.

Django Ninja already has a separate compatibility fix for the `ModelSchemaMetaclass` class-namespace case https://github.com/vitalik/django-ninja/pull/1688, but there were still a couple of `inspect.signature()` paths that could force annotation handling too early on Python 3.14:

- `get_typed_signature()` when wrapped view functions are inspected
- `get_args_names()` / `has_kwargs()` when schema resolver methods are inspected during class creation

This PR makes those Python 3.14 signature reads explicit about the annotation format:

- `get_typed_signature()` uses `annotation_format=annotationlib.Format.FORWARDREF`
- `get_args_names()` and `has_kwargs()` use `annotation_format=annotationlib.Format.STRING`

This is the same general failure mode seen in earlier reports such as https://github.com/vitalik/django-ninja/issues/1424 and https://github.com/vitalik/django-ninja/issues/1357 annotations attached to wrapped or not-yet-fully-bound callables can blow up during signature inspection when they are evaluated in the wrong scope.

https://github.com/vitalik/django-ninja/issues/1652 is related background for the broader Python 3.14 annotation transition, but its `ModelSchemaMetaclass` path was already addressed separately. This PR covers the remaining `inspect.signature()` edge cases.