### PR TITLE
fix: ensure DATABASE ROLLBACK on exception

### DIFF
--- a/ninja/main.py
+++ b/ninja/main.py
@@ -612,6 +612,7 @@ class NinjaAPI:
 
     def on_exception(self, request: HttpRequest, exc: Exc[_E]) -> HttpResponse:
         handler = self._lookup_exception_handler(exc)
+        transaction.set_rollback(True) # ensure DB rollback on exception
         if handler is None:
             raise exc
         return handler(request, exc)


### PR DESCRIPTION
# fix: rollback not trigger on exception


Addressing:

closes #619 
closes #1704 
closes #1224 
in discuss #924 



## Data Integrity at Risk in Local Development

AKA: transaction.atomic not working

This issue occurs in local development with `DEBUG=True` — exactly where you are writing tests, validating business logic, and trusting that the behavior mirrors production.

Here is what happens, step by step:

1. Your endpoint performs a database write
2. Something goes wrong during the response cycle — a wrong status code, a serialization error, a schema mismatch
3. Django Ninja catches the exception internally (code bellow)

```python
ninja/errors.py

# line 125
def _default_exception(
    request: HttpRequest, exc: Exception, api: "NinjaAPI"
) -> HttpResponse:
    if not settings.DEBUG:
        raise exc  # let django deal with it
    
    logger.exception(exc)
    tb = traceback.format_exc()
    return HttpResponse(tb, status=500, content_type="text/plain")

```




4. Django Ninja returns an `HttpResponse` with status 500
5. Django's transaction middleware **never sees the exception**
6. The transaction is **never rolled back**
7. **The client receives a 500. The database keeps the write.**

You look at the response — failure. You look at the database — the data is there. You assume the operation succeeded. It didn't. Your API lied to you, and your database is now in a state that never should have existed.

This silently corrupts your development assumptions, your test fixtures, and your confidence in the system before it ever reaches production.

---

## 🔁 How to Reproduce

```python
class User(Model):
    username = CharField()

# endpoint declares 201, but returns 203
@router.post("", response={201: UserSchema})
def create_user(request, payload: UserCreateSchema):
    with transaction.atomic():
        user = User.objects.create(username=payload.username)
        return 203, user  # wrong status → exception during response cycle

# result:
# ← HTTP 500 (client sees failure)
# ← User.objects.filter(username=payload.username).exists() → True
#    the write happened. silently.
```

Same behavior with:

```python
# serialization error — field missing in schema
return 201, user  # user has a field the schema doesn't expect

# validator raising inside schema
class UserSchema(Schema):
    username: str

    @validator("username")
    def validate(cls, v):
        raise ValueError("boom")  # exception after write
```

(The Bank Example) IKNOW ITS A DEBUG TRUE PROBLEM BUT A PROBLEM IS A PROBLEM

Here is a simplified scenario demonstrating the narrative above:

```python
from django.db import models, transaction
from ninja import NinjaAPI

api = NinjaAPI()

# 1. Simple Model
class BankAccount(models.Model):
    balance = models.IntegerField(default=1000)

# 2. Custom Exception and Handler
class InsufficientFundsError(Exception):
    pass

@api.exception_handler(InsufficientFundsError)
def handle_funds_error(request, exc):
    return api.create_response(request, {"error": "Not enough funds"}, status=400)

# 3. The Endpoint
@api.post("/transfer")
@transaction.atomic
def transfer_money(request):
    account = BankAccount.objects.get(id=1)
    
    # 👉 Step A: Write operation happens (Pending in transaction)
    account.balance -= 100
    account.save()
    
    # 👉 Step B: Business logic fails, exception is raised
    raise InsufficientFundsError()

```

Expected Behavior: The transaction rolls back. The balance remains 1000.

Actual Behavior: The client gets a 400 Bad Request, but the transaction is committed. The balance is now 900.


===============

**Every case produces the same result: 500 to the client, committed write in the database.**

---

## ✅ The Fix

```diff 
ninja/main.py

613    def on_exception(self, request: HttpRequest, exc: Exc[_E]) -> HttpResponse:
614        handler = self._lookup_exception_handler(exc)
+615       transaction.set_rollback(True)  # ensure DB rollback on exception
615        if handler is None:
616            raise exc
617        return handler(request, exc)
```

One line. Centralized. Applied before any handler runs — custom or default.

---

## 🛡️ Impact on Existing Projects

This change is **fully backwards compatible.**

- Projects not using transactions: no effect
- Projects using `transaction.atomic()`: now correctly rollback on error
- Projects with custom exception handlers: rollback is guaranteed regardless of handler implementation
- Projects already calling `set_rollback(True)` manually: no change in behavior

The fix only acts when something already went wrong. It does not interfere with the happy path. It does not change how responses are built. It does not affect custom handlers.

**It solely ensures that when your API fails in development, your database stays clean — and your assumptions stay true.**
