### PR TITLE
fix: combine router operations for matching paths

### DIFF
--- a/ninja/main.py
+++ b/ninja/main.py
@@ -14,6 +14,7 @@ from typing import (
 
 from django.http import HttpRequest, HttpResponse
 from django.urls import URLPattern, URLResolver, reverse
+from django.urls import path as django_path
 from django.utils.module_loading import import_string
 
 from ninja.constants import NOT_SET, NOT_SET_TYPE
@@ -28,11 +29,13 @@ from ninja.openapi import get_schema
 from ninja.openapi.docs import DocsBase, Swagger
 from ninja.openapi.schema import OpenAPISchema
 from ninja.openapi.urls import get_openapi_urls, get_root_url
+from ninja.operation import PathView
 from ninja.parser import Parser
 from ninja.renderers import BaseRenderer, JSONRenderer
 from ninja.router import BoundRouter, Router, RouterMount
 from ninja.throttling import BaseThrottle
 from ninja.types import DictStrAny, TCallable
+from ninja.utils import normalize_path, replace_path_param_notation
 
 if TYPE_CHECKING:
     from .operation import Operation  # pragma: no cover
@@ -530,8 +533,39 @@ class NinjaAPI:
     def _get_urls(self) -> List[Union[URLResolver, URLPattern]]:
         result = get_openapi_urls(self)
 
+        path_views: Dict[str, PathView] = {}
+        url_names: List[Tuple[str, str]] = []
+
         for bound_router in self._get_bound_routers():
-            result.extend(bound_router.urls_paths(bound_router.prefix))
+            prefix = replace_path_param_notation(bound_router.prefix)
+            for path, path_view in bound_router.path_operations.items():
+                path = replace_path_param_notation(path)
+                route = "/".join([i for i in (prefix, path) if i])
+                route = normalize_path(route)
+                route = route.lstrip("/")
+
+                combined_view = path_views.get(route)
+                if combined_view is None:
+                    combined_view = PathView()
+                    path_views[route] = combined_view
+
+                combined_view.operations.extend(path_view.operations)
+                combined_view.is_async = combined_view.is_async or path_view.is_async
+
+                for operation in path_view.operations:
+                    url_name = getattr(operation, "url_name", "")
+                    if not url_name:
+                        url_name = self.get_operation_url_name(
+                            operation, router=bound_router.template
+                        )
+                        if bound_router.url_name_prefix and url_name:
+                            url_name = f"{bound_router.url_name_prefix}_{url_name}"
+                    url_names.append((route, url_name))
+
+        for route, url_name in url_names:
+            result.append(
+                django_path(route, path_views[route].get_view(), name=url_name)
+            )
 
         result.append(get_root_url(self))
         return result

--- a/tests/test_api_instance.py
+++ b/tests/test_api_instance.py
@@ -68,3 +68,41 @@ def test_reuse_router_with_url_name_prefix():
     bound_routers = test_api._get_bound_routers()
     # default router + 2 mounts of test_router
     assert len(bound_routers) == 3
+
+
+def test_bound_router_urls_paths_remains_available():
+    """BoundRouter.urls_paths is kept for direct internal compatibility."""
+    test_api = NinjaAPI(urls_namespace="bound-router-urls-paths")
+    test_router = Router()
+    plain_router = Router()
+
+    @test_router.get("/{item_id}")
+    def get_item(request, item_id: int):
+        return {"item_id": item_id}
+
+    @test_router.get("/custom", url_name="custom-item")
+    def get_custom_item(request):
+        return {"custom": True}
+
+    @plain_router.get("/status")
+    def get_status(request):
+        return {"ok": True}
+
+    test_api.add_router("/v1/items", test_router, url_name_prefix="v1")
+    test_api.add_router("/plain", plain_router)
+
+    prefixed_router = test_api._get_bound_routers()[1]
+    prefixed_urls = list(prefixed_router.urls_paths(prefixed_router.prefix))
+
+    assert len(prefixed_urls) == 2
+    assert str(prefixed_urls[0].pattern) == "v1/items/<item_id>"
+    assert prefixed_urls[0].name == "v1_get_item"
+    assert str(prefixed_urls[1].pattern) == "v1/items/custom"
+    assert prefixed_urls[1].name == "custom-item"
+
+    plain_bound_router = test_api._get_bound_routers()[2]
+    plain_urls = list(plain_bound_router.urls_paths(plain_bound_router.prefix))
+
+    assert len(plain_urls) == 1
+    assert str(plain_urls[0].pattern) == "plain/status"
+    assert plain_urls[0].name == "get_status"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,7 +5,7 @@ from tempfile import NamedTemporaryFile
 import pytest
 from django.http import FileResponse, HttpResponse
 
-from ninja import NinjaAPI
+from ninja import NinjaAPI, Router, Schema
 from ninja.testing import TestClient
 
 api = NinjaAPI()
@@ -98,6 +98,40 @@ def test_method(method, path, expected_status, expected_data, expected_streaming
     except Exception:
         data = response.content
     assert data == expected_data
+
+
+def test_same_path_different_methods_across_api_and_router():
+    local_api = NinjaAPI(urls_namespace="same-path-methods")
+    router = Router()
+
+    class UserPostSchema(Schema):
+        username: str
+        password: str
+
+    class UserPutSchema(Schema):
+        id: int
+        username: str
+
+    @local_api.post("/users")
+    def user_create(request, rdata: UserPostSchema):
+        return {"method": request.method}
+
+    @router.put("/users")
+    def user_update(request, rdata: UserPutSchema):
+        return {"method": request.method}
+
+    local_api.add_router("", router)
+    local_client = TestClient(local_api)
+
+    response = local_client.post(
+        "/users", json={"username": "test", "password": "secret"}
+    )
+    assert response.status_code == 200
+    assert response.json() == {"method": "POST"}
+
+    response = local_client.put("/users", json={"id": 1, "username": "test"})
+    assert response.status_code == 200
+    assert response.json() == {"method": "PUT"}
 
 
 def test_validates():


### PR DESCRIPTION
## Summary

- combine bound router operations that normalize to the same Django route before creating URL patterns
- preserve one URL pattern name per operation while sharing a combined dispatcher for matching paths
- add regression coverage for API-level `POST /users` plus router-level `PUT /users`
- keep `BoundRouter.urls_paths()` covered as a direct internal compatibility surface

Fixes #1546.

## Tests

- `pytest tests/test_api_instance.py tests/test_app.py -q` → 17 passed
- `pytest tests/test_app.py tests/test_api_instance.py tests/test_auth_global.py -q` → 19 passed
- `pytest . -q` → 798 passed, 3 skipped
- Python 3.12: `pytest --cov=ninja --cov-report term-missing tests -q` → 799 passed, 3 skipped; 100.00% coverage
- `mypy ninja` → success
- `ruff format --check ninja tests` → 157 files already formatted
- `ruff check ninja tests` → all checks passed

## Review

- Independent Codex review: APPROVED, no blocking findings.
- Independent Codex review after coverage fix: APPROVED, no findings.

## Notes

Multiple URL names for the same route still resolve to the same path, matching existing same-router behavior. Future non-blocking hardening could add explicit coverage for reverse URL names and mixed sync/async operations on the same merged route.