### PR TITLE
Fix 1739 dark mode

### DIFF
--- a/docs/docs/chat.md
+++ b/docs/docs/chat.md
@@ -13,6 +13,24 @@ Please feel free to share any questions or describe any problems you're encounte
     --serenity-answer-code-bg: #fafafa;
     --serenity-widget-bg: #ffffff;
 }
+
+[data-md-color-scheme="slate"] .serenity_app {
+    --serenity-widget-bg: var(--md-default-bg-color);
+    --serenity-answer-code-bg: var(--md-code-bg-color);
+
+    --serenity-widget-text: var(--md-default-fg-color);
+    --serenity-widget-placeholder: color-mix(
+        in srgb,
+        var(--md-default-fg-color) 60%,
+        transparent
+    );
+    --serenity-chat-powered: color-mix(
+        in srgb,
+        var(--md-default-fg-color) 50%,
+        transparent
+    );
+}
+
 </style>
 
 <div id="serenity"></div>

--- a/docs/docs/guides/authentication.md
+++ b/docs/docs/guides/authentication.md
@@ -168,7 +168,28 @@ def staff_view(request):
 
 These authentication classes automatically use Django's `SESSION_COOKIE_NAME` setting and check the user's authentication status through the standard Django session framework.
 
+## Authorization and Permissions
 
+Authentication identifies who the user is, while permissions determine whether
+that user is allowed to perform a specific action.
+
+After a request has been authenticated, the authenticated user is available as
+`request.auth`. You can use it to implement your own permission checks.
+
+```python
+from ninja.security import django_auth
+from ninja.errors import HttpError
+
+@api.get("/admin", auth=django_auth)
+def admin_view(request):
+    if not request.auth.is_staff:
+        raise HttpError(403, "Permission denied")
+    return {"message": "Welcome!"}
+```
+
+For common Django use cases, Django Ninja also provides built-in authenticators
+such as `SessionAuthSuperUser`, `SessionAuthIsStaff`, and
+`django_auth_superuser` to restrict access to privileged users.
 
 ### HTTP Bearer
 


### PR DESCRIPTION
## Summary

Fixes the Ask AI page in dark mode by applying SerenityGPT theme variables when the MkDocs Material `slate` color scheme is active.

## Changes

- Override SerenityGPT background variables for dark mode
- Override SerenityGPT text and placeholder colors for dark mode
- Preserve existing light theme behavior

Fixes #1739

<img width="1917" height="931" alt="image" src="https://github.com/user-attachments/assets/62a34486-99fe-4cd5-bb26-9b40194f2ab5" />

