### PR TITLE
TestClient improvements

### DIFF
--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -78,14 +78,14 @@ class NinjaClientBase:
     ) -> "NinjaResponse":
         return self.request("DELETE", path, data, json, **request_params)
 
-    def request(
+    def _prepare_request(
         self,
         method: str,
         path: str,
         data: Optional[Dict] = None,
         json: Any = None,
         **request_params: Any,
-    ) -> "NinjaResponse":
+    ) -> Tuple[Callable, Mock, Dict]:
         if json is not None:
             request_params["body"] = json_dumps(json, cls=NinjaJSONEncoder)
         if data is None:
@@ -100,7 +100,19 @@ class NinjaClientBase:
                 **self.cookies,
                 **request_params.get("COOKIES", {}),
             }
-        func, request, kwargs = self._resolve(method, path, data, request_params)
+        return self._resolve(method, path, data, request_params)
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        data: Optional[Dict] = None,
+        json: Any = None,
+        **request_params: Any,
+    ) -> "NinjaResponse":
+        func, request, kwargs = self._prepare_request(
+            method, path, data, json, **request_params
+        )
         return self._call(func, request, kwargs)  # type: ignore
 
     @property
@@ -125,6 +137,7 @@ class NinjaClientBase:
             match = url.resolve(url_path)
             if match:
                 request = self._build_request(method, path, data, request_params)
+                request.resolver_match = match
                 return match.func, request, match.kwargs
         raise Exception(f'Cannot resolve "{path}"')
 
@@ -134,18 +147,24 @@ class NinjaClientBase:
         request = Mock(spec=HttpRequest)
         request.method = method
         request.path = path
-        request.body = ""
+        request.body = b""
         request.COOKIES = {}
         request._dont_enforce_csrf_checks = True
         request.is_secure.return_value = False
         request.build_absolute_uri = build_absolute_uri
 
         request.auth = None
+        request.session = {}
         request.user = Mock()
         if "user" not in request_params:
             request.user.is_authenticated = False
             request.user.is_staff = False
             request.user.is_superuser = False
+
+        async def _auser() -> Any:
+            return request.user
+
+        request.auser = _auser
 
         request.META = request_params.pop("META", {"REMOTE_ADDR": "127.0.0.1"})
         request.FILES = request_params.pop("FILES", {})
@@ -186,6 +205,10 @@ class NinjaClientBase:
 
         for k, v in request_params.items():
             setattr(request, k, v)
+
+        if isinstance(request.body, str):
+            request.body = request.body.encode("utf-8")
+
         return request
 
 
@@ -195,6 +218,60 @@ class TestClient(NinjaClientBase):
 
 
 class TestAsyncClient(NinjaClientBase):
+    async def request(  # type: ignore[override]
+        self,
+        method: str,
+        path: str,
+        data: Optional[Dict] = None,
+        json: Any = None,
+        **request_params: Any,
+    ) -> "NinjaResponse":
+        func, request, kwargs = self._prepare_request(
+            method, path, data, json, **request_params
+        )
+        return await self._call(func, request, kwargs)
+
+    async def get(  # type: ignore[override]
+        self, path: str, data: Optional[Dict] = None, **request_params: Any
+    ) -> "NinjaResponse":
+        return await self.request("GET", path, data, **request_params)
+
+    async def post(  # type: ignore[override]
+        self,
+        path: str,
+        data: Optional[Dict] = None,
+        json: Any = None,
+        **request_params: Any,
+    ) -> "NinjaResponse":
+        return await self.request("POST", path, data, json, **request_params)
+
+    async def patch(  # type: ignore[override]
+        self,
+        path: str,
+        data: Optional[Dict] = None,
+        json: Any = None,
+        **request_params: Any,
+    ) -> "NinjaResponse":
+        return await self.request("PATCH", path, data, json, **request_params)
+
+    async def put(  # type: ignore[override]
+        self,
+        path: str,
+        data: Optional[Dict] = None,
+        json: Any = None,
+        **request_params: Any,
+    ) -> "NinjaResponse":
+        return await self.request("PUT", path, data, json, **request_params)
+
+    async def delete(  # type: ignore[override]
+        self,
+        path: str,
+        data: Optional[Dict] = None,
+        json: Any = None,
+        **request_params: Any,
+    ) -> "NinjaResponse":
+        return await self.request("DELETE", path, data, json, **request_params)
+
     async def _call(
         self, func: Callable, request: Mock, kwargs: Dict
     ) -> "NinjaResponse":

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,7 +12,7 @@ class MyParser(Parser):
 
     def parse_body(self, request: HttpRequest):
         "just splitting body to lines"
