### PR TITLE
fix: create_schema crashes on models with a ForeignObject reverse relation

### DIFF
--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -1,8 +1,8 @@
 import itertools
-from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Type, Union, cast
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Type, Union
 
 from django.db.models import Field as DjangoField
-from django.db.models import ManyToManyRel, ManyToOneRel, Model
+from django.db.models import ForeignObjectRel, Model
 from pydantic import create_model as create_pydantic_model
 
 from ninja.errors import ConfigError
@@ -158,10 +158,11 @@ class SchemaFactory:
     def _model_fields(self, model: Type[Model]) -> Iterator[DjangoField]:
         "returns iterator with all the fields that can be part of schema"
         for fld in model._meta.get_fields():
-            if isinstance(fld, (ManyToOneRel, ManyToManyRel)):
-                # skipping relations
+            if isinstance(fld, ForeignObjectRel):
+                # skipping reverse relations (ManyToOneRel, ManyToManyRel, and the
+                # bare ForeignObjectRel produced by a ForeignObject field)
                 continue
-            yield cast(DjangoField, fld)
+            yield fld
 
 
 factory = SchemaFactory()

--- a/tests/test_orm_relations.py
+++ b/tests/test_orm_relations.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.test.utils import isolate_apps
 
 from ninja import NinjaAPI
 from ninja.orm import create_schema
@@ -35,3 +36,34 @@ def test_manytomany():
     response = client.post("/bar", json={"m2m": []})
     assert response.status_code == 200, str(response.json())
     assert response.json() == {"m2m": []}
+
+
+@isolate_apps("tests")
+def test_reverse_foreign_object_relation_is_skipped():
+    """A ForeignObject's reverse accessor is a bare ForeignObjectRel. Building a
+    schema for the referenced model must skip it like any other reverse relation
+    instead of crashing on the missing ``help_text`` attribute (see #1530)."""
+
+    class Order(models.Model):
+        class Meta:
+            app_label = "tests"
+
+    class OrderDetail(models.Model):
+        order_id = models.PositiveIntegerField()
+        order = models.ForeignObject(
+            Order,
+            on_delete=models.CASCADE,
+            from_fields=["order_id"],
+            to_fields=["id"],
+            related_name="details",
+        )
+
+        class Meta:
+            app_label = "tests"
+
+    # Order gets a reverse ForeignObjectRel "details"; schema generation must not raise.
+    OrderSchema = create_schema(Order)
+
+    # The reverse relation is skipped, so it does not appear as a schema field.
+    assert "details" not in OrderSchema.model_fields
+    assert "id" in OrderSchema.model_fields


### PR DESCRIPTION
## Summary

Generating a `ModelSchema` / calling `create_schema()` for a model that is the target of a `ForeignObject` relation crashes with:

```
AttributeError: 'ForeignObjectRel' object has no attribute 'help_text'
```

`SchemaFactory._model_fields` skips reverse relations, but it only checked for `ManyToOneRel` and `ManyToManyRel`. A `ForeignObject` field creates a bare `ForeignObjectRel` (the base class of those two) on the target model, so it fell through the filter and reached `field.help_text` in `get_schema_field`, which a reverse relation does not have.

Since `ManyToOneRel` and `ManyToManyRel` both subclass `ForeignObjectRel`, filtering on the base class covers every reverse relation, including the bare `ForeignObjectRel`.

Fixes #1530

## Changes

- `ninja/orm/factory.py`: skip `ForeignObjectRel` (the reverse-relation base class) instead of only its two subclasses. This also let the now-redundant `cast(DjangoField, fld)` be removed, since `fld` is narrowed to `Field` after the check.
- `tests/test_orm_relations.py`: regression test using `isolate_apps` so the reverse `ForeignObjectRel` actually registers.

## Testing

- `pytest tests/test_orm_relations.py tests/test_orm_metaclass.py tests/test_models.py tests/test_django_models.py` passes.
- The new test fails against `main` with the exact `AttributeError: 'ForeignObjectRel' object has no attribute 'help_text'`, and passes with the fix.
- `ruff format --check`, `ruff check`, and `mypy ninja/orm/factory.py` are clean.

Minimal reproduction (from the issue): a model `OrderDetail` with `models.ForeignObject(Order, ..., related_name="details")`, then `create_schema(Order)`.
