### PR TITLE
New method in router to create CRUD for a Django model.

### DIFF
--- a/docs/docs/guides/model-api.md
+++ b/docs/docs/guides/model-api.md
@@ -1,0 +1,238 @@
+# Auto-generated Model API
+
+**Django Ninja** can automatically generate a full set of CRUD endpoints for any Django model with a single method call.
+
+```python
+router.add_model_api(MyModel)
+```
+
+This registers **6 endpoints** at once, covering every standard CRUD operation — no boilerplate required.
+
+## Generated endpoints
+
+Given a model named `Category`, the following routes are registered (relative to the router prefix):
+
+| Method   | Path               | Action          | Status |
+|----------|--------------------|-----------------|--------|
+| `GET`    | `/category/`       | List all        | 200    |
+| `POST`   | `/category/`       | Create          | 201    |
+| `GET`    | `/category/{id}`   | Retrieve by PK  | 200    |
+| `PUT`    | `/category/{id}`   | Full update     | 200    |
+| `PATCH`  | `/category/{id}`   | Partial update  | 200    |
+| `DELETE` | `/category/{id}`   | Delete          | 204    |
+
+The URL prefix is derived automatically from the lowercase model name.
+
+## Quick start
+
+```python
+# myapp/api.py
+from ninja import Router
+from .models import Category
+
+router = Router()
+router.add_model_api(Category)
+```
+
+Mount the router in your main API file:
+
+```python
+# myproject/api.py
+from ninja import NinjaAPI
+from myapp.api import router as category_router
+
+api = NinjaAPI()
+api.add_router("", category_router)
+```
+
+Open `/api/docs` and you will see all six operations, complete with request/response schemas, ready to use.
+
+## Generated schemas
+
+Three Pydantic schemas are created automatically:
+
+| Schema                  | Used by            | Includes PK | All fields optional |
+|-------------------------|--------------------|-------------|---------------------|
+| `CategorySchema`        | List, Retrieve responses | Yes     | No                  |
+| `CategoryCreateSchema`  | POST / PUT body    | No          | No                  |
+| `CategoryPatchSchema`   | PATCH body         | No          | Yes (all optional)  |
+
+The schemas are derived from the model using [`create_schema`](response/django-pydantic-create-schema.md).
+
+## Parameters
+
+### `fields`
+
+Limit which model fields are included in the schemas. By default all fields are included.
+
+```python
+router.add_model_api(Article, fields=["title", "body"])
+```
+
+### `exclude`
+
+Remove specific fields from all three schemas.
+
+```python
+router.add_model_api(Order, exclude=["internal_notes", "cost_price"])
+```
+
+### `operations`
+
+Restrict which CRUD operations are registered. Available values:
+`"list"`, `"retrieve"`, `"create"`, `"update"`, `"patch"`, `"delete"`.
+
+```python
+# Read-only API — no writes allowed
+router.add_model_api(Product, operations=["list", "retrieve"])
+```
+
+### `tags`
+
+Override the OpenAPI tags applied to every generated operation. Defaults to the model class name.
+
+```python
+router.add_model_api(Category, tags=["catalog", "shop"])
+```
+
+### `auth`
+
+Apply an authenticator to every generated operation.
+
+```python
+from ninja.security import django_auth
+
+router.add_model_api(Order, auth=django_auth)
+```
+
+## Full example
+
+```python
+from ninja import NinjaAPI, Router
+from ninja.security import django_auth
+from myapp.models import Article
+
+api = NinjaAPI()
+router = Router()
+
+router.add_model_api(
+    Article,
+    exclude=["internal_notes"],
+    operations=["list", "retrieve", "create", "update", "patch", "delete"],
+    tags=["articles"],
+    auth=django_auth,
+)
+
+api.add_router("", router)
+```
+
+---
+
+## Async variant
+
+`add_async_model_api` generates **identical routes and schemas** but every view function is `async def`, taking full advantage of Django's async ORM (Django 4.1+).
+
+```python
+router.add_async_model_api(Category)
+```
+
+All parameters (`fields`, `exclude`, `operations`, `tags`, `auth`) work exactly the same way.
+
+### When to use the async variant
+
+Use `add_async_model_api` when:
+
+- Your project is deployed with an ASGI server (Uvicorn, Daphne, Hypercorn).
+- You expect high concurrency on these endpoints.
+- The rest of your API already uses `async def` views.
+
+Use `add_model_api` (sync) when:
+
+- You are using a WSGI server (gunicorn, uWSGI).
+- You are on Django < 4.1 (async ORM is not available).
+
+### Example
+
+```python
+# myapp/api.py
+from ninja import Router
+from .models import Category
+
+router = Router()
+router.add_async_model_api(Category)
+```
+
+!!! note
+    Both `add_model_api` and `add_async_model_api` produce identical OpenAPI schemas.
+    You can switch between them without changing your frontend or API clients.
+
+## Comparison with manual CRUD
+
+The auto-generated API is equivalent to writing this manually:
+
+```python
+from typing import List
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
+from ninja import Router, Schema
+from myapp.models import Category
+
+router = Router()
+
+
+class CategorySchema(Schema):
+    id: int
+    title: str
+
+
+class CategoryCreateSchema(Schema):
+    title: str
+
+
+class CategoryPatchSchema(Schema):
+    title: str | None = None
+
+
+@router.get("/category/", response=List[CategorySchema])
+def list_category(request):
+    return Category.objects.all()
+
+
+@router.post("/category/", response={201: CategorySchema})
+def create_category(request, payload: CategoryCreateSchema):
+    instance = Category(**payload.dict())
+    instance.save()
+    return 201, instance
+
+
+@router.get("/category/{id}", response=CategorySchema)
+def retrieve_category(request, id: int):
+    return get_object_or_404(Category, pk=id)
+
+
+@router.put("/category/{id}", response=CategorySchema)
+def update_category(request, id: int, payload: CategoryCreateSchema):
+    instance = get_object_or_404(Category, pk=id)
+    for attr, value in payload.dict().items():
+        setattr(instance, attr, value)
+    instance.save()
+    return instance
+
+
+@router.patch("/category/{id}", response=CategorySchema)
+def partial_update_category(request, id: int, payload: CategoryPatchSchema):
+    instance = get_object_or_404(Category, pk=id)
+    for attr, value in payload.dict(exclude_unset=True).items():
+        setattr(instance, attr, value)
+    instance.save()
+    return instance
+
+
+@router.delete("/category/{id}")
+def delete_category(request, id: int):
+    instance = get_object_or_404(Category, pk=id)
+    instance.delete()
+    return HttpResponse(status=204)
+```
+
+`add_model_api` handles all of the above — plus M2M field updates — in one line.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
           - guides/response/pagination.md
           - guides/response/response-renderers.md
       - Splitting your API with Routers: guides/routers.md
