### PR TITLE
fix: ModelSchema doesn't apply alias_generator to foreign key fields

### DIFF
--- a/ninja/orm/factory.py
+++ b/ninja/orm/factory.py
@@ -60,12 +60,15 @@ class SchemaFactory:
             if optional_fields == "__all__":
                 optional_fields = [f.name for f in model_fields_list]
 
+        alias_generator = getattr(base_class, "model_config", {}).get("alias_generator")
+
         definitions = {}
         for fld in model_fields_list:
             python_type, field_info = get_schema_field(
                 fld,
                 depth=depth,
                 optional=optional_fields and (fld.name in optional_fields),
+                alias_generator=alias_generator,
             )
             definitions[fld.name] = (python_type, field_info)
 

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from django.db.models import ManyToManyField
 from django.db.models.fields import Field as DjangoField
-from pydantic import IPvAnyAddress
+from pydantic import AliasGenerator, IPvAnyAddress
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined, core_schema
 
@@ -113,9 +113,25 @@ def create_m2m_link_type(type_: Type[TModel]) -> Type[TModel]:
     return M2MLink
 
 
+def _apply_alias_generator(alias_generator: Any, attname: str) -> str:
+    """Apply the schema's ``alias_generator`` to a relation's ``_id`` attname.
+
+    Relation fields set their alias explicitly (to the ``_id`` attname), which
+    otherwise bypasses the schema's ``alias_generator`` so the generated field
+    keeps its snake_case name while every other field is transformed (see #1691).
+    """
+    if isinstance(alias_generator, AliasGenerator):
+        return alias_generator.alias(attname) if alias_generator.alias else attname
+    return str(alias_generator(attname))
+
+
 @no_type_check
 def get_schema_field(
-    field: DjangoField, *, depth: int = 0, optional: bool = False
+    field: DjangoField,
+    *,
+    depth: int = 0,
+    optional: bool = False,
+    alias_generator: Any = None,
 ) -> Tuple:
     "Returns pydantic field from django's model field"
     alias = None
