### PR TITLE
Allow late router registration after NinjaAPI.urls access

### DIFF
--- a/ninja/main.py
+++ b/ninja/main.py
@@ -44,10 +44,6 @@ Exc = Union[_E, Type[_E]]
 ExcHandler = Callable[[HttpRequest, Exc[_E]], HttpResponse]
 
 
-def _same_value(left: Any, right: Any) -> bool:
-    return left is right or left == right
-
-
 class NinjaAPI:
     """
     Ninja API
@@ -436,8 +432,8 @@ class NinjaAPI:
             if (
                 existing_prefix == prefix
                 and existing_router is router
-                and _same_value(existing_auth, auth)
-                and _same_value(existing_throttle, throttle)
+                and (existing_auth is auth or existing_auth == auth)
+                and (existing_throttle is throttle or existing_throttle == throttle)
                 and existing_tags == tags
                 and existing_url_name_prefix == url_name_prefix
             ):

--- a/ninja/main.py
+++ b/ninja/main.py
@@ -13,7 +13,7 @@ from typing import (
 )
 
 from django.http import HttpRequest, HttpResponse
-from django.urls import URLPattern, URLResolver, reverse
+from django.urls import URLPattern, URLResolver, clear_url_caches, reverse
 from django.utils.module_loading import import_string
 
 from ninja.constants import NOT_SET, NOT_SET_TYPE
@@ -42,6 +42,10 @@ __all__ = ["NinjaAPI"]
 _E = TypeVar("_E", bound=Exception)
 Exc = Union[_E, Type[_E]]
 ExcHandler = Callable[[HttpRequest, Exc[_E]], HttpResponse]
+
+
+def _same_value(left: Any, right: Any) -> bool:
+    return left is right or left == right
 
 
 class NinjaAPI:
@@ -113,6 +117,8 @@ class NinjaAPI:
             Tuple[str, Router, Any, Any, Optional[List[str]], Optional[str]]
         ] = []
         self._bound_routers_cache: Optional[List[BoundRouter]] = None
+        self._url_patterns: List[Union[URLResolver, URLPattern]] = []
+        self._urls_materialized = False
 
         # Backward compat: keep _routers list populated
         self._routers: List[Tuple[str, Router]] = []
@@ -415,16 +421,27 @@ class NinjaAPI:
             url_name_prefix: Prefix for URL names (required when mounting same router multiple times)
             parent_router: Internal use - parent router for nested routers
         """
-        # Prevent adding routers after URLs have been generated
-        if self._bound_routers_cache is not None:
-            raise ConfigError(
-                "Cannot add routers after URLs have been generated. "
-                "Add all routers before accessing api.urls"
-            )
-
         if isinstance(router, str):
             router = import_string(router)
             assert isinstance(router, Router)
+
+        for (
+            existing_prefix,
+            existing_router,
+            existing_auth,
+            existing_throttle,
+            existing_tags,
+            existing_url_name_prefix,
+        ) in self._router_registrations:
+            if (
+                existing_prefix == prefix
+                and existing_router is router
+                and _same_value(existing_auth, auth)
+                and _same_value(existing_throttle, throttle)
+                and existing_tags == tags
+                and existing_url_name_prefix == url_name_prefix
+            ):
+                return
 
         # Check for duplicate router template - require url_name_prefix
         existing_templates = {reg[1] for reg in self._router_registrations}
@@ -445,8 +462,8 @@ class NinjaAPI:
             url_name_prefix,
         ))
 
-        # Backward compat: keep _routers list updated (just the top-level router)
-        self._routers.append((prefix, router))
+        router._mounted_apis.add(self)
+        self._on_router_tree_changed()
 
     @property
     def urls(self) -> Tuple[List[Union[URLResolver, URLPattern]], str, str]:
@@ -464,6 +481,24 @@ class NinjaAPI:
             self.urls_namespace.split(":")[-1],
             # ^ if api included into nested urls, we only care about last bit here
         )
+
+    def _invalidate_router_cache(self) -> None:
+        self._bound_routers_cache = None
+        self._routers = [
+            (prefix, router)
+            for prefix, router, _, _, _, _ in self._router_registrations
+        ]
+
+    def _on_router_tree_changed(self) -> None:
+        self._invalidate_router_cache()
+        if self._urls_materialized:
+            self._rebuild_urls_in_place()
+
+    def _rebuild_urls_in_place(self) -> None:
+        self._invalidate_router_cache()
+        self._url_patterns[:] = self._build_url_patterns()
+        self._urls_materialized = True
+        clear_url_caches()
 
     def _get_bound_routers(self) -> List[BoundRouter]:
         """Get or create bound router instances."""
