### PR TITLE
update NinjaGenerateJsonSchema to handle the MISSING sentinel

### DIFF
--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         django-version: ['<3.2', '<3.3', '<4.2', '<4.3', '<5.1', '<5.2', '<5.3', '<6.1']
+        pydantic-version: ['']
         exclude:
           - python-version: '3.7'
             django-version: '<5.1'
@@ -46,7 +47,18 @@ jobs:
             django-version: '<5.1'
           - python-version: '3.14'
             django-version: '<5.2'
-    
+
+        include:
+          - python-version: '3.7'
+            django-version: '<6.1'
+            pydantic-version: '<2.11'
+          - python-version: '3.13'
+            django-version: '<6.1'
+            pydantic-version: '<2.11'
+          - python-version: '3.14'
+            django-version: '<6.1'
+            pydantic-version: '<2.11'
+
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -42,6 +42,13 @@ from typing_extensions import dataclass_transform
 from ninja.signature.utils import get_args_names, has_kwargs
 from ninja.types import DictStrAny
 
+try:
+    from pydantic.experimental.missing_sentinel import MISSING
+except ImportError:  # pragma: no cover
+    # pydantic <2.11 does not have the MISSING sentinel, and thus it cannot be used for many reasons.
+    # fake it here with None so it doesn't error
+    MISSING = None
+
 pydantic_version = list(map(int, pydantic.VERSION.split(".")[:2]))
 assert pydantic_version >= [2, 0], "Pydantic 2.0+ required"
 
@@ -191,7 +198,11 @@ class NinjaGenerateJsonSchema(GenerateJsonSchema):
         json_schema = self.generate_inner(schema["schema"])
 
         default = None
-        if "default" in schema and schema["default"] is not None:
+        if (
+            "default" in schema
+            and schema["default"] is not None
+            and schema["default"] is not MISSING
+        ):
             default = self.encode_default(schema["default"])
 
         if "$ref" in json_schema:
@@ -200,7 +211,7 @@ class NinjaGenerateJsonSchema(GenerateJsonSchema):
         else:
             result = json_schema
 
-        if default is not None:
+        if default is not None and default is not MISSING:
             result["default"] = default
 
         return result

--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from ninja import Schema
 
 try:
@@ -8,8 +10,8 @@ except ImportError:
 
 class Contact(Schema):
     name: str
-    number: int | MISSING = MISSING
-    address: str | None = None
+    number: Union[int, MISSING] = MISSING
+    address: Union[str, None] = None
 
 
 def test_missing_serialization():

--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -1,0 +1,58 @@
+from ninja import Schema
+
+try:
+    from pydantic.experimental.missing_sentinel import MISSING
+except ImportError:
+    MISSING = None
+
+
+class Contact(Schema):
+    name: str
+    number: int | MISSING = MISSING
+    address: str | None = None
+
+
+def test_missing_serialization():
+    contact = Contact(name="Sam")
+    if MISSING is None:
+        assert contact.model_dump() == {"name": "Sam", "address": None, "number": None}
+    else:
+        assert contact.model_dump() == {"name": "Sam", "address": None}
+
+
+def test_missing_json_schema():
+    schema = Contact.json_schema()
+    output = {
+        "properties": {
+            "name": {
+                "title": "Name",
+                "type": "string",
+            },
+            "number": {
+                "title": "Number",
+                "type": "integer",
+            },
+            "address": {
+                "anyOf": [
+                    {
+                        "type": "string",
+                    },
+                    {
+                        "type": "null",
+                    },
+                ],
+                "title": "Address",
+            },
+        },
+        "required": ["name"],
+        "title": "Contact",
+        "type": "object",
+    }
+    if MISSING is None:
+        output["properties"]["number"] = {
+            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "title": "Number",
+        }
+        assert schema == output
+    else:
+        assert schema == output


### PR DESCRIPTION
Small update to the custom schema generator method `NinjaGenerateJsonSchema.default_schema` so it can handle the new pydantic `MISSING` sentinel. The changes here reflect the [changes in pydantic](https://github.com/pydantic/pydantic/blob/ebc4652df990affb79bb3c3db960fb8d2a2b4308/pydantic/json_schema.py#L1183).

This does not address any integration of `MISSING` into `ModelSchema` django fields as done here: https://github.com/vitalik/django-ninja/pull/1656