@@ -138,6 +154,8 @@ def get_schema_field(
             nullable = True
 
         alias = getattr(field, "get_attname", None) and field.get_attname()
+        if alias and alias_generator is not None:
+            alias = _apply_alias_generator(alias_generator, alias)
 
         pk_type = TYPES.get(internal_type, int)
         if field.one_to_many or field.many_to_many:

--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -113,16 +113,32 @@ def create_m2m_link_type(type_: Type[TModel]) -> Type[TModel]:
     return M2MLink
 
 
-def _apply_alias_generator(alias_generator: Any, attname: str) -> str:
-    """Apply the schema's ``alias_generator`` to a relation's ``_id`` attname.
+def _relation_field_aliases(attname: str, alias_generator: Any) -> Tuple[str, Any, Any]:
+    """Aliases for a relation's ``_id`` field, per validation/serialization direction.
 
-    Relation fields set their alias explicitly (to the ``_id`` attname), which
-    otherwise bypasses the schema's ``alias_generator`` so the generated field
-    keeps its snake_case name while every other field is transformed (see #1691).
+    A relation field is exposed under its ``_id`` attname (e.g. ``author_id``) by
+    setting the alias explicitly. That explicit alias otherwise bypasses the
+    schema's ``alias_generator``, so the ``_id`` field keeps its snake_case name
+    while every other field is transformed (see #1691). We reproduce pydantic's
+    own alias generation here, honoring an ``AliasGenerator``'s independent
+    ``alias`` / ``validation_alias`` / ``serialization_alias`` callbacks and
+    falling back to the ``_id`` attname for any direction the generator leaves
+    unset, so a single-callback generator still aliases both directions.
     """
+    if alias_generator is None:
+        return attname, attname, attname
     if isinstance(alias_generator, AliasGenerator):
-        return alias_generator.alias(attname) if alias_generator.alias else attname
-    return str(alias_generator(attname))
+        alias, validation_alias, serialization_alias = alias_generator.generate_aliases(
+            attname
+        )
+        alias = alias if alias is not None else attname
+        return (
+            alias,
+            validation_alias if validation_alias is not None else alias,
+            serialization_alias if serialization_alias is not None else alias,
+        )
+    generated = str(alias_generator(attname))
+    return generated, generated, generated
 
 
 @no_type_check
@@ -135,6 +151,8 @@ def get_schema_field(
 ) -> Tuple:
     "Returns pydantic field from django's model field"
     alias = None
+    validation_alias = None
+    serialization_alias = None
     default = ...
     default_factory = None
     description = None
@@ -153,9 +171,11 @@ def get_schema_field(
             default = None
             nullable = True
 
-        alias = getattr(field, "get_attname", None) and field.get_attname()
-        if alias and alias_generator is not None:
-            alias = _apply_alias_generator(alias_generator, alias)
+        attname = getattr(field, "get_attname", None) and field.get_attname()
+        if attname:
+            alias, validation_alias, serialization_alias = _relation_field_aliases(
+                attname, alias_generator
+            )
 
         pk_type = TYPES.get(internal_type, int)
         if field.one_to_many or field.many_to_many:
@@ -205,8 +225,8 @@ def get_schema_field(
         FieldInfo(
             default=default,
             alias=alias,
-            validation_alias=alias,
-            serialization_alias=alias,
+            validation_alias=validation_alias,
+            serialization_alias=serialization_alias,
             default_factory=default_factory,
             title=title,
             description=description,

--- a/tests/test_orm_relations.py
+++ b/tests/test_orm_relations.py
@@ -1,6 +1,9 @@
 from django.db import models
+from django.test.utils import isolate_apps
+from pydantic import ConfigDict
+from pydantic.alias_generators import to_camel
 
-from ninja import NinjaAPI
+from ninja import ModelSchema, NinjaAPI
 from ninja.orm import create_schema
 from ninja.testing import TestClient
 
@@ -35,3 +38,33 @@ def test_manytomany():
     response = client.post("/bar", json={"m2m": []})
     assert response.status_code == 200, str(response.json())
     assert response.json() == {"m2m": []}
+
+
+@isolate_apps("tests")
+def test_foreignkey_id_field_honors_alias_generator():
+    """A ForeignKey's generated ``_id`` field must honor the schema's
+    alias_generator like every other field, instead of staying snake_case while
+    the rest of the schema is transformed (see #1691)."""
+
+    class RelTarget(models.Model):
+        class Meta:
+            app_label = "tests"
+
+    class RelSource(models.Model):
+        target = models.ForeignKey(RelTarget, on_delete=models.CASCADE)
+        some_value = models.CharField(max_length=10)
+
+        class Meta:
+            app_label = "tests"
+
+    class SourceSchema(ModelSchema):
+        model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+        class Meta:
+            model = RelSource
+            fields = ["id", "target", "some_value"]
+
+    aliases = {name: f.alias for name, f in SourceSchema.model_fields.items()}
+    # The FK id field is camelCased just like the plain field, not left snake_case.
+    assert aliases["target"] == "targetId"
+    assert aliases["some_value"] == "someValue"

--- a/tests/test_orm_relations.py
+++ b/tests/test_orm_relations.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.test.utils import isolate_apps
-from pydantic import ConfigDict
-from pydantic.alias_generators import to_camel
+from pydantic import AliasGenerator, ConfigDict
+from pydantic.alias_generators import to_camel, to_pascal
 
 from ninja import ModelSchema, NinjaAPI
 from ninja.orm import create_schema
@@ -68,3 +68,51 @@ def test_foreignkey_id_field_honors_alias_generator():
     # The FK id field is camelCased just like the plain field, not left snake_case.
     assert aliases["target"] == "targetId"
     assert aliases["some_value"] == "someValue"
+
+
+@isolate_apps("tests")
+def test_foreignkey_id_field_honors_directional_alias_generator():
+    """An ``AliasGenerator`` may set ``validation_alias`` and ``serialization_alias``
+    independently (with no plain ``alias``). The FK ``_id`` field must pick up each
+    direction just like an ordinary field, so validation and ``by_alias`` dumping
+    both round-trip (see #1691)."""
+
+    class RelTarget(models.Model):
+        class Meta:
+            app_label = "tests"
+
+    class RelSource(models.Model):
+        target = models.ForeignKey(RelTarget, on_delete=models.CASCADE)
+        some_value = models.CharField(max_length=10)
+
+        class Meta:
+            app_label = "tests"
+
+    class SourceSchema(ModelSchema):
+        model_config = ConfigDict(
+            alias_generator=AliasGenerator(
+                validation_alias=to_camel, serialization_alias=to_pascal
+            )
+        )
+
+        class Meta:
+            model = RelSource
+            fields = ["id", "target", "some_value"]
+
+    target_field = SourceSchema.model_fields["target"]
+    plain_field = SourceSchema.model_fields["some_value"]
+    # The FK id field carries both directional aliases, just like a plain field.
+    assert target_field.validation_alias == "targetId"
+    assert target_field.serialization_alias == "TargetId"
+    assert plain_field.validation_alias == "someValue"
+    assert plain_field.serialization_alias == "SomeValue"
+
+    # Runtime: validation consumes the camelCase validation alias...
+    instance = SourceSchema.model_validate({"targetId": 5, "someValue": "ok"})
+    assert instance.target == 5
+    assert instance.some_value == "ok"
+
+    # ...and serialization emits the PascalCase serialization alias.
+    dumped = instance.model_dump(by_alias=True)
+    assert dumped["TargetId"] == 5
+    assert dumped["SomeValue"] == "ok"


### PR DESCRIPTION
## Summary

When a `ModelSchema` sets an `alias_generator` (e.g. `to_camel`), regular fields are aliased but a foreign key's generated `_id` field is not — it stays snake_case while everything else is transformed:

```json
{
  "id": "...",
  "model_a_id": ...,        // stays snake_case
  "myOtherProperty": "..."  // camelCased
}
```

The reason is that relation fields set their alias **explicitly** (to the `_id` attname) in `get_schema_field`. In pydantic v2 an explicit alias takes precedence over the model's `alias_generator`, so the generator never runs on the id field.

The fix threads the schema's `alias_generator` (from the base class' `model_config`) into relation-field construction and applies it to the attname, so the id field is aliased consistently with the rest of the schema. When no generator is configured, behavior is unchanged (`model_a_id`).

Fixes #1691

## Changes

- `ninja/orm/fields.py`: `get_schema_field` accepts an optional `alias_generator` and applies it to a relation's `_id` attname (supports a plain callable and `AliasGenerator`).
- `ninja/orm/factory.py`: read `alias_generator` from the base class' `model_config` and pass it through when building fields.
- `tests/test_orm_relations.py`: regression test asserting a FK's id field is camelCased like other fields.

## Testing

- `pytest tests/test_orm_relations.py tests/test_orm_metaclass.py tests/test_models.py` passes.
- The new test fails against `main` (the FK alias is `target_id` instead of `targetId`) and passes with the fix.
- `ruff format --check`, `ruff check`, and `mypy ninja` are all clean.