@@ -527,7 +562,7 @@ class NinjaAPI:
 
         return self._bound_routers_cache
 
-    def _get_urls(self) -> List[Union[URLResolver, URLPattern]]:
+    def _build_url_patterns(self) -> List[Union[URLResolver, URLPattern]]:
         result = get_openapi_urls(self)
 
         for bound_router in self._get_bound_routers():
@@ -535,6 +570,11 @@ class NinjaAPI:
 
         result.append(get_root_url(self))
         return result
+
+    def _get_urls(self) -> List[Union[URLResolver, URLPattern]]:
+        if not self._urls_materialized or self._bound_routers_cache is None:
+            self._rebuild_urls_in_place()
+        return self._url_patterns
 
     def get_root_path(self, path_params: DictStrAny) -> str:
         name = f"{self.urls_namespace}:api-root"

--- a/ninja/main.py
+++ b/ninja/main.py
@@ -553,10 +553,6 @@ class NinjaAPI:
                 BoundRouter(mount, self) for mount in all_mounts
             ]
 
-            # Freeze all templates after binding
-            for mount in all_mounts:
-                mount.template._freeze()
-
             # Update _routers for backward compat (include all nested routers)
             self._routers = [(m.prefix, m.template) for m in all_mounts]
 

--- a/ninja/router.py
+++ b/ninja/router.py
@@ -8,9 +8,11 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Set,
     Tuple,
     Union,
 )
+from weakref import WeakSet
 
 from django.urls import URLPattern
 from django.urls import path as django_path
@@ -18,7 +20,6 @@ from django.utils.module_loading import import_string
 
 from ninja.constants import NOT_SET, NOT_SET_TYPE
 from ninja.decorators import DecoratorMode
-from ninja.errors import ConfigError
 from ninja.operation import PathView
 from ninja.throttling import BaseThrottle
 from ninja.types import TCallable
@@ -29,6 +30,10 @@ if TYPE_CHECKING:
 
 
 __all__ = ["Router", "RouterMount", "BoundRouter"]
+
+
+def _same_value(left: Any, right: Any) -> bool:
+    return left is right or left == right
 
 
 @dataclass
@@ -213,6 +218,8 @@ class Router:
         self.path_operations: Dict[str, PathView] = {}
         self._routers: List[Tuple[str, Router, Optional[List[str]]]] = []
         self._decorators: List[Tuple[Callable, DecoratorMode]] = []
+        self._parent_routers: WeakSet[Router] = WeakSet()
+        self._mounted_apis: WeakSet[NinjaAPI] = WeakSet()
 
     def _freeze(self) -> None:
         """Mark router as frozen - no more modifications allowed."""
@@ -221,12 +228,29 @@ class Router:
             child_router._freeze()
 
     def _check_not_frozen(self) -> None:
-        """Raise error if attempting to modify a frozen router."""
+        """Thaw router templates so mounted APIs can be rebuilt after mutation."""
         if self._frozen:
-            raise ConfigError(
-                "Cannot modify router after URLs have been generated. "
-                "Routers become frozen when api.urls is accessed."
-            )
+            self._frozen = False
+
+    def _collect_affected_apis(
+        self, visited_router_ids: Optional[Set[int]] = None
+    ) -> Set["NinjaAPI"]:
+        if visited_router_ids is None:
+            visited_router_ids = set()
+
+        router_id = id(self)
+        if router_id in visited_router_ids:
+            return set()
+        visited_router_ids.add(router_id)
+
+        affected_apis = set(self._mounted_apis)
+        for parent in tuple(self._parent_routers):
+            affected_apis.update(parent._collect_affected_apis(visited_router_ids))
+        return affected_apis
+
+    def _invalidate_affected_apis(self) -> None:
+        for api in self._collect_affected_apis():
+            api._on_router_tree_changed()
 
     def get(
         self,
@@ -539,6 +563,7 @@ class Router:
             openapi_extra=openapi_extra,
         )
         # Note: API binding is now done via BoundRouter when urls are generated
+        self._invalidate_affected_apis()
 
         return None
 
@@ -588,6 +613,18 @@ class Router:
             router = import_string(router)
             assert isinstance(router, Router)
 
