### PR TITLE
fix(streaming): make SSE and JSONL generic

### DIFF
--- a/ninja/streaming.py
+++ b/ninja/streaming.py
@@ -1,29 +1,32 @@
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Generic, Type, TypeVar
 
 from ninja.responses import NinjaJSONEncoder
 
 __all__ = ["StreamFormat", "SSE", "JSONL"]
 
 
+T = TypeVar("T")
+
+
 def _serialize_item(item: Any) -> str:
     return json.dumps(item, cls=NinjaJSONEncoder)
 
 
-class _StreamAlias:
+class _StreamAlias(Generic[T]):
     """Marker created by StreamFormat[ItemType]."""
 
-    def __init__(self, format_cls: type, item_type: type) -> None:
+    def __init__(self, format_cls: Type[Any], item_type: Type[T]) -> None:
         self.format_cls = format_cls
         self.item_type = item_type
 
 
-class StreamFormat:
+class StreamFormat(Generic[T]):
     """Base class for streaming formats. Extensible by users."""
 
     media_type: str
 
-    def __class_getitem__(cls, item_type: type) -> "_StreamAlias":
+    def __class_getitem__(cls, item_type: Type[T]) -> "_StreamAlias[T]":
         return _StreamAlias(cls, item_type)
 
     @classmethod
@@ -42,7 +45,7 @@ class StreamFormat:
         return {}
 
 
-class JSONL(StreamFormat):
+class JSONL(StreamFormat, Generic[T]):
     media_type = "application/jsonl"
 
     @classmethod
@@ -50,7 +53,7 @@ class JSONL(StreamFormat):
         return data + "\n"
 
 
-class SSE(StreamFormat):
+class SSE(StreamFormat, Generic[T]):
     media_type = "text/event-stream"
 
     @classmethod

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -5,6 +5,7 @@ from django.http import HttpRequest
 from typing_extensions import Annotated
 
 from ninja import Body, BodyEx, NinjaAPI, P, Schema, Status
+from ninja.streaming import JSONL, SSE
 
 
 class Payload(Schema):
@@ -47,3 +48,16 @@ def status_generic(request: HttpRequest) -> Status[dict]:
 @api.post("/status_generic_schema")
 def status_generic_schema(request: HttpRequest) -> Status[Payload]:
     return Status(200, Payload(x=1, y=2.0, s="test"))
+
+
+# -- Streaming generics --
+
+
+@api.get("/streaming_jsonl", response=JSONL[Payload])
+def streaming_jsonl(request: HttpRequest) -> Any:
+    yield {"x": 1, "y": 2.0, "s": "jsonl"}
+
+
+@api.get("/streaming_sse", response=SSE[Payload])
+def streaming_sse(request: HttpRequest) -> Any:
+    yield {"x": 1, "y": 2.0, "s": "sse"}


### PR DESCRIPTION
## What does this PR do?

Makes `ninja.streaming.StreamFormat`-based response containers generic so static type checkers accept documented usage like `SSE[Schema]` and `JSONL[Schema]`.

## Why is this change needed?

Tracked in #1713.

`SSE[Schema]` and `JSONL[Schema]` work at runtime via `__class_getitem__`, but mypy rejects them because the streaming containers were not modeled as generics. This forces users with strict type checking to add ignores around valid code.

## How was this tested?

- Added mypy regression coverage in `tests/mypy_test.py` for both `JSONL[Payload]` and `SSE[Payload]`
- Ran `mypy ninja tests/mypy_test.py`
- Ran `pytest tests/test_streaming.py`

## Checklist

- [x] I've read the CONTRIBUTING.md
- [x] Tests pass locally
- [x] I've added tests where applicable
- [ ] I've updated documentation where applicable
