### PR TITLE
Drop Django upper version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 
-requires = ["Django >=3.1, <6.2", "pydantic >=2.0,<3.0.0"]
+requires = ["Django >=3.1", "pydantic >=2.0,<3.0.0"]
 description-file = "README.md"
 requires-python = ">=3.7"
 


### PR DESCRIPTION
The upper version constraint for Django was introduced in https://github.com/vitalik/django-ninja/pull/1481 and shipped in release v1.5.0. I don't believe there was an intentional reason why it was added - there are no remarks specifically calling out that change and why it was made.

This constraint makes it unnecessarily difficult to test projects and other re-usable Django libraries against upcoming Django versions, because dependency resolution will fail or [install v1.4.5 which was the last version that had no upper bound](https://github.com/vitalik/django-ninja/blob/b7ac09820573f0a1802000134b1e49684cc8d7d1/pyproject.toml#L45).

See also this blog post about the topic: https://iscinumpy.dev/post/bound-version-constraints/