-        return request.body.encode().splitlines()
+        return request.body.decode().splitlines()
 
     def parse_querydict(
         self, data: QueryDict, list_fields: List[str], request: HttpRequest

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -1,3 +1,4 @@
+import inspect
 from datetime import datetime
 from http import HTTPStatus
 from unittest import mock
@@ -5,9 +6,9 @@ from unittest import mock
 import pytest
 from django.utils import timezone
 
-from ninja import Router
+from ninja import NinjaAPI, Router
 from ninja.schema import Schema
-from ninja.testing import TestClient
+from ninja.testing import TestAsyncClient, TestClient
 
 router = Router()
 
@@ -35,6 +36,24 @@ def get_headers(request):
 @router.get("/test-cookies")
 def get_cookies(request):
     return dict(request.COOKIES)
+
+
+@router.post("/check-body-type")
+def check_body_type(request):
+    return {"is_bytes": isinstance(request.body, bytes)}
+
+
+@router.get("/check-session")
+def check_session(request):
+    return {"has_session": isinstance(request.session, dict)}
+
+
+@router.get("/check-resolver-match/{item_id}")
+def check_resolver_match(request, item_id: int):
+    return {
+        "has_resolver_match": request.resolver_match is not None,
+        "item_id": item_id,
+    }
 
 
 client = TestClient(router)
@@ -124,3 +143,54 @@ def test_headered_client_request_with_default_cookies():
 def test_headered_client_request_with_overwritten_and_additional_cookies():
     r = cookied_client.get("/test-cookies", COOKIES={"A": "na", "C": "nc"})
     assert r.json() == {"A": "na", "B": "b", "C": "nc"}
+
+
+def test_body_is_bytes_with_json():
+    response = client.post("/check-body-type", json={"key": "value"})
+    assert response.json() == {"is_bytes": True}
+
+
+def test_body_is_bytes_empty():
+    response = client.post("/check-body-type")
+    assert response.json() == {"is_bytes": True}
+
+
+def test_session_exists():
+    response = client.get("/check-session")
+    assert response.json() == {"has_session": True}
+
+
+@pytest.mark.asyncio
+async def test_auser():
+    api = NinjaAPI()
+
+    @api.get("/check-auser")
+    async def check_auser(request):
+        user = await request.auser()
+        return {"has_user": user is not None}
+
+    async_client = TestAsyncClient(api)
+    response = await async_client.get("/check-auser")
+    assert response.status_code == 200
+    assert response.json() == {"has_user": True}
+
+
+def test_resolver_match():
+    response = client.get("/check-resolver-match/42")
+    assert response.json() == {"has_resolver_match": True, "item_id": 42}
+
+
+def test_async_client_methods_are_coroutines():
+    api = NinjaAPI()
+
+    @api.get("/dummy")
+    async def dummy(request):
+        return "ok"
+
+    async_client = TestAsyncClient(api)
+    assert inspect.iscoroutinefunction(async_client.get)
+    assert inspect.iscoroutinefunction(async_client.post)
+    assert inspect.iscoroutinefunction(async_client.put)
+    assert inspect.iscoroutinefunction(async_client.patch)
+    assert inspect.iscoroutinefunction(async_client.delete)
+    assert inspect.iscoroutinefunction(async_client.request)

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -175,6 +175,27 @@ async def test_auser():
     assert response.json() == {"has_user": True}
 
 
+@pytest.mark.asyncio
+async def test_async_client_patch_and_delete():
+    api = NinjaAPI()
+
+    @api.patch("/item")
+    async def patch_item(request):
+        return {"method": "PATCH"}
+
+    @api.delete("/item")
+    async def delete_item(request):
+        return {"method": "DELETE"}
+
+    async_client = TestAsyncClient(api)
+
+    response = await async_client.patch("/item")
+    assert response.json() == {"method": "PATCH"}
+
+    response = await async_client.delete("/item")
+    assert response.json() == {"method": "DELETE"}
+
+
 def test_resolver_match():
     response = client.get("/check-resolver-match/42")
     assert response.json() == {"has_resolver_match": True, "item_id": 42}


### PR DESCRIPTION
TestClient: improve mock request mock

  - request.body is now bytes (was str), matching Django's HttpRequest.body
  - request.session is set to {} by default
  - request.auser() async method added, returns request.user (Django 5.0+)
  - request.resolver_match is set from URL resolution
  - TestAsyncClient methods (get, post, put, patch, delete, request) are now properly async, fixing mypy errors when using await

fixes  #1675 #1321 #1252 #1061 #1361