### PR TITLE
fix: handle aliases with dashes in DjangoGetter attribute resolution

### DIFF
--- a/ninja/router.py
+++ b/ninja/router.py
@@ -151,8 +151,8 @@ class BoundRouter:
                         )
 
                 # Apply tags inheritance
-                if operation.tags is None and self.tags is not None:  # type: ignore[has-type]
-                    operation.tags = self.tags  # type: ignore[has-type]
+                if operation.tags is None and self.tags is not None:
+                    operation.tags = self.tags
 
                 # Apply decorators (fresh application - no tracking needed)
                 for decorator, mode in effective_decorators:

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -18,6 +18,7 @@ dotted attributes and resolver methods. For example::
 
 """
 
+import re
 import warnings
 from typing import (
     Any,
@@ -44,6 +45,9 @@ from ninja.types import DictStrAny
 
 pydantic_version = list(map(int, pydantic.VERSION.split(".")[:2]))
 assert pydantic_version >= [2, 0], "Pydantic 2.0+ required"
+
+# Django template Variable only accepts word chars and dots (no dashes, spaces, etc.)
+_DJANGO_VAR_RE = re.compile(r"^[\w.]+$")
 
 __all__ = ["BaseModel", "Field", "DjangoGetter", "Schema"]
 
@@ -74,6 +78,8 @@ class DjangoGetter:
                 try:
                     value = getattr(self._obj, key)
                 except AttributeError:
+                    if not _DJANGO_VAR_RE.match(key):
+                        raise
                     try:
                         # value = attrgetter(key)(self._obj)
                         value = Variable(key).resolve(self._obj)


### PR DESCRIPTION
Fix TemplateSyntaxError when a Schema field uses an alias containing a dash (e.g. alias="CloudFront-Policy").

DjangoGetter.__getattr__ was falling through to Django's template Variable(key).resolve() even for keys that are invalid template variable names. Django's parser rejects dashes, raising TemplateSyntaxError instead of a catchable error.

The fix adds a guard using re.compile(r"^[\w.]+$") to skip Variable.resolve for keys that contain characters outside the set Django Template Variables accept (word chars and dots). Dotted paths like "boss.name" continue to work normally.

Fixes: aliases with - in name (e.g. AWS CloudFront cookies headers). Fixes #1660 