+        requested_auth = router.auth if auth is NOT_SET else auth
+        requested_throttle = router.throttle if throttle is NOT_SET else throttle
+        for existing_prefix, existing_router, existing_tags in self._routers:
+            if (
+                existing_prefix == prefix
+                and existing_router is router
+                and existing_tags == tags
+                and _same_value(existing_router.auth, requested_auth)
+                and _same_value(existing_router.throttle, requested_throttle)
+            ):
+                return
+
         # Store child router with its mount-time configuration
         # Auth/throttle are stored on the child router template,
         # but tags from add_router are stored separately to distinguish from Router(tags=...)
@@ -597,6 +634,8 @@ class Router:
             router.throttle = throttle
         # Store as (prefix, router, tags) - tags here are mount-level overrides
         self._routers.append((prefix, router, tags))
+        router._parent_routers.add(self)
+        self._invalidate_affected_apis()
 
     def add_decorator(
         self,
@@ -615,6 +654,7 @@ class Router:
         if mode not in ("view", "operation"):
             raise ValueError(f"Invalid decorator mode: {mode}")
         self._decorators.append((decorator, mode))
+        self._invalidate_affected_apis()
 
     def build_routers(
         self,

--- a/ninja/router.py
+++ b/ninja/router.py
@@ -206,7 +206,6 @@ class Router:
         exclude_defaults: Optional[bool] = None,
         exclude_none: Optional[bool] = None,
     ) -> None:
-        self._frozen = False
         self.auth = auth
         self.throttle = throttle
         self.tags = tags
@@ -220,17 +219,6 @@ class Router:
         self._decorators: List[Tuple[Callable, DecoratorMode]] = []
         self._parent_routers: WeakSet[Router] = WeakSet()
         self._mounted_apis: WeakSet[NinjaAPI] = WeakSet()
-
-    def _freeze(self) -> None:
-        """Mark router as frozen - no more modifications allowed."""
-        self._frozen = True
-        for _, child_router, _ in self._routers:
-            child_router._freeze()
-
-    def _check_not_frozen(self) -> None:
-        """Thaw router templates so mounted APIs can be rebuilt after mutation."""
-        if self._frozen:
-            self._frozen = False
 
     def _collect_affected_apis(
         self, visited_router_ids: Optional[Set[int]] = None
@@ -520,7 +508,6 @@ class Router:
         include_in_schema: bool = True,
         openapi_extra: Optional[Dict[str, Any]] = None,
     ) -> None:
-        self._check_not_frozen()
         path = re.sub(r"\{uuid:(\w+)\}", r"{uuidstr:\1}", path, flags=re.IGNORECASE)
         # django by default convert strings to UUIDs
         # but we want to keep them as strings to let pydantic handle conversion/validation
@@ -607,8 +594,6 @@ class Router:
         throttle: Union[BaseThrottle, List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
         tags: Optional[List[str]] = None,
     ) -> None:
-        self._check_not_frozen()
-
         if isinstance(router, str):
             router = import_string(router)
             assert isinstance(router, Router)
@@ -650,7 +635,6 @@ class Router:
             mode: "operation" (default) applies after validation,
                   "view" applies before validation
         """
-        self._check_not_frozen()
         if mode not in ("view", "operation"):
             raise ValueError(f"Invalid decorator mode: {mode}")
         self._decorators.append((decorator, mode))

--- a/ninja/router.py
+++ b/ninja/router.py
@@ -32,10 +32,6 @@ if TYPE_CHECKING:
 __all__ = ["Router", "RouterMount", "BoundRouter"]
 
 
-def _same_value(left: Any, right: Any) -> bool:
-    return left is right or left == right
-
-
 @dataclass
 class RouterMount:
     """
@@ -605,8 +601,14 @@ class Router:
                 existing_prefix == prefix
                 and existing_router is router
                 and existing_tags == tags
-                and _same_value(existing_router.auth, requested_auth)
-                and _same_value(existing_router.throttle, requested_throttle)
+                and (
+                    existing_router.auth is requested_auth
+                    or existing_router.auth == requested_auth
+                )
+                and (
+                    existing_router.throttle is requested_throttle
+                    or existing_router.throttle == requested_throttle
+                )
             ):
                 return
 

--- a/tests/late_router_registration_urls.py
+++ b/tests/late_router_registration_urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from ninja import NinjaAPI
+
+api = NinjaAPI(urls_namespace="late-urls")
+
+
+@api.get("/initial", url_name="initial")
+def initial(request):
+    return {"ok": True}
+
+
+urlpatterns = [path("late/", api.urls)]