+      - Auto-generated Model API: guides/model-api.md
       - guides/decorators.md
       - guides/authentication.md
       - guides/throttling.md

--- a/ninja/router.py
+++ b/ninja/router.py
@@ -713,7 +713,9 @@ class Router:
             "partial_update",
             "destroy",
         ]
-        ops: List[str] = list(_all_operations) if operations is None else list(operations)
+        ops: List[str] = (
+            list(_all_operations) if operations is None else list(operations)
+        )
 
         model_name: str = model.__name__
 
@@ -726,14 +728,11 @@ class Router:
         auto_field_names = [
             f.name
             for f in model._meta.get_fields()
-            if hasattr(f, "get_internal_type")
-            and f.get_internal_type() in _auto_types
+            if hasattr(f, "get_internal_type") and f.get_internal_type() in _auto_types
         ]
 
         m2m_field_names = {
-            f.name
-            for f in model._meta.get_fields()
-            if isinstance(f, ManyToManyField)
+            f.name for f in model._meta.get_fields() if isinstance(f, ManyToManyField)
         }
 
         response_schema = _create_schema(
@@ -754,7 +753,7 @@ class Router:
                 model,
                 name=f"{model_name}PatchSchema",
                 fields=write_fields,
-                optional_fields="__all__",
+                optional_fields="__all__",  # type: ignore[arg-type]
             )
         else:
             write_exclude: List[str] = list(auto_field_names)
@@ -771,7 +770,7 @@ class Router:
                 model,
                 name=f"{model_name}PatchSchema",
                 exclude=write_exclude,
