### PR TITLE
fix: annotate ArrayField item types in ModelSchema

### DIFF
--- a/ninja/orm/fields.py
+++ b/ninja/orm/fields.py
@@ -163,6 +163,10 @@ def get_schema_field(
             ]
             raise ConfigError("\n".join(msg)) from e
 
+        if internal_type == "ArrayField":
+            item_type: Any = get_schema_field(field.base_field)[0]
+            python_type = List[item_type]
+
         if field.primary_key or blank or null or optional:
             default = None
             nullable = True

--- a/tests/test_orm_schemas.py
+++ b/tests/test_orm_schemas.py
@@ -150,7 +150,11 @@ def test_all_fields():
             "timefield": {"type": "string", "format": "time", "title": "Timefield"},
             "urlfield": {"type": "string", "title": "Urlfield"},
             "uuidfield": {"type": "string", "format": "uuid", "title": "Uuidfield"},
-            "arrayfield": {"type": "array", "items": {}, "title": "Arrayfield"},
+            "arrayfield": {
+                "type": "array",
+                "items": {"type": "string"},
+                "title": "Arrayfield",
+            },
             "cicharfield": {"type": "string", "title": "Cicharfield"},
             "ciemailfield": {
                 "type": "string",
@@ -234,6 +238,38 @@ def test_altautofield():
                 "title": "Autofield",
             }
         }
+
+
+def test_array_field():
+    class ModelWithArrayField(models.Model):
+        tags = ps_fields.ArrayField(models.CharField())
+
+        class Meta:
+            app_label = "tests"
+
+    SchemaCls = create_schema(ModelWithArrayField)
+
+    assert SchemaCls.json_schema()["properties"]["tags"] == {
+        "items": {"type": "string"},
+        "title": "Tags",
+        "type": "array",
+    }
+
+
+def test_nested_array_field():
+    class ModelWithNestedArrayField(models.Model):
+        tags = ps_fields.ArrayField(ps_fields.ArrayField(models.CharField()))
+
+        class Meta:
+            app_label = "tests"
+
+    SchemaCls = create_schema(ModelWithNestedArrayField)
+
+    assert SchemaCls.json_schema()["properties"]["tags"] == {
+        "items": {"items": {"type": "string"}, "type": "array"},
+        "title": "Tags",
+        "type": "array",
+    }
 
 
 def test_django_31_fields():


### PR DESCRIPTION
Fixes #1490.

`ModelSchema` previously converted PostgreSQL `ArrayField` fields to an unparameterized `List`. As a result, Pydantic generated an empty `items` schema and did not validate the array item type.

This change derives the item type from `ArrayField.base_field`.
