### PR TITLE
fix: Fixed typing for Meta configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,13 +6,13 @@ repos:
       # - id: end-of-file-fixer
       # - id: trailing-whitespace
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
+    rev: v1.13.0
     hooks:
       - id: mypy
         additional_dependencies: ["django-stubs", "pydantic"]
         exclude: (tests|docs)/
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.2
+    rev: v0.5.7
     hooks:
       - id: ruff-format
       - id: ruff

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,6 +13,7 @@ exclude = ^(\.venv|venv|env)/
 # be strict
 disallow_untyped_calls = True
 warn_return_any = True
+strict_equality = True
 strict_optional = True
 warn_no_return = True
 warn_redundant_casts = True
@@ -21,6 +22,9 @@ warn_unused_ignores = True
 disallow_untyped_defs = True
 check_untyped_defs = True
 no_implicit_reexport = True
+
+plugins =
+    pydantic.mypy
 
 [mypy-ninja.compatibility.*]
 ignore_errors = True

--- a/ninja/decorators.py
+++ b/ninja/decorators.py
@@ -10,6 +10,7 @@ from ninja.utils import contribute_operation_callback
 # Type for decorator modes
 DecoratorMode = Literal["operation", "view"]
 
+
 # Since @api.method decorator is applied to function
 # that is not always returns a HttpResponse object
 # there is no way to apply some standard decorators form