-                optional_fields="__all__",
+                optional_fields="__all__",  # type: ignore[arg-type]
             )
 
         return {
@@ -856,7 +855,7 @@ class Router:
         # --- LIST ---
         if "list" in ops:
 
-            def list_view(request):  # type: ignore[return]
+            def list_view(request: Any) -> Any:
                 return model.objects.all()
 
             list_view.__name__ = f"list_{model_name.lower()}"
@@ -864,7 +863,7 @@ class Router:
                 collection_path,
                 ["GET"],
                 list_view,
-                response=TypingList[response_schema],  # type: ignore[valid-type]
+                response=TypingList[response_schema],
                 summary=f"List {model_name}",
                 tags=_tags,
                 **_auth_kwarg,
@@ -873,7 +872,7 @@ class Router:
         # --- RETRIEVE ---
         if "retrieve" in ops:
 
-            def retrieve_view(request, id):  # type: ignore[return]
+            def retrieve_view(request: Any, id: Any) -> Any:
                 return get_object_or_404(model, pk=id)
 
             retrieve_view.__name__ = f"retrieve_{model_name.lower()}"
@@ -891,10 +890,10 @@ class Router:
         # --- CREATE ---
         if "create" in ops:
 
-            def create_view(request, payload):  # type: ignore[return]
+            def create_view(request: Any, payload: Any) -> Any:
                 data = payload.model_dump()
                 m2m_data = {k: data.pop(k) for k in m2m_field_names if k in data}
-                instance = model(**data)
+                instance: Any = model(**data)
                 instance.save()
                 for field_name, values in m2m_data.items():
                     getattr(instance, field_name).set(values)
@@ -915,8 +914,8 @@ class Router:
         # --- UPDATE (PUT) ---
         if "update" in ops:
 
-            def update_view(request, id, payload):  # type: ignore[return]
-                instance = get_object_or_404(model, pk=id)
+            def update_view(request: Any, id: Any, payload: Any) -> Any:
+                instance: Any = get_object_or_404(model, pk=id)
                 data = payload.model_dump()
                 m2m_data = {k: data.pop(k) for k in m2m_field_names if k in data}
                 for attr, value in data.items():
@@ -944,8 +943,8 @@ class Router:
         # --- PARTIAL UPDATE (PATCH) ---
         if "partial_update" in ops:
 
-            def partial_update_view(request, id, payload):  # type: ignore[return]
-                instance = get_object_or_404(model, pk=id)
+            def partial_update_view(request: Any, id: Any, payload: Any) -> Any:
+                instance: Any = get_object_or_404(model, pk=id)
                 data = payload.model_dump(exclude_unset=True)
                 m2m_data = {k: data.pop(k) for k in m2m_field_names if k in data}
                 for attr, value in data.items():
@@ -973,8 +972,8 @@ class Router:
         # --- DESTROY (DELETE) ---
         if "destroy" in ops:
 
-            def destroy_view(request, id):
-                instance = get_object_or_404(model, pk=id)
+            def destroy_view(request: Any, id: Any) -> HttpResponse:
+                instance: Any = get_object_or_404(model, pk=id)
                 instance.delete()
                 return HttpResponse(status=204)
 
@@ -1055,7 +1054,7 @@ class Router:
         # --- LIST ---
         if "list" in ops:
 
-            async def list_view(request):  # type: ignore[return]
+            async def list_view(request: Any) -> Any:
                 return [obj async for obj in model.objects.all()]
 
             list_view.__name__ = f"list_{model_name.lower()}"
@@ -1063,7 +1062,7 @@ class Router:
                 collection_path,
                 ["GET"],
                 list_view,
-                response=TypingList[response_schema],  # type: ignore[valid-type]
+                response=TypingList[response_schema],
                 summary=f"List {model_name}",
                 tags=_tags,
                 **_auth_kwarg,
@@ -1072,7 +1071,7 @@ class Router:
         # --- RETRIEVE ---
         if "retrieve" in ops:
 
-            async def retrieve_view(request, id):  # type: ignore[return]
+            async def retrieve_view(request: Any, id: Any) -> Any:
                 return await aget_object_or_404(model, pk=id)
 
             retrieve_view.__name__ = f"retrieve_{model_name.lower()}"
@@ -1090,10 +1089,10 @@ class Router:
         # --- CREATE ---
         if "create" in ops:
 
-            async def create_view(request, payload):  # type: ignore[return]
+            async def create_view(request: Any, payload: Any) -> Any:
                 data = payload.model_dump()
                 m2m_data = {k: data.pop(k) for k in m2m_field_names if k in data}
-                instance = model(**data)
+                instance: Any = model(**data)
                 await instance.asave()
                 for field_name, values in m2m_data.items():
                     await getattr(instance, field_name).aset(values)
@@ -1114,8 +1113,8 @@ class Router:
         # --- UPDATE (PUT) ---
         if "update" in ops:
 
-            async def update_view(request, id, payload):  # type: ignore[return]
-                instance = await aget_object_or_404(model, pk=id)
+            async def update_view(request: Any, id: Any, payload: Any) -> Any:
+                instance: Any = await aget_object_or_404(model, pk=id)
                 data = payload.model_dump()
                 m2m_data = {k: data.pop(k) for k in m2m_field_names if k in data}
                 for attr, value in data.items():
@@ -1143,8 +1142,8 @@ class Router:
         # --- PARTIAL UPDATE (PATCH) ---
         if "partial_update" in ops:
 
-            async def partial_update_view(request, id, payload):  # type: ignore[return]
-                instance = await aget_object_or_404(model, pk=id)
+            async def partial_update_view(request: Any, id: Any, payload: Any) -> Any:
+                instance: Any = await aget_object_or_404(model, pk=id)
                 data = payload.model_dump(exclude_unset=True)
                 m2m_data = {k: data.pop(k) for k in m2m_field_names if k in data}
                 for attr, value in data.items():
@@ -1172,8 +1171,8 @@ class Router:
         # --- DESTROY (DELETE) ---
         if "destroy" in ops:
 
-            async def destroy_view(request, id):
-                instance = await aget_object_or_404(model, pk=id)
+            async def destroy_view(request: Any, id: Any) -> HttpResponse:
+                instance: Any = await aget_object_or_404(model, pk=id)
                 await instance.adelete()
                 return HttpResponse(status=204)
 

--- a/ninja/router.py
+++ b/ninja/router.py
@@ -682,6 +682,515 @@ class Router:
 
         return [mount, *child_mounts]
 
+    def _prepare_model_api(
+        self,
+        model: Any,
+        fields: Optional[List[str]],
+        exclude: Optional[List[str]],
+        tags: Optional[List[str]],
+        auth: Any,
+        operations: Optional[List[str]],
+    ) -> Dict[str, Any]:
+        """
+        Build schemas and shared config for add_model_api / add_async_model_api.
+
+        Returns a dict with keys: model_name, pk_python_type, m2m_field_names,
+        response_schema, create_schema_cls, patch_schema_cls, operations,
+        tags, auth_kwarg.
+        """
+        from typing import List as TypingList
+
+        from django.db.models import ManyToManyField
+
+        from ninja.orm import create_schema as _create_schema
+        from ninja.orm.fields import TYPES
+
+        _all_operations = [
+            "list",
+            "retrieve",
+            "create",
+            "update",
+            "partial_update",
+            "destroy",
+        ]
+        ops: List[str] = list(_all_operations) if operations is None else list(operations)
+
+        model_name: str = model.__name__
+
+        pk_field = model._meta.pk
+        pk_python_type = (
+            TYPES.get(pk_field.get_internal_type(), int) if pk_field else int
+        )
+
+        _auto_types = {"AutoField", "BigAutoField", "SmallAutoField"}
+        auto_field_names = [
+            f.name
+            for f in model._meta.get_fields()
+            if hasattr(f, "get_internal_type")
+            and f.get_internal_type() in _auto_types
+        ]
+
+        m2m_field_names = {
+            f.name
+            for f in model._meta.get_fields()
+            if isinstance(f, ManyToManyField)
+        }
+
+        response_schema = _create_schema(
+            model,
+            name=f"{model_name}Schema",
+            fields=fields,
+            exclude=exclude,
+        )
+
+        if fields:
+            write_fields = [f for f in fields if f not in auto_field_names]
+            create_schema_cls = _create_schema(
+                model,
+                name=f"{model_name}CreateSchema",
+                fields=write_fields,
+            )
+            patch_schema_cls = _create_schema(
+                model,
+                name=f"{model_name}PatchSchema",
+                fields=write_fields,
+                optional_fields="__all__",
+            )
+        else:
+            write_exclude: List[str] = list(auto_field_names)
+            if exclude:
+                for _f in exclude:
+                    if _f not in write_exclude:
+                        write_exclude.append(_f)
+            create_schema_cls = _create_schema(
+                model,
+                name=f"{model_name}CreateSchema",
+                exclude=write_exclude,
+            )
+            patch_schema_cls = _create_schema(
+                model,
+                name=f"{model_name}PatchSchema",
+                exclude=write_exclude,
+                optional_fields="__all__",
+            )
+
+        return {
+            "model_name": model_name,
+            "path_prefix": model_name.lower(),
+            "pk_python_type": pk_python_type,
+            "m2m_field_names": m2m_field_names,
+            "response_schema": response_schema,
+            "create_schema_cls": create_schema_cls,
+            "patch_schema_cls": patch_schema_cls,
+            "operations": ops,
+            "tags": tags or [model_name],
+            "auth_kwarg": {} if auth is NOT_SET else {"auth": auth},
+            # expose for convenience inside the view-registration methods
+            "_TypingList": TypingList,
+        }
+
+    def add_model_api(
+        self,
+        model: Any,
+        *,
+        fields: Optional[List[str]] = None,
+        exclude: Optional[List[str]] = None,
+        tags: Optional[List[str]] = None,
+        auth: Any = NOT_SET,
+        operations: Optional[List[str]] = None,
+    ) -> None:
+        """
+        Automatically generate synchronous CRUD endpoints for a Django model.
+
+        Generated endpoints (all relative to the router prefix):
+        - GET /       - List all instances
+        - GET /{id}   - Retrieve a single instance by primary key
+        - POST /      - Create a new instance (responds 201)
+        - PUT /{id}   - Full update of an instance
+        - PATCH /{id} - Partial update of an instance
+        - DELETE /{id} - Delete an instance (responds 204)
+
+        Args:
+            model: Django model class to generate endpoints for.
+            fields: Fields to include in the response schema. Default: all.
+            exclude: Fields to exclude from the response schema.
+            tags: OpenAPI tags applied to all generated endpoints.
+                  Defaults to the model class name.
+            auth: Authentication override for all generated endpoints.
+            operations: Subset of operations to generate. Possible values:
+                        "list", "retrieve", "create", "update",
+                        "partial_update", "destroy". Default: all.
+
+        Example::
+
+            router = Router()
+            router.add_model_api(MyModel)
+
+            # Only GET endpoints:
+            router.add_model_api(MyModel, operations=["list", "retrieve"])
+
+            # Custom field selection:
+            router.add_model_api(MyModel, exclude=["internal_field"])
+        """
+        from django.http import HttpResponse
+        from django.shortcuts import get_object_or_404
+
+        from ninja.responses import Status
+
+        cfg = self._prepare_model_api(model, fields, exclude, tags, auth, operations)
+        model_name = cfg["model_name"]
+        prefix = cfg["path_prefix"]
+        pk_python_type = cfg["pk_python_type"]
+        m2m_field_names = cfg["m2m_field_names"]
+        response_schema = cfg["response_schema"]
+        create_schema_cls = cfg["create_schema_cls"]
+        patch_schema_cls = cfg["patch_schema_cls"]
+        ops = cfg["operations"]
+        _tags = cfg["tags"]
+        _auth_kwarg: Dict[str, Any] = cfg["auth_kwarg"]
+        TypingList = cfg["_TypingList"]
+
+        collection_path = f"/{prefix}/"
+        detail_path = f"/{prefix}/{{id}}"
+
+        # --- LIST ---
+        if "list" in ops:
+
+            def list_view(request):  # type: ignore[return]
+                return model.objects.all()
+
+            list_view.__name__ = f"list_{model_name.lower()}"
+            self.add_api_operation(
+                collection_path,
+                ["GET"],
+                list_view,
+                response=TypingList[response_schema],  # type: ignore[valid-type]
+                summary=f"List {model_name}",
+                tags=_tags,
+                **_auth_kwarg,
+            )
+
+        # --- RETRIEVE ---
+        if "retrieve" in ops:
+
+            def retrieve_view(request, id):  # type: ignore[return]
+                return get_object_or_404(model, pk=id)
+
+            retrieve_view.__name__ = f"retrieve_{model_name.lower()}"
+            retrieve_view.__annotations__ = {"id": pk_python_type}
+            self.add_api_operation(
+                detail_path,
+                ["GET"],
+                retrieve_view,
+                response=response_schema,
+                summary=f"Retrieve {model_name}",
+                tags=_tags,
+                **_auth_kwarg,
+            )
+
+        # --- CREATE ---
+        if "create" in ops:
+
+            def create_view(request, payload):  # type: ignore[return]
+                data = payload.model_dump()
+                m2m_data = {k: data.pop(k) for k in m2m_field_names if k in data}
+                instance = model(**data)
+                instance.save()
+                for field_name, values in m2m_data.items():
+                    getattr(instance, field_name).set(values)
+                return Status(201, instance)
+
+            create_view.__name__ = f"create_{model_name.lower()}"
+            create_view.__annotations__ = {"payload": create_schema_cls}
+            self.add_api_operation(
+                collection_path,
+                ["POST"],
+                create_view,
+                response={201: response_schema},
+                summary=f"Create {model_name}",
+                tags=_tags,
+                **_auth_kwarg,
+            )
+
+        # --- UPDATE (PUT) ---
+        if "update" in ops:
+
+            def update_view(request, id, payload):  # type: ignore[return]
+                instance = get_object_or_404(model, pk=id)
+                data = payload.model_dump()
+                m2m_data = {k: data.pop(k) for k in m2m_field_names if k in data}
+                for attr, value in data.items():
+                    setattr(instance, attr, value)
+                instance.save()
+                for field_name, values in m2m_data.items():
+                    getattr(instance, field_name).set(values)
+                return instance
+
+            update_view.__name__ = f"update_{model_name.lower()}"
+            update_view.__annotations__ = {
+                "id": pk_python_type,
+                "payload": create_schema_cls,
+            }
+            self.add_api_operation(
+                detail_path,
+                ["PUT"],
+                update_view,
+                response=response_schema,
+                summary=f"Update {model_name}",
+                tags=_tags,
+                **_auth_kwarg,
+            )
+
+        # --- PARTIAL UPDATE (PATCH) ---
+        if "partial_update" in ops:
+
+            def partial_update_view(request, id, payload):  # type: ignore[return]
+                instance = get_object_or_404(model, pk=id)
+                data = payload.model_dump(exclude_unset=True)
+                m2m_data = {k: data.pop(k) for k in m2m_field_names if k in data}
+                for attr, value in data.items():
+                    setattr(instance, attr, value)
+                instance.save()
+                for field_name, values in m2m_data.items():
+                    getattr(instance, field_name).set(values)
+                return instance
+
+            partial_update_view.__name__ = f"partial_update_{model_name.lower()}"
+            partial_update_view.__annotations__ = {
+                "id": pk_python_type,
+                "payload": patch_schema_cls,
+            }
+            self.add_api_operation(
+                detail_path,
+                ["PATCH"],
+                partial_update_view,
+                response=response_schema,
+                summary=f"Partial Update {model_name}",
+                tags=_tags,
+                **_auth_kwarg,
+            )
+
+        # --- DESTROY (DELETE) ---
+        if "destroy" in ops:
+
+            def destroy_view(request, id):
+                instance = get_object_or_404(model, pk=id)
+                instance.delete()
+                return HttpResponse(status=204)
+
+            destroy_view.__name__ = f"destroy_{model_name.lower()}"
+            destroy_view.__annotations__ = {
+                "id": pk_python_type,
+                "return": HttpResponse,
+            }
+            self.add_api_operation(
+                detail_path,
+                ["DELETE"],
+                destroy_view,
+                summary=f"Delete {model_name}",
+                tags=_tags,
+                **_auth_kwarg,
+            )
+
+    def add_async_model_api(
+        self,
+        model: Any,
+        *,
+        fields: Optional[List[str]] = None,
+        exclude: Optional[List[str]] = None,
+        tags: Optional[List[str]] = None,
+        auth: Any = NOT_SET,
+        operations: Optional[List[str]] = None,
+    ) -> None:
+        """
+        Automatically generate asynchronous CRUD endpoints for a Django model.
+
+        Identical to :meth:`add_model_api` in every respect (paths, schemas,
+        status codes, tags) but every view function is ``async def``, making
+        full use of Django's async ORM (``asave``, ``adelete``, ``aset``,
+        ``aget_object_or_404``, ``async for``).
+
+        Requires Django ≥ 4.1 (async ORM) and an ASGI server (e.g. uvicorn).
+
+        Args:
+            model: Django model class to generate endpoints for.
+            fields: Fields to include in the response schema. Default: all.
+            exclude: Fields to exclude from the response schema.
+            tags: OpenAPI tags applied to all generated endpoints.
+                  Defaults to the model class name.
+            auth: Authentication override for all generated endpoints.
+            operations: Subset of operations to generate. Possible values:
+                        "list", "retrieve", "create", "update",
+                        "partial_update", "destroy". Default: all.
+
+        Example::
+
+            router = Router()
+            router.add_async_model_api(MyModel)
+
+            # Only read endpoints:
+            router.add_async_model_api(MyModel, operations=["list", "retrieve"])
+        """
+        from django.http import HttpResponse
+        from django.shortcuts import aget_object_or_404
+
+        from ninja.responses import Status
+
+        cfg = self._prepare_model_api(model, fields, exclude, tags, auth, operations)
+        model_name = cfg["model_name"]
+        prefix = cfg["path_prefix"]
+        pk_python_type = cfg["pk_python_type"]
+        m2m_field_names = cfg["m2m_field_names"]
+        response_schema = cfg["response_schema"]
+        create_schema_cls = cfg["create_schema_cls"]
+        patch_schema_cls = cfg["patch_schema_cls"]
+        ops = cfg["operations"]
+        _tags = cfg["tags"]
+        _auth_kwarg: Dict[str, Any] = cfg["auth_kwarg"]
+        TypingList = cfg["_TypingList"]
+
+        collection_path = f"/{prefix}/"
+        detail_path = f"/{prefix}/{{id}}"
+
+        # --- LIST ---
+        if "list" in ops:
+
+            async def list_view(request):  # type: ignore[return]
+                return [obj async for obj in model.objects.all()]
+
+            list_view.__name__ = f"list_{model_name.lower()}"
+            self.add_api_operation(
+                collection_path,
+                ["GET"],
+                list_view,
+                response=TypingList[response_schema],  # type: ignore[valid-type]
+                summary=f"List {model_name}",
+                tags=_tags,
+                **_auth_kwarg,
+            )
+
+        # --- RETRIEVE ---
+        if "retrieve" in ops:
+
+            async def retrieve_view(request, id):  # type: ignore[return]
+                return await aget_object_or_404(model, pk=id)
+
+            retrieve_view.__name__ = f"retrieve_{model_name.lower()}"
+            retrieve_view.__annotations__ = {"id": pk_python_type}
+            self.add_api_operation(
+                detail_path,
+                ["GET"],
+                retrieve_view,
+                response=response_schema,
+                summary=f"Retrieve {model_name}",
+                tags=_tags,
+                **_auth_kwarg,
+            )
+
+        # --- CREATE ---
+        if "create" in ops:
+
+            async def create_view(request, payload):  # type: ignore[return]
+                data = payload.model_dump()
+                m2m_data = {k: data.pop(k) for k in m2m_field_names if k in data}
+                instance = model(**data)
+                await instance.asave()
+                for field_name, values in m2m_data.items():
+                    await getattr(instance, field_name).aset(values)
+                return Status(201, instance)
+
+            create_view.__name__ = f"create_{model_name.lower()}"
+            create_view.__annotations__ = {"payload": create_schema_cls}
+            self.add_api_operation(
+                collection_path,
+                ["POST"],
+                create_view,
+                response={201: response_schema},
+                summary=f"Create {model_name}",
+                tags=_tags,
+                **_auth_kwarg,
+            )
+
+        # --- UPDATE (PUT) ---
+        if "update" in ops:
+
+            async def update_view(request, id, payload):  # type: ignore[return]
+                instance = await aget_object_or_404(model, pk=id)
+                data = payload.model_dump()
+                m2m_data = {k: data.pop(k) for k in m2m_field_names if k in data}
+                for attr, value in data.items():
+                    setattr(instance, attr, value)
+                await instance.asave()
+                for field_name, values in m2m_data.items():
+                    await getattr(instance, field_name).aset(values)
+                return instance
+
+            update_view.__name__ = f"update_{model_name.lower()}"
+            update_view.__annotations__ = {
+                "id": pk_python_type,
+                "payload": create_schema_cls,
+            }
+            self.add_api_operation(
+                detail_path,
+                ["PUT"],
+                update_view,
+                response=response_schema,
+                summary=f"Update {model_name}",
+                tags=_tags,
+                **_auth_kwarg,
+            )
+
+        # --- PARTIAL UPDATE (PATCH) ---
+        if "partial_update" in ops:
+
+            async def partial_update_view(request, id, payload):  # type: ignore[return]
+                instance = await aget_object_or_404(model, pk=id)
+                data = payload.model_dump(exclude_unset=True)
+                m2m_data = {k: data.pop(k) for k in m2m_field_names if k in data}
+                for attr, value in data.items():
+                    setattr(instance, attr, value)
+                await instance.asave()
+                for field_name, values in m2m_data.items():
+                    await getattr(instance, field_name).aset(values)
+                return instance
+
+            partial_update_view.__name__ = f"partial_update_{model_name.lower()}"
+            partial_update_view.__annotations__ = {
+                "id": pk_python_type,
+                "payload": patch_schema_cls,
+            }
+            self.add_api_operation(
+                detail_path,
+                ["PATCH"],
+                partial_update_view,
+                response=response_schema,
+                summary=f"Partial Update {model_name}",
+                tags=_tags,
+                **_auth_kwarg,
+            )
+
+        # --- DESTROY (DELETE) ---
+        if "destroy" in ops:
+
+            async def destroy_view(request, id):
+                instance = await aget_object_or_404(model, pk=id)
+                await instance.adelete()
+                return HttpResponse(status=204)
+
+            destroy_view.__name__ = f"destroy_{model_name.lower()}"
+            destroy_view.__annotations__ = {
+                "id": pk_python_type,
+                "return": HttpResponse,
+            }
+            self.add_api_operation(
+                detail_path,
+                ["DELETE"],
+                destroy_view,
+                summary=f"Delete {model_name}",
+                tags=_tags,
+                **_auth_kwarg,
+            )
+
     def _apply_decorators_to_operations(self) -> None:
         """Apply all stored decorators to operations in this router"""
         for path_view in self.path_operations.values():

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -259,7 +259,9 @@ def test_schema_response_schema_has_id(category_schema):
 
 def test_schema_create_schema_excludes_id(category_schema):
     """CategoryCreateSchema must NOT include the auto PK 'id'."""
-    props = category_schema["components"]["schemas"]["CategoryCreateSchema"]["properties"]
+    props = category_schema["components"]["schemas"]["CategoryCreateSchema"][
+        "properties"
+    ]
     assert "id" not in props
     assert "title" in props
     required = category_schema["components"]["schemas"]["CategoryCreateSchema"].get(
@@ -302,9 +304,9 @@ def test_schema_exclude_field_removed_from_all_component_schemas():
     for schema_name in ("EventSchema", "EventCreateSchema", "EventPatchSchema"):
         assert schema_name in components, f"Missing schema: {schema_name}"
         props = components[schema_name]["properties"]
-        assert "category" not in props, (
-            f"'category' should be excluded from {schema_name}"
-        )
+        assert (
+            "category" not in props
+        ), f"'category' should be excluded from {schema_name}"
 
 
 # ===========================================================================

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -1,0 +1,477 @@
+import pytest
+import pytest_asyncio
+from someapp.models import Category, Event
+
+from ninja import NinjaAPI, Router
+from ninja.testing import TestAsyncClient, TestClient  # noqa: E402
+
+# Routes are now prefixed with the lowercase model name, so with the router
+# mounted at the API root ("") the paths become /api/category/ and
+# /api/category/{id}.  Fixtures mount at "" to avoid a double prefix.
+
+
+@pytest.fixture
+def client():
+    api = NinjaAPI()
+    router = Router()
+    router.add_model_api(Category)
+    api.add_router("", router)
+    return TestClient(api)
+
+
+@pytest.mark.django_db
+def test_list_empty(client):
+    response = client.get("/category/")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.django_db
+def test_create(client):
+    response = client.post("/category/", json={"title": "Python"})
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "Python"
+    assert "id" in data
+
+
+@pytest.mark.django_db
+def test_list_after_create(client):
+    client.post("/category/", json={"title": "Django"})
+    response = client.get("/category/")
+    assert response.status_code == 200
+    items = response.json()
+    assert len(items) == 1
+    assert items[0]["title"] == "Django"
+
+
+@pytest.mark.django_db
+def test_retrieve(client):
+    create_resp = client.post("/category/", json={"title": "Ninja"})
+    pk = create_resp.json()["id"]
+
+    response = client.get(f"/category/{pk}")
+    assert response.status_code == 200
+    assert response.json()["title"] == "Ninja"
+
+
+@pytest.mark.django_db
+def test_retrieve_not_found(client):
+    response = client.get("/category/9999")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_update_put(client):
+    create_resp = client.post("/category/", json={"title": "Old"})
+    pk = create_resp.json()["id"]
+
+    response = client.put(f"/category/{pk}", json={"title": "New"})
+    assert response.status_code == 200
+    assert response.json()["title"] == "New"
+
+
+@pytest.mark.django_db
+def test_partial_update_patch(client):
+    create_resp = client.post("/category/", json={"title": "Original"})
+    pk = create_resp.json()["id"]
+
+    response = client.patch(f"/category/{pk}", json={"title": "Patched"})
+    assert response.status_code == 200
+    assert response.json()["title"] == "Patched"
+
+
+@pytest.mark.django_db
+def test_delete(client):
+    create_resp = client.post("/category/", json={"title": "ToDelete"})
+    pk = create_resp.json()["id"]
+
+    response = client.delete(f"/category/{pk}")
+    assert response.status_code == 204
+
+    assert client.get(f"/category/{pk}").status_code == 404
+
+
+@pytest.mark.django_db
+def test_operations_subset():
+    """Only the requested operations are registered."""
+    api = NinjaAPI()
+    router = Router()
+    router.add_model_api(Category, operations=["list", "retrieve"])
+    api.add_router("", router)
+    c = TestClient(api)
+
+    assert c.get("/category/").status_code == 200
+    assert c.post("/category/", json={"title": "x"}).status_code == 405
+    assert c.delete("/category/1").status_code == 405
+
+
+@pytest.mark.django_db
+def test_exclude_fields():
+    """Excluded fields must not appear in the response schema."""
+    api = NinjaAPI()
+    router = Router()
+    router.add_model_api(Event, exclude=["category"])
+    api.add_router("", router)
+    c = TestClient(api)
+
+    resp = c.post(
+        "/event/",
+        json={
+            "title": "PyCon",
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-03",
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "title" in data
+    assert "category" not in data
+
+
+# ===========================================================================
+# OpenAPI / Swagger schema tests
+# ===========================================================================
+
+
+@pytest.fixture(scope="module")
+def category_schema():
+    """OpenAPI schema for a basic add_model_api(Category) setup."""
+    api = NinjaAPI()
+    router = Router()
+    router.add_model_api(Category)
+    api.add_router("", router)
+    return api.get_openapi_schema()
+
+
+def test_schema_paths_exist(category_schema):
+    """Both collection and detail paths must be present."""
+    paths = category_schema["paths"]
+    assert "/api/category/" in paths
+    assert "/api/category/{id}" in paths
+
+
+def test_schema_collection_methods(category_schema):
+    """Collection path must expose GET and POST only."""
+    collection = category_schema["paths"]["/api/category/"]
+    assert set(collection.keys()) == {"get", "post"}
+
+
+def test_schema_detail_methods(category_schema):
+    """Detail path must expose GET, PUT, PATCH and DELETE only."""
+    detail = category_schema["paths"]["/api/category/{id}"]
+    assert set(detail.keys()) == {"get", "put", "patch", "delete"}
+
+
+def test_schema_list_response(category_schema):
+    """GET / must return a 200 array of CategorySchema."""
+    get_op = category_schema["paths"]["/api/category/"]["get"]
+    assert 200 in get_op["responses"]
+    content = get_op["responses"][200]["content"]["application/json"]["schema"]
+    assert content["type"] == "array"
+    assert content["items"]["$ref"] == "#/components/schemas/CategorySchema"
+
+
+def test_schema_create_response_201(category_schema):
+    """POST / must return 201 with CategorySchema body."""
+    post_op = category_schema["paths"]["/api/category/"]["post"]
+    assert 201 in post_op["responses"]
+    ref = post_op["responses"][201]["content"]["application/json"]["schema"]["$ref"]
+    assert ref == "#/components/schemas/CategorySchema"
+
+
+def test_schema_create_request_body(category_schema):
+    """POST / request body must reference CategoryCreateSchema."""
+    post_op = category_schema["paths"]["/api/category/"]["post"]
+    ref = post_op["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+    assert ref == "#/components/schemas/CategoryCreateSchema"
+    assert post_op["requestBody"]["required"] is True
+
+
+def test_schema_retrieve_response(category_schema):
+    """GET /{id} must return 200 with CategorySchema."""
+    get_op = category_schema["paths"]["/api/category/{id}"]["get"]
+    assert 200 in get_op["responses"]
+    ref = get_op["responses"][200]["content"]["application/json"]["schema"]["$ref"]
+    assert ref == "#/components/schemas/CategorySchema"
+
+
+def test_schema_retrieve_path_param(category_schema):
+    """GET /{id} must declare an integer path parameter named 'id'."""
+    params = category_schema["paths"]["/api/category/{id}"]["get"]["parameters"]
+    id_param = next(p for p in params if p["name"] == "id")
+    assert id_param["in"] == "path"
+    assert id_param["required"] is True
+    assert id_param["schema"]["type"] == "integer"
+
+
+def test_schema_update_request_body(category_schema):
+    """PUT /{id} must use CategoryCreateSchema (all required fields)."""
+    put_op = category_schema["paths"]["/api/category/{id}"]["put"]
+    ref = put_op["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+    assert ref == "#/components/schemas/CategoryCreateSchema"
+
+
+def test_schema_partial_update_request_body(category_schema):
+    """PATCH /{id} must use CategoryPatchSchema (all optional fields)."""
+    patch_op = category_schema["paths"]["/api/category/{id}"]["patch"]
+    ref = patch_op["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+    assert ref == "#/components/schemas/CategoryPatchSchema"
+
+
+def test_schema_summaries(category_schema):
+    """All generated operations must carry the correct human-readable summary."""
+    paths = category_schema["paths"]
+    assert paths["/api/category/"]["get"]["summary"] == "List Category"
+    assert paths["/api/category/"]["post"]["summary"] == "Create Category"
+    assert paths["/api/category/{id}"]["get"]["summary"] == "Retrieve Category"
+    assert paths["/api/category/{id}"]["put"]["summary"] == "Update Category"
+    assert paths["/api/category/{id}"]["patch"]["summary"] == "Partial Update Category"
+    assert paths["/api/category/{id}"]["delete"]["summary"] == "Delete Category"
+
+
+def test_schema_default_tags(category_schema):
+    """All operations default to the model class name as their tag."""
+    paths = category_schema["paths"]
+    for path_item in paths.values():
+        for operation in path_item.values():
+            assert operation["tags"] == ["Category"]
+
+
+def test_schema_custom_tags():
+    """tags= kwarg propagates to every generated operation."""
+    api = NinjaAPI()
+    router = Router()
+    router.add_model_api(Category, tags=["products", "shop"])
+    api.add_router("", router)
+    schema = api.get_openapi_schema()
+
+    for path_item in schema["paths"].values():
+        for operation in path_item.values():
+            assert operation["tags"] == ["products", "shop"]
+
+
+def test_schema_response_schema_has_id(category_schema):
+    """CategorySchema (response) must include the 'id' primary-key field."""
+    props = category_schema["components"]["schemas"]["CategorySchema"]["properties"]
+    assert "id" in props
+
+
+def test_schema_create_schema_excludes_id(category_schema):
+    """CategoryCreateSchema must NOT include the auto PK 'id'."""
+    props = category_schema["components"]["schemas"]["CategoryCreateSchema"]["properties"]
+    assert "id" not in props
+    assert "title" in props
+    required = category_schema["components"]["schemas"]["CategoryCreateSchema"].get(
+        "required", []
+    )
+    assert "title" in required
+
+
+def test_schema_patch_schema_all_optional(category_schema):
+    """CategoryPatchSchema must have no required fields (all fields optional)."""
+    patch_schema = category_schema["components"]["schemas"]["CategoryPatchSchema"]
+    assert "required" not in patch_schema or patch_schema.get("required") == []
+
+
+def test_schema_operations_subset():
+    """When operations= is given, only those paths/methods appear in the schema."""
+    api = NinjaAPI()
+    router = Router()
+    router.add_model_api(Category, operations=["list", "retrieve"])
+    api.add_router("", router)
+    schema = api.get_openapi_schema()
+
+    paths = schema["paths"]
+    assert "/api/category/" in paths
+    assert set(paths["/api/category/"].keys()) == {"get"}  # no POST
+
+    assert "/api/category/{id}" in paths
+    assert set(paths["/api/category/{id}"].keys()) == {"get"}  # no PUT/PATCH/DELETE
+
+
+def test_schema_exclude_field_removed_from_all_component_schemas():
+    """Fields listed in exclude= must be absent from all three component schemas."""
+    api = NinjaAPI()
+    router = Router()
+    router.add_model_api(Event, exclude=["category"])
+    api.add_router("", router)
+    schema = api.get_openapi_schema()
+
+    components = schema["components"]["schemas"]
+    for schema_name in ("EventSchema", "EventCreateSchema", "EventPatchSchema"):
+        assert schema_name in components, f"Missing schema: {schema_name}"
+        props = components[schema_name]["properties"]
+        assert "category" not in props, (
+            f"'category' should be excluded from {schema_name}"
+        )
+
+
+# ===========================================================================
+# Async CRUD tests  (add_async_model_api)
+# ===========================================================================
+
+
+@pytest_asyncio.fixture
+async def async_client():
+    api = NinjaAPI()
+    router = Router()
+    router.add_async_model_api(Category)
+    api.add_router("", router)
+    return TestAsyncClient(api)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_async_list_empty(async_client):
+    response = await async_client.get("/category/")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_async_create(async_client):
+    response = await async_client.post("/category/", json={"title": "Async"})
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "Async"
+    assert "id" in data
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_async_list_after_create(async_client):
+    await async_client.post("/category/", json={"title": "Django"})
+    response = await async_client.get("/category/")
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    assert response.json()[0]["title"] == "Django"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_async_retrieve(async_client):
+    create_resp = await async_client.post("/category/", json={"title": "Ninja"})
+    pk = create_resp.json()["id"]
+
+    response = await async_client.get(f"/category/{pk}")
+    assert response.status_code == 200
+    assert response.json()["title"] == "Ninja"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_async_retrieve_not_found(async_client):
+    response = await async_client.get("/category/9999")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_async_update_put(async_client):
+    create_resp = await async_client.post("/category/", json={"title": "Old"})
+    pk = create_resp.json()["id"]
+
+    response = await async_client.put(f"/category/{pk}", json={"title": "New"})
+    assert response.status_code == 200
+    assert response.json()["title"] == "New"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_async_partial_update_patch(async_client):
+    create_resp = await async_client.post("/category/", json={"title": "Original"})
+    pk = create_resp.json()["id"]
+
+    response = await async_client.patch(f"/category/{pk}", json={"title": "Patched"})
+    assert response.status_code == 200
+    assert response.json()["title"] == "Patched"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_async_delete(async_client):
+    create_resp = await async_client.post("/category/", json={"title": "ToDelete"})
+    pk = create_resp.json()["id"]
+
+    response = await async_client.delete(f"/category/{pk}")
+    assert response.status_code == 204
+
+    assert (await async_client.get(f"/category/{pk}")).status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_async_operations_subset():
+    """Only requested operations are wired up."""
+    api = NinjaAPI()
+    router = Router()
+    router.add_async_model_api(Category, operations=["list", "retrieve"])
+    api.add_router("", router)
+    c = TestAsyncClient(api)
+
+    assert (await c.get("/category/")).status_code == 200
+    assert (await c.post("/category/", json={"title": "x"})).status_code == 405
+    assert (await c.delete("/category/1")).status_code == 405
+
+
+# --- OpenAPI schema for async endpoints ---
+
+
+@pytest.fixture(scope="module")
+def async_category_schema():
+    api = NinjaAPI()
+    router = Router()
+    router.add_async_model_api(Category)
+    api.add_router("", router)
+    return api.get_openapi_schema()
+
+
+def test_async_schema_paths_exist(async_category_schema):
+    paths = async_category_schema["paths"]
+    assert "/api/category/" in paths
+    assert "/api/category/{id}" in paths
+
+
+def test_async_schema_collection_methods(async_category_schema):
+    assert set(async_category_schema["paths"]["/api/category/"].keys()) == {
+        "get",
+        "post",
+    }
+
+
+def test_async_schema_detail_methods(async_category_schema):
+    assert set(async_category_schema["paths"]["/api/category/{id}"].keys()) == {
+        "get",
+        "put",
+        "patch",
+        "delete",
+    }
+
+
+def test_async_schema_create_response_201(async_category_schema):
+    post_op = async_category_schema["paths"]["/api/category/"]["post"]
+    assert 201 in post_op["responses"]
+
+
+def test_async_schema_matches_sync_schema():
+    """The OpenAPI output of add_async_model_api must be identical to add_model_api."""
+    sync_api = NinjaAPI()
+    sync_router = Router()
+    sync_router.add_model_api(Category, tags=["CmpTest"])
+    sync_api.add_router("", sync_router)
+
+    async_api = NinjaAPI()
+    async_router = Router()
+    async_router.add_async_model_api(Category, tags=["CmpTest"])
+    async_api.add_router("", async_router)
+
+    assert (
+        sync_api.get_openapi_schema()["paths"]
+        == async_api.get_openapi_schema()["paths"]
+    )
+    assert (
+        sync_api.get_openapi_schema()["components"]
+        == async_api.get_openapi_schema()["components"]
+    )


### PR DESCRIPTION
This pull request adds comprehensive documentation for the new auto-generated Model API feature in Django Ninja. The documentation explains how to quickly generate full CRUD endpoints for any Django model using a single method call, details the generated routes and schemas, and describes all available configuration options. It also covers the async variant for projects using Django's async ORM, provides a full example, and compares the auto-generated API to manual CRUD implementations. Additionally, the new documentation page is integrated into the guides navigation.

**Documentation for auto-generated Model API:**

* Added a new guide (`guides/model-api.md`) detailing how to use `add_model_api` and `add_async_model_api` to automatically generate CRUD endpoints for Django models, including descriptions of generated endpoints, schemas, parameters (`fields`, `exclude`, `operations`, `tags`, `auth`), and usage examples.
* Explained the difference between sync and async variants, when to use each, and highlighted that both produce identical OpenAPI schemas.
* Included a side-by-side comparison showing how the auto-generated API replaces manual CRUD endpoint definitions.

**Documentation navigation update:**

* Added the new "Auto-generated Model API" guide to the documentation navigation in `mkdocs.yml` for easy discoverability.