### PR TITLE
fix: make streaming responses generic for type checkers

### DIFF
--- a/ninja/streaming.py
+++ b/ninja/streaming.py
@@ -1,7 +1,9 @@
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Generic, Type, TypeVar
 
 from ninja.responses import NinjaJSONEncoder
+
+_T = TypeVar("_T")
 
 __all__ = ["StreamFormat", "SSE", "JSONL"]
 
@@ -13,12 +15,12 @@ def _serialize_item(item: Any) -> str:
 class _StreamAlias:
     """Marker created by StreamFormat[ItemType]."""
 
-    def __init__(self, format_cls: type, item_type: type) -> None:
+    def __init__(self, format_cls: Type["StreamFormat[Any]"], item_type: type) -> None:
         self.format_cls = format_cls
         self.item_type = item_type
 
 
-class StreamFormat:
+class StreamFormat(Generic[_T]):
     """Base class for streaming formats. Extensible by users."""
 
     media_type: str
@@ -42,7 +44,7 @@ class StreamFormat:
         return {}
 
 
-class JSONL(StreamFormat):
+class JSONL(StreamFormat, Generic[_T]):
     media_type = "application/jsonl"
 
     @classmethod
@@ -50,7 +52,7 @@ class JSONL(StreamFormat):
         return data + "\n"
 
 
-class SSE(StreamFormat):
+class SSE(StreamFormat, Generic[_T]):
     media_type = "text/event-stream"
 
     @classmethod

--- a/tests/mypy_test.py
+++ b/tests/mypy_test.py
@@ -5,6 +5,7 @@ from django.http import HttpRequest
 from typing_extensions import Annotated
 
 from ninja import Body, BodyEx, NinjaAPI, P, Schema, Status
+from ninja.streaming import JSONL, SSE
 
 
 class Payload(Schema):
@@ -47,3 +48,16 @@ def status_generic(request: HttpRequest) -> Status[dict]:
 @api.post("/status_generic_schema")
 def status_generic_schema(request: HttpRequest) -> Status[Payload]:
     return Status(200, Payload(x=1, y=2.0, s="test"))
+
+
+# -- Streaming generics --
+
+
+@api.get("/sse_stream", response=SSE[Payload])
+def sse_stream(request: HttpRequest) -> Any:
+    yield {"x": 1, "y": 2.0, "s": "test"}
+
+
+@api.get("/jsonl_stream", response=JSONL[Payload])
+def jsonl_stream(request: HttpRequest) -> Any:
+    yield {"x": 1, "y": 2.0, "s": "test"}


### PR DESCRIPTION
## Summary

- Make `StreamFormat`, `SSE`, and `JSONL` generic so type checkers accept `SSE[Schema]` and `JSONL[Schema]`.
- Add streaming response examples to the existing mypy parametrization smoke test.

Fixes #1713.

## Tests

- `pytest tests/test_streaming.py -q`
- `ruff format --check ninja tests`
- `ruff check ninja tests`
- `mypy ninja tests/mypy_test.py`
- `pytest . -q`

## Notes

- `pytest --cov=ninja` runs all tests successfully locally but exits non-zero because total coverage reports `99.98%`, below the repository's `fail_under = 100`; the only reported missing line is `ninja/signature/utils.py:79`, unrelated to this change.
