### PR TITLE
Fix PatchDict schema generation for repeated sub-models

### DIFF
--- a/ninja/patch_dict.py
+++ b/ninja/patch_dict.py
@@ -25,7 +25,7 @@ class ModelToDict(dict):
     def __get_pydantic_core_schema__(cls, _source: Any, _handler: Any) -> Any:
         return core_schema.no_info_after_validator_function(
             cls._validate,
-            cls._wrapped_model.__pydantic_core_schema__,
+            _handler.generate_schema(cls._wrapped_model),
         )
 
     @classmethod

--- a/tests/test_patch_dict.py
+++ b/tests/test_patch_dict.py
@@ -22,6 +22,21 @@ class OtherSchema(SomeSchema):
     category: Optional[List[str]] = None
 
 
+class TagSchema(Schema):
+    name: str
+
+
+class MultiRefSchema(Schema):
+    label: str
+    primary: Optional[List[TagSchema]] = None
+    secondary: Optional[List[TagSchema]] = None
+
+
+@api.patch("/patch-multi-ref")
+def patch_multi_ref(request, payload: PatchDict[MultiRefSchema]):
+    return {"payload": payload, "type": str(type(payload))}
+
+
 @api.patch("/patch")
 def patch(request, payload: PatchDict[SomeSchema]):
     return {"payload": payload, "type": str(type(payload))}
@@ -75,6 +90,16 @@ def test_patch_inherited():
     expected_output = {"payload": input, "type": "<class 'dict'>"}
 
     response = client.patch("/patch-inherited", json=input)
+    assert response.json() == expected_output
+
+
+def test_patch_repeated_sub_model():
+    # a sub-model referenced by more than one field must not break schema
+    # generation (the wrapped model's schema uses $ref definitions).
+    input = {"label": "x", "primary": [{"name": "a"}]}
+    expected_output = {"payload": input, "type": "<class 'dict'>"}
+
+    response = client.patch("/patch-multi-ref", json=input)
     assert response.json() == expected_output
 
 


### PR DESCRIPTION
Fixes #1698.

`ModelToDict.__get_pydantic_core_schema__` spliced the wrapped model's prebuilt `__pydantic_core_schema__` straight into the validator schema:

```python
return core_schema.no_info_after_validator_function(
    cls._validate,
    cls._wrapped_model.__pydantic_core_schema__,
)
```

When the wrapped model references the same sub-model in more than one field, that prebuilt schema is a `definitions` schema that uses `$ref`s. Splicing the raw node in never registers those definitions in the outer `TypeAdapter`, so it is left "not fully defined" and building `PatchDict[Model]` raises:

```
PydanticUserError: `TypeAdapter[...]` is not fully defined; you should define ... then call `.rebuild()`
```

With a single reference pydantic inlines the sub-model (no `$ref`), which is why the single-reference case works.

Minimal repro:

```python
class Tag(Schema):
    name: str

class MultiRef(Schema):
    label: str
    primary: Optional[List[Tag]] = None
    secondary: Optional[List[Tag]] = None   # same sub-model, second field

PatchDict[MultiRef]   # raises PydanticUserError
```

This generates the wrapped model's schema through the handler instead, so its definitions are collected in the current schema-generation context:

```python
_handler.generate_schema(cls._wrapped_model)
```

Added `tests/test_patch_dict.py::test_patch_repeated_sub_model`, which fails on `main` and passes with the change. The full test suite passes locally (757 passed, the pre-existing `demo_project` import failure aside); `ruff` is clean.