--- a/tests/test_router_reuse.py
+++ b/tests/test_router_reuse.py
@@ -148,14 +148,12 @@ class TestLateRegistration:
         api.add_router("", router)
 
         patterns = api.urls[0]
-        assert router._frozen is True
 
         @router.get("/new")
         def new_endpoint(request):
             return ["new"]
 
         assert api.urls[0] is patterns
-        assert router._frozen is True
 
         client = TestClient(api)
         response = client.get("/new")

--- a/tests/test_router_reuse.py
+++ b/tests/test_router_reuse.py
@@ -10,6 +10,8 @@ These tests verify that:
 """
 
 import pytest
+from django.test import override_settings
+from django.urls import reverse
 
 from ninja import NinjaAPI, Router
 from ninja.errors import ConfigError
@@ -131,61 +133,189 @@ class TestDecoratorIsolation:
         assert calls["api2"] == 1
 
 
-class TestFreezeBehavior:
-    """Test that routers are frozen after URLs are generated."""
+class TestLateRegistration:
+    """Test late router mutation and registration after URLs are built."""
 
-    def test_router_frozen_after_urls_accessed(self):
-        """Router becomes frozen after api.urls is accessed."""
+    def test_router_operation_added_after_urls_accessed(self):
+        """Adding operations late rebuilds API URLs in place."""
         router = Router()
 
         @router.get("/items")
         def list_items(request):
             return []
 
-        api = NinjaAPI(urls_namespace="freeze-test")
+        api = NinjaAPI(urls_namespace="late-op-test")
         api.add_router("", router)
 
-        # Access urls (triggers freezing)
-        _ = api.urls
+        patterns = api.urls[0]
+        assert router._frozen is True
 
-        # Trying to add more operations should fail
-        with pytest.raises(ConfigError, match="frozen"):
+        @router.get("/new")
+        def new_endpoint(request):
+            return ["new"]
 
-            @router.get("/new")
-            def new_endpoint(request):
-                return []
+        assert api.urls[0] is patterns
+        assert router._frozen is True
 
-    def test_cannot_add_router_after_urls_accessed(self):
-        """Cannot add routers after URLs have been generated."""
-        api = NinjaAPI(urls_namespace="freeze-add-router")
+        client = TestClient(api)
+        response = client.get("/new")
+        assert response.status_code == 200
+        assert response.json() == ["new"]
 
-        # Access urls
-        _ = api.urls
+    def test_router_added_after_urls_accessed(self):
+        """Adding routers late rebuilds API URLs in place."""
+        api = NinjaAPI(urls_namespace="late-router-test")
+        patterns = api.urls[0]
 
         router = Router()
 
-        with pytest.raises(ConfigError, match="Cannot add routers"):
-            api.add_router("/new", router)
+        @router.get("/items")
+        def list_items(request):
+            return [1]
 
-    def test_cannot_add_decorator_to_frozen_router(self):
-        """Cannot add decorator to frozen router."""
+        api.add_router("/new", router)
+
+        assert api.urls[0] is patterns
+
+        client = TestClient(api)
+        response = client.get("/new/items")
+        assert response.status_code == 200
+        assert response.json() == [1]
+
+    def test_decorator_added_after_urls_accessed_updates_existing_client(self):
+        """Late decorator registration invalidates cached bound routers."""
         router = Router()
+        calls = []
 
         @router.get("/items")
         def list_items(request):
             return []
 
-        api = NinjaAPI(urls_namespace="freeze-decorator")
+        api = NinjaAPI(urls_namespace="late-decorator-test")
         api.add_router("", router)
 
-        # Access urls (triggers freezing)
-        _ = api.urls
+        client = TestClient(api)
+        response = client.get("/items")
+        assert response.status_code == 200
+        assert calls == []
 
         def some_decorator(func):
-            return func
+            def wrapper(*args, **kwargs):
+                calls.append("decorated")
+                return func(*args, **kwargs)
 
-        with pytest.raises(ConfigError, match="frozen"):
-            router.add_decorator(some_decorator)
+            return wrapper
+
+        router.add_decorator(some_decorator)
+
+        response = client.get("/items")
+        assert response.status_code == 200
+        assert calls == ["decorated"]
+
+    def test_exact_duplicate_api_registration_is_idempotent(self):
+        """Adding the exact same router mount twice is a no-op."""
+        router = Router()
+
+        @router.get("/items")
+        def list_items(request):
+            return []
+
+        api = NinjaAPI(urls_namespace="late-idempotent-api-test")
+        api.add_router("/items", router)
+        api.add_router("/items", router)
+
+        mounted = [b for b in api._get_bound_routers() if b.template is router]
+        assert len(mounted) == 1
+
+    def test_exact_duplicate_nested_registration_is_idempotent(self):
+        """Adding the exact same child router twice is a no-op."""
+        parent = Router()
+        child = Router()
+
+        @child.get("/items")
+        def list_items(request):
+            return []
+
+        parent.add_router("/child", child)
+        parent.add_router("/child", child)
+
+        api = NinjaAPI(urls_namespace="late-idempotent-child-test")
+        api.add_router("/parent", parent)
+
+        mounted = [b for b in api._get_bound_routers() if b.template is child]
+        assert len(mounted) == 1
+
+    def test_shared_child_router_invalidation_rebuilds_all_apis(self):
+        """Late changes to a shared child router invalidate every affected API."""
+        child = Router()
+
+        @child.get("/items")
+        def list_items(request):
+            return ["shared"]
+
+        parent_a = Router()
+        parent_b = Router()
+        parent_a.add_router("/child", child)
+        parent_b.add_router("/child", child)
+
+        api_a = NinjaAPI(urls_namespace="late-shared-a")
+        api_a.add_router("/a", parent_a)
+        api_b = NinjaAPI(urls_namespace="late-shared-b")
+        api_b.add_router("/b", parent_b)
+
+        client_a = TestClient(api_a)
+        client_b = TestClient(api_b)
+
+        assert client_a.get("/a/child/items").status_code == 200
+        assert client_b.get("/b/child/items").status_code == 200
+
+        @child.get("/late")
+        def late_endpoint(request):
+            return {"ok": True}
+
+        assert client_a.get("/a/child/late").status_code == 200
+        assert client_b.get("/b/child/late").status_code == 200
+
+    def test_collect_affected_apis_handles_diamond_router_graph(self):
+        """Shared parents should not cause duplicate traversal when walking upward."""
+        # Covers the visited-router guard in _collect_affected_apis(): traversing
+        # upward from `shared` reaches `grandparent` through both parents, so the
+        # second visit must short-circuit instead of recursing again.
+        shared = Router()
+        parent_a = Router()
+        parent_b = Router()
+        grandparent = Router()
+
+        parent_a.add_router("/shared", shared)
+        parent_b.add_router("/shared", shared)
+        grandparent.add_router("/a", parent_a)
+        grandparent.add_router("/b", parent_b)
+
+        api = NinjaAPI(urls_namespace="late-diamond-test")
+        api.add_router("/root", grandparent)
+
+        affected_apis = shared._collect_affected_apis()
+
+        assert affected_apis == {api}
+
+    @override_settings(ROOT_URLCONF="tests.late_router_registration_urls")
+    def test_reverse_sees_late_registered_routes(self):
+        """Django reverse sees routes added after the URLConf was imported."""
+        from tests import late_router_registration_urls
+
+        api = late_router_registration_urls.api
+
+        assert reverse("late-urls:initial") == "/late/initial"
+
+        router = Router()
+
+        @router.get("/route", url_name="late_route")
+        def late_route(request):
+            return {"ok": True}
+
+        api.add_router("/dynamic", router)
+
+        assert reverse("late-urls:late_route") == "/late/dynamic/route"
 
 
 class TestOperationClone:


### PR DESCRIPTION
## Summary

Allow `django-ninja` routes to be registered or mutated after the first
`NinjaAPI.urls` access.

Today, once `api.urls` has been accessed, adding routers, operations, or
decorators is effectively blocked by the materialized URL state. This change
makes those updates work by invalidating and rebuilding the bound router and URL
pattern caches in place.

This is especially useful in tests, where routes are often registered late
inside the test body or after a test URLConf has already been imported.

For a bit more context, our usecase is that in some of our tests we reconfigure `INSTALLED_APPS` via [`modify_settings`](https://docs.djangoproject.com/en/6.0/topics/testing/tools/#django.test.SimpleTestCase.modify_settings)  and some apps have ninja routes registered on `AppConfig.ready`. Another usecase we have is testing ninja exception handlers (`add_exception_handler`).

## Includes

- late `add_router()` support
- late operation / decorator / child-router registration support
- in-place URL pattern rebuilds
- Django `reverse()` support for late routes
- idempotency for duplicate registrations
- tests for shared-router invalidation and diamond traversal