### PR TITLE
Add HTTP QUERY method support (RFC 10008)

### DIFF
--- a/docs/docs/guides/input/operations.md
+++ b/docs/docs/guides/input/operations.md
@@ -9,10 +9,11 @@ An `operation` can be one of the following [HTTP methods](https://developer.mozi
 - PUT
 - DELETE
 - PATCH
+- QUERY
 
 **Django Ninja** comes with a decorator for each operation:
 
-```python hl_lines="1 5 9 13 17"
+```python hl_lines="1 5 9 13 17 21"
 @api.get("/path")
 def get_operation(request):
     ...
@@ -32,7 +33,15 @@ def delete_operation(request):
 @api.patch("/path")
 def patch_operation(request):
     ...
+
+@api.query("/path")
+def query_operation(request):
+    ...
 ```
+
+`QUERY` is a safe, idempotent method (like `GET`) that also carries a request
+body (like `POST`), making it a good fit for complex search criteria that
+don't fit cleanly into a URL's query string.
 
 See the [operations parameters](../../reference/operations-parameters.md)
 reference docs for information on what you can pass to any of these decorators.

--- a/ninja/conf.py
+++ b/ninja/conf.py
@@ -31,7 +31,7 @@ class Settings(BaseModel):
     )
 
     FIX_REQUEST_FILES_METHODS: Set[str] = Field(
-        {"PUT", "PATCH", "DELETE"}, alias="NINJA_FIX_REQUEST_FILES_METHODS"
+        {"PUT", "PATCH", "DELETE", "QUERY"}, alias="NINJA_FIX_REQUEST_FILES_METHODS"
     )
 
 

--- a/ninja/main.py
+++ b/ninja/main.py
@@ -292,6 +292,49 @@ class NinjaAPI:
             openapi_extra=openapi_extra,
         )
 
+    def query(
+        self,
+        path: str,
+        *,
+        auth: Any = NOT_SET,
+        throttle: Union[BaseThrottle, List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
+        response: Any = NOT_SET,
+        operation_id: Optional[str] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        deprecated: Optional[bool] = None,
+        by_alias: Optional[bool] = None,
+        exclude_unset: Optional[bool] = None,
+        exclude_defaults: Optional[bool] = None,
+        exclude_none: Optional[bool] = None,
+        url_name: Optional[str] = None,
+        include_in_schema: bool = True,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+    ) -> Callable[[TCallable], TCallable]:
+        """
+        `QUERY` operation. See <a href="../operations-parameters">operations
+        parameters</a> reference.
+        """
+        return self.default_router.query(
+            path,
+            auth=auth is NOT_SET and self.auth or auth,
+            throttle=throttle is NOT_SET and self.throttle or throttle,
+            response=response,
+            operation_id=operation_id,
+            summary=summary,
+            description=description,
+            tags=tags,
+            deprecated=deprecated,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+            url_name=url_name,
+            include_in_schema=include_in_schema,
+            openapi_extra=openapi_extra,
+        )
+
     def put(
         self,
         path: str,

--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -40,6 +40,7 @@ class OpenAPISchema(dict):
         self.schemas: DictStrAny = {}
         self.securitySchemes: DictStrAny = {}
         self.all_operation_ids: Set = set()
+        self.uses_query_method = False
         extra_info = api.openapi_extra.get("info", {})
         super().__init__([
             ("openapi", "3.1.0"),
@@ -56,6 +57,8 @@ class OpenAPISchema(dict):
             ("components", self.get_components()),
             ("servers", api.servers),
         ])
+        if self.uses_query_method:
+            self["openapi"] = "3.2.0"
         for k, v in api.openapi_extra.items():
             if k not in self:
                 self[k] = v
@@ -86,6 +89,8 @@ class OpenAPISchema(dict):
             if op.include_in_schema:
                 operation_details = self.operation_details(op)
                 for method in op.methods:
+                    if method == "QUERY":
+                        self.uses_query_method = True
                     result[method.lower()] = operation_details
         return result
 

--- a/ninja/openapi/schema.py
+++ b/ninja/openapi/schema.py
@@ -18,6 +18,12 @@ if TYPE_CHECKING:
 
 REF_TEMPLATE: str = "#/components/schemas/{model}"
 
+# OpenAPI 3.1 has no `query` PathItem field; 3.2 added it. We only need to
+# bump to the newer version when a QUERY operation is actually present, so
+# every other API keeps generating the version it always has.
+OPENAPI_VERSION: str = "3.1.0"
+OPENAPI_VERSION_WITH_QUERY: str = "3.2.0"
+
 BODY_CONTENT_TYPES: Dict[str, str] = {
     "body": "application/json",
     "form": "application/x-www-form-urlencoded",
@@ -42,8 +48,14 @@ class OpenAPISchema(dict):
         self.all_operation_ids: Set = set()
         self.uses_query_method = False
         extra_info = api.openapi_extra.get("info", {})
+
+        # Walking the paths determines self.uses_query_method as a side
+        # effect, so it needs to run before we can pick an openapi version.
+        paths = self.get_paths()
+        openapi_version = api.openapi_extra.get("openapi", self.get_openapi_version())
+
         super().__init__([
-            ("openapi", "3.1.0"),
+            ("openapi", openapi_version),
             (
                 "info",
                 {
@@ -53,15 +65,26 @@ class OpenAPISchema(dict):
                     **extra_info,
                 },
             ),
-            ("paths", self.get_paths()),
+            ("paths", paths),
             ("components", self.get_components()),
             ("servers", api.servers),
         ])
-        if self.uses_query_method:
-            self["openapi"] = "3.2.0"
         for k, v in api.openapi_extra.items():
             if k not in self:
                 self[k] = v
+
+    def get_openapi_version(self) -> str:
+        """
+        The lowest OpenAPI version that can represent this schema.
+
+        OpenAPI 3.1 has no `query` PathItem field; 3.2 added it, so a schema
+        with at least one QUERY operation needs the newer version. Every
+        other schema stays on the version it always has. Set `openapi` in
+        `NinjaAPI(openapi_extra=...)` to override this.
+        """
+        if self.uses_query_method:
+            return OPENAPI_VERSION_WITH_QUERY
+        return OPENAPI_VERSION
 
     def get_paths(self) -> DictStrAny:
         result: DictStrAny = {}

--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -78,7 +78,9 @@ class Operation:
         self.methods: List[str] = methods
         self.view_func: Callable = view_func
         self.api: NinjaAPI = cast("NinjaAPI", None)
-        self.csrf_exempt: bool = getattr(view_func, "csrf_exempt", False)
+        self.csrf_exempt: bool = (
+            getattr(view_func, "csrf_exempt", False) or "QUERY" in methods
+        )
         if url_name is not None:
             self.url_name = url_name
 

--- a/ninja/router.py
+++ b/ninja/router.py
@@ -388,6 +388,46 @@ class Router:
             openapi_extra=openapi_extra,
         )
 
+    def query(
+        self,
+        path: str,
+        *,
+        auth: Any = NOT_SET,
+        throttle: Union[BaseThrottle, List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
+        response: Any = NOT_SET,
+        operation_id: Optional[str] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        deprecated: Optional[bool] = None,
+        by_alias: Optional[bool] = None,
+        exclude_unset: Optional[bool] = None,
+        exclude_defaults: Optional[bool] = None,
+        exclude_none: Optional[bool] = None,
+        url_name: Optional[str] = None,
+        include_in_schema: bool = True,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+    ) -> Callable[[TCallable], TCallable]:
+        return self.api_operation(
+            ["QUERY"],
+            path,
+            auth=auth,
+            throttle=throttle,
+            response=response,
+            operation_id=operation_id,
+            summary=summary,
+            description=description,
+            tags=tags,
+            deprecated=deprecated,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+            url_name=url_name,
+            include_in_schema=include_in_schema,
+            openapi_extra=openapi_extra,
+        )
+
     def put(
         self,
         path: str,

--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -78,6 +78,15 @@ class NinjaClientBase:
     ) -> "NinjaResponse":
         return self.request("DELETE", path, data, json, **request_params)
 
+    def query(
+        self,
+        path: str,
+        data: Optional[Dict] = None,
+        json: Any = None,
+        **request_params: Any,
+    ) -> "NinjaResponse":
+        return self.request("QUERY", path, data, json, **request_params)
+
     def _prepare_request(
         self,
         method: str,
@@ -271,6 +280,15 @@ class TestAsyncClient(NinjaClientBase):
         **request_params: Any,
     ) -> "NinjaResponse":
         return await self.request("DELETE", path, data, json, **request_params)
+
+    async def query(  # type: ignore[override]
+        self,
+        path: str,
+        data: Optional[Dict] = None,
+        json: Any = None,
+        **request_params: Any,
+    ) -> "NinjaResponse":
+        return await self.request("QUERY", path, data, json, **request_params)
 
     async def _call(
         self, func: Callable, request: Mock, kwargs: Dict

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -50,6 +50,11 @@ def delete(request):
     return f"this is {request.method}"
 
 
+@api.query("/query")
+def query(request):
+    return f"this is {request.method}"
+
+
 @api.api_operation(["GET", "POST"], "/multi")
 def multiple(request):
     return f"this is {request.method}"
@@ -81,6 +86,7 @@ def file_response(request):
         ("put", "/put", 200, "this is PUT", False),
         ("patch", "/patch", 200, "this is PATCH", False),
         ("delete", "/delete", 200, "this is DELETE", False),
+        ("query", "/query", 200, "this is QUERY", False),
         ("get", "/multi", 200, "this is GET", False),
         ("post", "/multi", 200, "this is POST", False),
         ("patch", "/multi", 405, b"Method not allowed", False),

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -79,6 +79,11 @@ def obtain_csrf_token_post_no_auth_route(request):
     return JsonResponse(data={"success": True})
 
 
+@csrf_ON.query("/query")
+def query_on(request):
+    return {"success": True}
+
+
 TOKEN = "1bcdefghij2bcdefghij3bcdefghij4bcdefghij5bcdefghij6bcdefghijABCD"
 COOKIES = {settings.CSRF_COOKIE_NAME: TOKEN}
 
@@ -103,6 +108,14 @@ def test_csrf_on():
 
     # exempt check
     assert client.post("/post/csrf_exempt", COOKIES=COOKIES).status_code == 200
+
+
+def test_csrf_query_is_safe():
+    "QUERY is a safe/idempotent method like GET, so it should never be CSRF checked"
+    client = TestClient(csrf_ON)
+
+    # no csrf token needed, just like GET
+    assert client.query("/query", COOKIES=COOKIES).status_code == 200
 
 
 def test_csrf_cookie_auth():

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -908,6 +908,26 @@ def test_unique_operation_ids(capsys):
     assert '"test_openapi_schema_same_name" is already used ' in captured.out
 
 
+def test_openapi_version_bumped_for_query_method():
+    api = NinjaAPI()
+
+    @api.get("/get")
+    def get_op(request):
+        pass
+
+    schema = api.get_openapi_schema()
+    assert schema["openapi"] == "3.1.0"
+
+    api_with_query = NinjaAPI(urls_namespace="test_openapi_version_query")
+
+    @api_with_query.query("/query")
+    def query_op(request):
+        pass
+
+    schema = api_with_query.get_openapi_schema(path_prefix="")
+    assert schema["openapi"] == "3.2.0"
+
+
 def test_docs_decorator():
     api = NinjaAPI(docs_decorator=staff_member_required)
 

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -928,6 +928,23 @@ def test_openapi_version_bumped_for_query_method():
     assert schema["openapi"] == "3.2.0"
 
 
+def test_openapi_version_explicit_override_wins():
+    "openapi_extra can pin the version explicitly, overriding auto-detection"
+    api = NinjaAPI(
+        urls_namespace="test_openapi_version_override",
+        openapi_extra={"openapi": "3.1.0"},
+    )
+
+    @api.query("/query")
+    def query_op(request):
+        pass
+
+    # would normally auto-bump to 3.2.0 because a QUERY route is present,
+    # but the explicit override takes precedence
+    schema = api.get_openapi_schema(path_prefix="")
+    assert schema["openapi"] == "3.1.0"
+
+
 def test_docs_decorator():
     api = NinjaAPI(docs_decorator=staff_member_required)
 

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -196,6 +196,20 @@ async def test_async_client_patch_and_delete():
     assert response.json() == {"method": "DELETE"}
 
 
+@pytest.mark.asyncio
+async def test_async_client_query():
+    api = NinjaAPI()
+
+    @api.query("/item")
+    async def query_item(request):
+        return {"method": "QUERY"}
+
+    async_client = TestAsyncClient(api)
+
+    response = await async_client.query("/item")
+    assert response.json() == {"method": "QUERY"}
+
+
 def test_resolver_match():
     response = client.get("/check-resolver-match/42")
     assert response.json() == {"has_resolver_match": True, "item_id": 42}
@@ -214,4 +228,5 @@ def test_async_client_methods_are_coroutines():
     assert inspect.iscoroutinefunction(async_client.put)
     assert inspect.iscoroutinefunction(async_client.patch)
     assert inspect.iscoroutinefunction(async_client.delete)
+    assert inspect.iscoroutinefunction(async_client.query)
     assert inspect.iscoroutinefunction(async_client.request)


### PR DESCRIPTION
Adds support for the HTTP `QUERY` method, standardized by [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008) — safe and idempotent like `GET`, but carries a request body like `POST`. OpenAPI 3.2 added an official `query` PathItem field to match.

This is useful for search/filter endpoints whose criteria don't fit cleanly into a query string (nested filter trees, large ID lists, etc.) without giving up GET's safe/idempotent/cacheable semantics the way a `POST /search` workaround does.

## Usage

```python
class SearchRequest(Schema):
    tags: Optional[List[str]] = None
    min_price: Optional[float] = None
    ids: Optional[List[int]] = None
    limit: int = 50

@api.query("/products/search", response=List[Product])
def search_products(request, payload: SearchRequest = Body(...)):
    ...
```

```python
# test client
response = client.query("/products/search", json={"tags": ["chair"], "limit": 20})
```

## Changes

- `Router.query()` / `NinjaAPI.query()` — new decorator, mirrors `.patch()`
- CSRF: QUERY requests are now exempted from CSRF checks (same mechanism as `@csrf_exempt`), since Django's `CsrfViewMiddleware` doesn't know about QUERY and would otherwise wrongly block it under cookie-based auth
- `Body()`/`Form()`/`File()` params now work on QUERY requests (added to the existing `FIX_REQUEST_FILES_METHODS` compatibility shim used for PUT/PATCH/DELETE)
- OpenAPI schema version bumps from `3.1.0` to `3.2.0` only when a QUERY route is registered — zero impact on APIs that don't use it
- `.query()` added to the sync and async test clients
- Tests for dispatch, CSRF exemption, and schema versioning
- Docs updated in the HTTP methods guide

## Testing

- `pytest .` — full suite green
- `pytest --cov=ninja --cov-report term-missing tests` — 100% coverage maintained
- `ruff format --check`, `ruff check`, `mypy ninja` — clean