### PR TITLE
fix: avoid duplicate async authentication calls

### DIFF
--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -50,6 +50,10 @@ if TYPE_CHECKING:
 __all__ = ["Operation", "PathView", "ResponseObject"]
 
 
+async def _await_coroutine(coroutine: Coroutine[Any, Any, Any]) -> Any:
+    return await coroutine
+
+
 class Operation:
     def __init__(
         self,
@@ -314,7 +318,7 @@ class Operation:
                 if is_async_callable(callback) or getattr(callback, "is_async", False):
                     result = callback(request)
                     if inspect.iscoroutine(result):
-                        result = async_to_sync(callback)(request)
+                        result = async_to_sync(_await_coroutine)(result)
                 else:
                     result = callback(request)
             except Exception as exc:

--- a/tests/test_auth_async.py
+++ b/tests/test_auth_async.py
@@ -155,6 +155,32 @@ def test_async_authenticate_method_in_sync_context():
     assert res.json() == {"auth": "secret"}
 
 
+def test_async_bearer_auth_is_called_once_in_sync_context(recwarn):
+    call_count = 0
+
+    class BearerAuth(HttpBearer):
+        def __call__(self, request):
+            nonlocal call_count
+            call_count += 1
+            return super().__call__(request)
+
+        async def authenticate(self, request, key):
+            await asyncio.sleep(0)
+            return key
+
+    api = NinjaAPI(auth=BearerAuth())
+
+    @api.get("/sync")
+    def sync_view(request):
+        return {"auth": request.auth}
+
+    response = TestClient(api).get("/sync", headers={"Authorization": "Bearer secret"})
+
+    assert response.json() == {"auth": "secret"}
+    assert call_count == 1
+    assert not recwarn
+
+
 @pytest.mark.asyncio
 async def test_async_with_bearer():
     class BearerAuth(HttpBearer):


### PR DESCRIPTION
## Summary

- await the coroutine returned by the first invocation of an async-marked authentication callback
- add regression coverage for async bearer authentication on a synchronous endpoint
- verify the callback runs once and emits no warnings

## Root cause

The synchronous authentication path called an async-marked callback once to inspect its return value. When that value was a coroutine, it discarded the coroutine and invoked the callback a second time through `async_to_sync`. This duplicated synchronous work in `__call__` and emitted both an un-awaited coroutine warning and an `async_to_sync` warning.

The fix bridges the coroutine returned by the first invocation instead of invoking the callback again.

Fixes #1751.

## Validation

- `.venv/bin/pytest -q tests/test_auth_async.py` — 8 passed
- `.venv/bin/pytest -q tests/test_auth.py` — 34 passed
- `.venv/bin/ruff format --check ninja/operation.py tests/test_auth_async.py`
- `.venv/bin/ruff check ninja/operation.py tests/test_auth_async.py`
- `.venv/bin/mypy ninja/operation.py`
