### PR TITLE
Use real HttpRequest objects in TestClient

### DIFF
--- a/ninja/testing/client.py
+++ b/ninja/testing/client.py
@@ -1,7 +1,7 @@
 import inspect
 from json import dumps as json_dumps
 from json import loads as json_loads
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 from unittest.mock import Mock
 from urllib.parse import urljoin
 
@@ -85,7 +85,7 @@ class NinjaClientBase:
         data: Optional[Dict] = None,
         json: Any = None,
         **request_params: Any,
-    ) -> Tuple[Callable, Mock, Dict]:
+    ) -> Tuple[Callable, HttpRequest, Dict]:
         if json is not None:
             request_params["body"] = json_dumps(json, cls=NinjaJSONEncoder)
         if data is None:
@@ -131,7 +131,7 @@ class NinjaClientBase:
 
     def _resolve(
         self, method: str, path: str, data: Dict, request_params: Any
-    ) -> Tuple[Callable, Mock, Dict]:
+    ) -> Tuple[Callable, HttpRequest, Dict]:
         url_path = path.split("?")[0].lstrip("/")
         for url in self.urls:
             match = url.resolve(url_path)
@@ -143,14 +143,13 @@ class NinjaClientBase:
 
     def _build_request(
         self, method: str, path: str, data: Dict, request_params: Any
-    ) -> Mock:
-        request = Mock(spec=HttpRequest)
+    ) -> HttpRequest:
+        request: Any = HttpRequest()
         request.method = method
         request.path = path
-        request.body = b""
+        request._body = b""
         request.COOKIES = {}
         request._dont_enforce_csrf_checks = True
-        request.is_secure.return_value = False
         request.build_absolute_uri = build_absolute_uri
 
         request.auth = None
@@ -203,17 +202,19 @@ class NinjaClientBase:
             else:
                 request.GET = QueryDict()
 
+        body = request_params.pop("body", b"")
+        request._body = body.encode("utf-8") if isinstance(body, str) else body
+
         for k, v in request_params.items():
             setattr(request, k, v)
 
-        if isinstance(request.body, str):
-            request.body = request.body.encode("utf-8")
-
-        return request
+        return cast(HttpRequest, request)
 
 
 class TestClient(NinjaClientBase):
-    def _call(self, func: Callable, request: Mock, kwargs: Dict) -> "NinjaResponse":
+    def _call(
+        self, func: Callable, request: HttpRequest, kwargs: Dict
+    ) -> "NinjaResponse":
         return NinjaResponse(func(request, **kwargs))
 
 
@@ -273,7 +274,7 @@ class TestAsyncClient(NinjaClientBase):
         return await self.request("DELETE", path, data, json, **request_params)
 
     async def _call(
-        self, func: Callable, request: Mock, kwargs: Dict
+        self, func: Callable, request: HttpRequest, kwargs: Dict
     ) -> "NinjaResponse":
         http_response = await func(request, **kwargs)
         if http_response.streaming and inspect.isasyncgen(

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from http import HTTPStatus
 from unittest import mock
 
+import django
 import pytest
 from django.utils import timezone
 
@@ -82,6 +83,10 @@ def test_sync_build_absolute_uri(path, expected_status, expected_response):
     assert response.json() == expected_response
 
 
+@pytest.mark.skipif(
+    django.VERSION < (5, 2),
+    reason="HttpRequest.get_preferred_type() requires Django 5.2+",
+)
 def test_get_preferred_type():
     response = client.get(
         "/request/get-preferred-type",

--- a/tests/test_test_client.py
+++ b/tests/test_test_client.py
@@ -23,6 +23,11 @@ def request_build_absolute_uri_location(request):
     return request.build_absolute_uri("location")
 
 
+@router.get("/request/get-preferred-type")
+def request_get_preferred_type(request):
+    return request.get_preferred_type(["application/json", "text/plain"])
+
+
 @router.get("/test")
 def simple_get(request):
     return "test"
@@ -75,6 +80,16 @@ def test_sync_build_absolute_uri(path, expected_status, expected_response):
 
     assert response.status_code == expected_status
     assert response.json() == expected_response
+
+
+def test_get_preferred_type():
+    response = client.get(
+        "/request/get-preferred-type",
+        headers={"Accept": "text/html,application/json;q=0.8"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == "application/json"
 
 
 class ClientTestSchema(Schema):


### PR DESCRIPTION
## Summary

- Build Django Ninja test requests with a real `HttpRequest` instead of a spec-only `Mock`.
- Keep the existing TestClient defaults for body, user, session, auth, CSRF, headers, cookies, and absolute URLs.
- Add regression coverage for `HttpRequest.get_preferred_type()` with an `Accept` header.

## Root cause

`Mock(spec=HttpRequest)` exposes Django request methods, but calling them returns more mocks instead of executing Django's implementation. Endpoints using `get_preferred_type()` therefore returned a `Mock`, which failed during JSON serialization. A real `HttpRequest` provides the standard request behavior while remaining mutable enough for TestClient's lightweight setup. Request bodies are stored in `_body` because Django exposes `body` as a read-only property.

## Validation

- `.venv/bin/python -m pytest -q tests/test_test_client.py` (18 passed)
- `.venv/bin/python -m pytest -q tests -m 'not asyncio'` (748 passed, 3 skipped, 50 deselected)
- `.venv/bin/ruff format --check ninja/testing/client.py tests/test_test_client.py`
- `.venv/bin/ruff check ninja/testing/client.py tests/test_test_client.py`
- `.venv/bin/mypy ninja/testing/client.py`
- `git diff --check`

The repository's database-backed async cursor pagination test stalls in my local environment, so the broad run excludes async-marked tests; the TestClient file's async cases pass.

Fixes #1743
