### PR TITLE
Fix OpenAPI 3.1 compliance for query parameter examples

### DIFF
--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -155,6 +155,30 @@ class OpenAPISchema(dict):
                 result.extend(self._extract_parameters(model))
         return result
 
+    def _normalize_parameter_examples(self, examples: Any) -> DictStrAny:
+        if isinstance(examples, dict):
+            return examples
+
+        if not isinstance(examples, list):
+            return {}
+
+        normalized_examples: DictStrAny = {}
+        for index, example in enumerate(examples, start=1):
+            # OpenAPI Parameter Object expects examples to be a map where each value
+            # is an Example Object (or a Reference Object).
+            if isinstance(example, dict) and (
+                "$ref" in example
+                or any(
+                    key in example
+                    for key in ("summary", "description", "value", "externalValue")
+                )
+            ):
+                normalized_examples[f"example{index}"] = example
+            else:
+                normalized_examples[f"example{index}"] = {"value": example}
+
+        return normalized_examples
+
     def _extract_parameters(self, model: TModel) -> List[DictStrAny]:
         result = []
 
@@ -191,7 +215,9 @@ class OpenAPISchema(dict):
                 if "description" in p_schema:
                     param["description"] = p_schema["description"]
                 if "examples" in p_schema:
-                    param["examples"] = p_schema["examples"]
+                    examples = self._normalize_parameter_examples(p_schema["examples"])
+                    if examples:
+                        param["examples"] = examples
                 elif "example" in p_schema:
                     param["example"] = p_schema["example"]
                 if "deprecated" in p_schema:

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -209,6 +209,7 @@ def method_test_deprecated_example_examples(
             },
         },
     ),
+    param5: str = Query(..., examples=["Foo", "Bar"]),
     param4: int = Query(None, deprecated=True, include_in_schema=False),
 ):
     return dict(i=param2, f=param3)
@@ -803,6 +804,20 @@ def test_schema_deprecated_example_examples(schema):
                     "summary": "A normal example",
                     "value": "Foo",
                 },
+            },
+        },
+        {
+            "in": "query",
+            "name": "param5",
+            "required": True,
+            "schema": {
+                "title": "Param5",
+                "type": "string",
+                "examples": ["Foo", "Bar"],
+            },
+            "examples": {
+                "example1": {"value": "Foo"},
+                "example2": {"value": "Bar"},
             },
         },
     ]


### PR DESCRIPTION
Fixes #1636

Pydantic provides `examples` as a list (valid JSON Schema), but OpenAPI 3.1 requires the `examples` field at the Parameter Object level to be a map of Example Objects.

Currently, Django Ninja copies the list directly, causing Swagger UI to fail with:
TypeError: i.get is not a function

This PR:
- Normalizes list-based examples into OpenAPI-compliant map format at the parameter level
- Preserves dict-based examples unchanged
- Adds regression test for list-style examples

Schema-level examples remain unchanged as they are valid JSON Schema.

Builds upon #1637 by adding regression tests and ensuring compatibility.