@@ -28,7 +29,7 @@ def decorate_view(*decorators: Callable[..., Any]) -> Callable[[TCallable], TCal
     def outer_wrapper(op_func: TCallable) -> TCallable:
         if hasattr(op_func, "_ninja_operation"):
             # Means user used decorate_view on top of @api.method
-            _apply_decorators(decorators, op_func._ninja_operation)  # type: ignore
+            _apply_decorators(decorators, op_func._ninja_operation)
         else:
             # Means user used decorate_view after(bottom) of @api.method
             contribute_operation_callback(
@@ -41,7 +42,7 @@ def decorate_view(*decorators: Callable[..., Any]) -> Callable[[TCallable], TCal
 
 
 def _apply_decorators(
-    decorators: Tuple[Callable[..., Any]], operation: Operation
+    decorators: Tuple[Callable[..., Any], ...], operation: Operation
 ) -> None:
     # Track decorators for cloning support
     if not hasattr(operation, "_run_decorators"):

--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -123,7 +123,7 @@ class Operation:
         self.operation_id = operation_id
         self.summary = summary or self.view_func.__name__.title().replace("_", " ")
         self.description = description or self.signature.docstring
-        self.tags = tags
+        self.tags: Optional[List[str]] = tags
         self.deprecated = deprecated
         self.include_in_schema = include_in_schema
         self.openapi_extra = openapi_extra

--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -1,5 +1,17 @@
 import itertools
-from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Type, Union, cast
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 from django.db.models import Field as DjangoField
 from django.db.models import ManyToManyRel, ManyToOneRel, Model
@@ -40,7 +52,7 @@ class SchemaFactory:
         depth: int = 0,
         fields: Optional[List[str]] = None,
         exclude: Optional[List[str]] = None,
-        optional_fields: Optional[List[str]] = None,
+        optional_fields: Optional[List[str] | Literal["__all__"]] = None,
         custom_fields: Optional[List[Tuple[str, Any, Any]]] = None,
         base_class: Type[Schema] = Schema,
     ) -> Type[Schema]:
@@ -56,16 +68,17 @@ class SchemaFactory:
             return self.schemas[key]
 
         model_fields_list = list(self._selected_model_fields(model, fields, exclude))
-        if optional_fields:
-            if optional_fields == "__all__":
-                optional_fields = [f.name for f in model_fields_list]
+        if optional_fields == "__all__":
+            optional_fields_list = [f.name for f in model_fields_list]
+        else:
+            optional_fields_list = optional_fields or []
 
         definitions = {}
         for fld in model_fields_list:
             python_type, field_info = get_schema_field(
                 fld,
                 depth=depth,
-                optional=optional_fields and (fld.name in optional_fields),
+                optional=fld.name in optional_fields_list,
             )
             definitions[fld.name] = (python_type, field_info)
 
@@ -78,14 +91,15 @@ class SchemaFactory:
         if name in self.schema_names:
             name = self._get_unique_name(name)
 
-        schema: Type[Schema] = create_pydantic_model(
-            name,
-            __config__=None,
-            __base__=base_class,
-            __module__=base_class.__module__,
-            __validators__={},
-            **definitions,
-        )  # type: ignore
+        schema: Type[Schema] = cast(
+            Type[Schema],
+            create_pydantic_model(  # type: ignore[call-overload]
+                name,
+                __base__=base_class,
+                __module__=base_class.__module__,
+                **definitions,
+            ),
+        )
         # __model_name: str,
         # *,
         # __config__: ConfigDict | None = None,

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -1,16 +1,16 @@
 import datetime
 from decimal import Decimal
-from typing import Any, Callable, Dict, List, Tuple, Type, TypeVar, Union, no_type_check
+from typing import Any, Callable, Dict, List, Tuple, Type, TypeVar, Union, cast
 from uuid import UUID
 
 from django.db.models import ManyToManyField
 from django.db.models.fields import Field as DjangoField
-from pydantic import IPvAnyAddress
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, IPvAnyAddress
 from pydantic.fields import FieldInfo
+from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticUndefined, core_schema
 
 from ninja.errors import ConfigError
-from ninja.openapi.schema import OpenAPISchema
 from ninja.types import DictStrAny
 
 __all__ = ["create_m2m_link_type", "get_schema_field", "get_related_field_schema"]
@@ -43,7 +43,7 @@ class AnyObject:
         return value
 
 
-TYPES = {
+TYPES: dict[str, Any] = {
     "AutoField": int,
     "BigAutoField": int,
     "BigIntegerField": int,
@@ -86,15 +86,18 @@ def register_field(django_field: str, python_type: Any) -> None:
     TYPES[django_field] = python_type
 
 
-@no_type_check
 def create_m2m_link_type(type_: Type[TModel]) -> Type[TModel]:
     class M2MLink(type_):  # type: ignore
         @classmethod
-        def __get_pydantic_core_schema__(cls, source, handler):
+        def __get_pydantic_core_schema__(
+            cls, source_type: Any, handler: GetCoreSchemaHandler
+        ) -> core_schema.CoreSchema:
             return core_schema.with_info_plain_validator_function(cls._validate)
 
         @classmethod
-        def __get_pydantic_json_schema__(cls, schema, handler):
+        def __get_pydantic_json_schema__(
+            cls, core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+        ) -> JsonSchemaValue:
             json_type = {
                 int: "integer",
                 str: "string",
@@ -104,33 +107,31 @@ def create_m2m_link_type(type_: Type[TModel]) -> Type[TModel]:
             return {"type": json_type}
 
         @classmethod
-        def _validate(cls, v: Any, _):
+        def _validate(cls, v: Any, _: core_schema.ValidationInfo[Any]) -> Any:
             try:
                 return v.pk  # when we output queryset - we have db instances
             except AttributeError:
-                return type_(v)  # when we read payloads we have primakey keys
+                return type_(v)  # type: ignore[call-arg] # when we read payloads we have primary keys
 
     return M2MLink
 
 
-@no_type_check
 def get_schema_field(
     field: DjangoField, *, depth: int = 0, optional: bool = False
-) -> Tuple:
+) -> Tuple[Any, FieldInfo]:
     "Returns pydantic field from django's model field"
     alias = None
-    default = ...
+    default: Any = ...
     default_factory = None
-    description = None
-    title = None
     max_length = None
     nullable = False
-    python_type = None
+    python_type: Type[Any]
 
     if field.is_relation:
         if depth > 0:
             return get_related_field_schema(field, depth=depth)
 
+        assert isinstance(field.related_model, type)
         internal_type = field.related_model._meta.pk.get_internal_type()
 
         if not field.concrete and field.auto_created or field.null or optional:
@@ -141,8 +142,8 @@ def get_schema_field(
 
         pk_type = TYPES.get(internal_type, int)
         if field.one_to_many or field.many_to_many:
-            m2m_type = create_m2m_link_type(pk_type)
-            python_type = List[m2m_type]  # type: ignore
+            m2m_type: Type[Any] = create_m2m_link_type(pk_type)
+            python_type = List[m2m_type]  # type: ignore[valid-type]
         else:
             python_type = pk_type
 
@@ -177,10 +178,10 @@ def get_schema_field(
         default = PydanticUndefined
 
     if nullable:
-        python_type = Union[python_type, None]  # aka Optional in 3.7+
+        python_type = Union[python_type, None]  # type: ignore[assignment]  # aka Optional in 3.7+
 
-    description = field.help_text or None
-    title = title_if_lower(field.verbose_name)
+    description = cast(str, field.help_text) or None
+    title = title_if_lower(cast(str, field.verbose_name))
 
     return (
         python_type,
@@ -197,13 +198,15 @@ def get_schema_field(
     )
 
 
-@no_type_check
-def get_related_field_schema(field: DjangoField, *, depth: int) -> Tuple[OpenAPISchema]:
+def get_related_field_schema(
+    field: DjangoField, *, depth: int
+) -> Tuple[Any, FieldInfo]:
     from ninja.orm import create_schema
 
     model = field.related_model
+    assert isinstance(model, type)
     schema = create_schema(model, depth=depth - 1)
-    default = ...
+    default: Any = ...
     if not field.concrete and field.auto_created or field.null:
         default = None
     if isinstance(field, ManyToManyField):
@@ -213,7 +216,7 @@ def get_related_field_schema(field: DjangoField, *, depth: int) -> Tuple[OpenAPI
         schema,
         FieldInfo(
             default=default,
-            description=field.help_text,
-            title=title_if_lower(field.verbose_name),
+            description=cast(str, field.help_text),
+            title=title_if_lower(cast(str, field.verbose_name)),
         ),
     )

--- a/ninja/orm/metaclass.py
+++ b/ninja/orm/metaclass.py
@@ -1,4 +1,5 @@
-from typing import Any, List, Optional, Union, no_type_check
+import typing
+from typing import Any, List, Optional, Union
 
 from django.apps import apps
 from django.db.models import Model as DjangoModel
@@ -16,8 +17,8 @@ _is_modelschema_class_defined = False
 class MetaConf:
     model: Any
     fields: Optional[List[str]] = None
-    exclude: Union[List[str], str, None] = None
-    fields_optional: Union[List[str], str, None] = None
+    exclude: Union[List[str], None] = None
+    fields_optional: Union[List[str], typing.Literal["__all__"], None] = None
 
     @staticmethod
     def from_schema_class(name: str, namespace: dict) -> "MetaConf":
@@ -64,14 +65,13 @@ class MetaConf:
 
 
 class ModelSchemaMetaclass(ResolverMetaclass):
-    @no_type_check
     def __new__(
         mcs,
         name: str,
         bases: tuple,
         namespace: dict,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> type:
         cls = super().__new__(
             mcs,
             name,

--- a/ninja/router.py
+++ b/ninja/router.py
@@ -147,12 +147,12 @@ class BoundRouter:
                         operation.throttle_objects = (
                             isinstance(throttle, BaseThrottle)
                             and [throttle]
-                            or throttle  # type: ignore
+                            or throttle  # type: ignore[assignment]
                         )
 
                 # Apply tags inheritance
-                if operation.tags is None and self.tags is not None:  # type: ignore[has-type]
-                    operation.tags = self.tags  # type: ignore[has-type]
+                if operation.tags is None and self.tags is not None:
+                    operation.tags = self.tags
 
                 # Apply decorators (fresh application - no tracking needed)
                 for decorator, mode in effective_decorators:

--- a/ninja/schema.py
+++ b/ninja/schema.py
@@ -26,7 +26,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    no_type_check,
 )
 
 import pydantic
@@ -93,7 +92,7 @@ class DjangoGetter:
         if isinstance(result, Manager):
             return list(result.all())
 
-        elif isinstance(result, getattr(QuerySet, "__origin__", QuerySet)):
+        elif isinstance(result, QuerySet):
             return list(result)
 
         if callable(result):
@@ -159,8 +158,13 @@ class Resolver:
 class ResolverMetaclass(ModelMetaclass):
     _ninja_resolvers: Dict[str, Resolver]
 
-    @no_type_check
-    def __new__(cls, name, bases, namespace, **kwargs):
+    def __new__(
+        cls,
+        name: str,
+        bases: tuple,
+        namespace: dict,
+        **kwargs: Any,
+    ) -> type:
         resolvers = {}
 
         for base in reversed(bases):
@@ -179,7 +183,7 @@ class ResolverMetaclass(ModelMetaclass):
             resolvers[attr[8:]] = Resolver(resolve_func)
 
         result = super().__new__(cls, name, bases, namespace, **kwargs)
-        result._ninja_resolvers = resolvers
+        result._ninja_resolvers = resolvers  # type: ignore[attr-defined]
         return result
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,9 @@ test = [
     "pytest-django",
     "pytest-asyncio",
     "psycopg2-binary",
-    "mypy==1.7.1",
+    "mypy==1.13.0",
     "ruff==0.5.7",
-    "django-stubs",
+    "django-stubs[compatible-mypy]",
 ]
 doc = ["mkdocs", "mkdocs-material", "markdown-include", "mkdocstrings"]
 dev = ["pre-commit"]


### PR DESCRIPTION
This bundles a few (related) fixes into one PR:

1. `Meta.exclude` is typed as a possible `str` but that is in no way supported
2. `Meta.fields_optional` can be a `"__all__"` but not any other `str`
3. `fields_optional` is typed as `str` but `SchemaFactory` isn't typed to take an `str`
4. Missing mypy `strict_equality` which would have caught the issue in `SchemaFactory`
5. Old mypy version that is incompatible with recent `django-stubs` - upgraded to the first supported version
6. `@no_type_check` in this area - removed and fixed (or ignored) all issues