### PR TITLE
Fix override_settings support for Ninja settings

### DIFF
--- a/ninja/conf.py
+++ b/ninja/conf.py
@@ -1,7 +1,9 @@
 from math import inf
-from typing import Dict, Optional, Set, Tuple
+from typing import Any, Dict, Optional, Set, Tuple
 
 from django.conf import settings as django_settings
+from django.dispatch import receiver
+from django.test.signals import setting_changed
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -36,6 +38,17 @@ class Settings(BaseModel):
 
 
 settings = Settings.model_validate(django_settings)
+
+
+@receiver(setting_changed)
+def reload_ninja_settings(*args: Any, setting: str, **kwargs: Any) -> None:
+    if not setting.startswith("NINJA_"):
+        return
+
+    updated_settings = Settings.model_validate(django_settings)
+    for field_name in Settings.model_fields:
+        setattr(settings, field_name, getattr(updated_settings, field_name))
+
 
 if hasattr(django_settings, "NINJA_DOCS_VIEW"):
     raise Exception(

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,6 +1,20 @@
+from django.test import override_settings
+
 from ninja.conf import settings
 
 
 def test_default_configuration():
     assert settings.PAGINATION_CLASS == "ninja.pagination.LimitOffsetPagination"
+    assert settings.PAGINATION_PER_PAGE == 100
+
+
+def test_override_settings_updates_ninja_settings():
+    assert settings.NUM_PROXIES is None
+    assert settings.PAGINATION_PER_PAGE == 100
+
+    with override_settings(NINJA_NUM_PROXIES=3, NINJA_PAGINATION_PER_PAGE=20):
+        assert settings.NUM_PROXIES == 3
+        assert settings.PAGINATION_PER_PAGE == 20
+
+    assert settings.NUM_PROXIES is None
     assert settings.PAGINATION_PER_PAGE == 100


### PR DESCRIPTION
Fixes #1679.

## Summary

- refresh Django Ninja's validated settings when a `NINJA_*` Django setting changes
- update the existing settings object in place so modules that imported it observe overrides
- add regression coverage for applying and restoring multiple `override_settings` values

## Root cause

`ninja.conf.settings` was created once at import time with `Settings.model_validate(django_settings)`. Django's `override_settings` updates `django.conf.settings` and emits `setting_changed`, but the already-created Ninja settings object was never refreshed. Consumers such as throttling therefore kept stale values unless tests patched the Pydantic object directly or reloaded modules.

The receiver rebuilds a validated `Settings` instance only for `NINJA_*` changes, then copies its fields onto the existing object. This also restores defaults correctly when an override context exits.

## Validation

- `.venv/bin/pytest -q tests/test_conf.py tests/test_throttling.py tests/test_pagination.py::test_10_max_limit_set tests/test_pagination.py::test_11_max_limit_set_and_exceeded` (`16 passed`)
- `.venv/bin/pytest -vv -s tests/test_pagination_cursor.py::test_cursor_pagination_settings_override` (`1 passed`)
- `.venv/bin/ruff format --check ninja/conf.py tests/test_conf.py`
- `.venv/bin/ruff check ninja/conf.py tests/test_conf.py`
- `.venv/bin/mypy ninja/conf.py`
- `git diff --check`

The broader suite was started but could not complete locally because the existing async cursor pagination test stalled in this environment.
