### PR TITLE
 fix: AI dark mode compatibility

### DIFF
--- a/docs/docs/chat.md
+++ b/docs/docs/chat.md
@@ -14,28 +14,18 @@ Please feel free to share any questions or describe any problems you're encounte
     --serenity-widget-bg: #ffffff;
 }
 
-[data-md-color-scheme="slate"] .serenity_app {
+[data-md-color-scheme="slate"] .serenity_theme-dark {
     --serenity-widget-bg: var(--md-default-bg-color);
     --serenity-answer-code-bg: var(--md-code-bg-color);
-
     --serenity-widget-text: var(--md-default-fg-color);
+    --serenity-widget-primary: var(--serenity-widget-secondary);
     --serenity-widget-placeholder: color-mix(
         in srgb,
-        var(--md-default-fg-color) 60%,
+        var(--md-default-fg-color) 70%,
         transparent
-    );
-    --serenity-chat-powered: color-mix(
-        in srgb,
-        var(--md-default-fg-color) 50%,
-        transparent
-    );
-
-    --serenity-widget-secondary: color-mix(
-        in srgb,
-        var(--md-default-fg-color) 12%,
-        var(--md-default-bg-color)
     );
 }
+
 </style>
 
 <div id="serenity"></div>
@@ -48,3 +38,30 @@ var SERENITY_WIDGET = {
 };
 </script>
 <script src="https://js.serenitygpt.com/widget.js"></script>
+<script>
+(function () {
+    function serenityShouldBeDark() {
+        var schemeEl = document.querySelector('[data-md-color-scheme]');
+        return !!schemeEl && schemeEl.getAttribute('data-md-color-scheme') === 'slate';
+    }
+
+    function syncSerenityTheme() {
+        var widget = document.querySelector('.serenity_app');
+        if (!widget) return;
+        widget.classList.toggle('serenity_theme-dark', serenityShouldBeDark());
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var mountObserver = new MutationObserver(syncSerenityTheme);
+        mountObserver.observe(document.body, { childList: true, subtree: true });
+        syncSerenityTheme();
+
+        var schemeTarget = document.querySelector('[data-md-color-scheme]') || document.body;
+        var schemeObserver = new MutationObserver(syncSerenityTheme);
+        schemeObserver.observe(schemeTarget, {
+            attributes: true,
+            attributeFilter: ['data-md-color-scheme']
+        });
+    });
+})();
+</script>

--- a/docs/docs/chat.md
+++ b/docs/docs/chat.md
@@ -13,6 +13,29 @@ Please feel free to share any questions or describe any problems you're encounte
     --serenity-answer-code-bg: #fafafa;
     --serenity-widget-bg: #ffffff;
 }
+
+[data-md-color-scheme="slate"] .serenity_app {
+    --serenity-widget-bg: var(--md-default-bg-color);
+    --serenity-answer-code-bg: var(--md-code-bg-color);
+
+    --serenity-widget-text: var(--md-default-fg-color);
+    --serenity-widget-placeholder: color-mix(
+        in srgb,
+        var(--md-default-fg-color) 60%,
+        transparent
+    );
+    --serenity-chat-powered: color-mix(
+        in srgb,
+        var(--md-default-fg-color) 50%,
+        transparent
+    );
+
+    --serenity-widget-secondary: color-mix(
+        in srgb,
+        var(--md-default-fg-color) 12%,
+        var(--md-default-bg-color)
+    );
+}
 </style>
 
 <div id="serenity"></div>


### PR DESCRIPTION
## Summary

Fixes the Ask AI page in dark mode by applying SerenityGPT theme variables when the MkDocs Material `slate` color scheme is active.

## Changes

- Override SerenityGPT background variables for dark mode
- Override SerenityGPT text, placeholder, ordering number colors for dark mode
- Preserve existing light theme behavior

Fixes #1739

<img width="2559" height="1382" alt="Screenshot 2026-08-16 230656" src="https://github.com/user-attachments/assets/8ed19532-09d8-4383-8fb9-e4a82a8651fc" />
