### PR TITLE
fix: dispatch same-path API and router operations by method

### DIFF
--- a/ninja/main.py
+++ b/ninja/main.py
@@ -14,6 +14,7 @@ from typing import (
 
 from django.http import HttpRequest, HttpResponse
 from django.urls import URLPattern, URLResolver, reverse
+from django.urls import path as django_path
 from django.utils.module_loading import import_string
 
 from ninja.constants import NOT_SET, NOT_SET_TYPE
@@ -28,6 +29,7 @@ from ninja.openapi import get_schema
 from ninja.openapi.docs import DocsBase, Swagger
 from ninja.openapi.schema import OpenAPISchema
 from ninja.openapi.urls import get_openapi_urls, get_root_url
+from ninja.operation import PathView
 from ninja.parser import Parser
 from ninja.renderers import BaseRenderer, JSONRenderer
 from ninja.router import BoundRouter, Router, RouterMount
@@ -529,9 +531,27 @@ class NinjaAPI:
 
     def _get_urls(self) -> List[Union[URLResolver, URLPattern]]:
         result = get_openapi_urls(self)
+        bound_paths: List[Tuple[BoundRouter, str, PathView]] = []
+        merged_path_views: Dict[str, PathView] = {}
 
         for bound_router in self._get_bound_routers():
-            result.extend(bound_router.urls_paths(bound_router.prefix))
+            for route, path_view in bound_router.iter_path_views(bound_router.prefix):
+                merged_view = merged_path_views.setdefault(route, PathView())
+                merged_view.operations.extend(path_view.operations)
+                merged_view.is_async = merged_view.is_async or path_view.is_async
+                bound_paths.append((bound_router, route, path_view))
+
+        for bound_router, route, path_view in bound_paths:
+            merged_view = merged_path_views[route]
+            for operation in path_view.operations:
+                url_name = getattr(operation, "url_name", "")
+                if not url_name:
+                    url_name = self.get_operation_url_name(
+                        operation, router=bound_router.template
+                    )
+                    if bound_router.url_name_prefix and url_name:
+                        url_name = f"{bound_router.url_name_prefix}_{url_name}"
+                result.append(django_path(route, merged_view.get_view(), name=url_name))
 
         result.append(get_root_url(self))
         return result

--- a/ninja/router.py
+++ b/ninja/router.py
@@ -167,26 +167,14 @@ class BoundRouter:
 
             self.path_operations[path] = cloned_view
 
-    def urls_paths(self, prefix: str) -> Iterator[URLPattern]:
-        """Generate URL patterns for this bound router."""
+    def iter_path_views(self, prefix: str) -> Iterator[Tuple[str, PathView]]:
+        """Yield normalized routes and their bound path views."""
         prefix = replace_path_param_notation(prefix)
         for path, path_view in self.path_operations.items():
             path = replace_path_param_notation(path)
             route = "/".join([i for i in (prefix, path) if i])
             route = normalize_path(route)
-            route = route.lstrip("/")
-
-            for operation in path_view.operations:
-                url_name = getattr(operation, "url_name", "")
-                if not url_name:
-                    url_name = self.api.get_operation_url_name(
-                        operation, router=self.template
-                    )
-                    # Apply url_name_prefix if specified
-                    if self.url_name_prefix and url_name:
-                        url_name = f"{self.url_name_prefix}_{url_name}"
-
-                yield django_path(route, path_view.get_view(), name=url_name)
+            yield route.lstrip("/"), path_view
 
 
 class Router:

--- a/tests/test_router_reuse.py
+++ b/tests/test_router_reuse.py
@@ -80,6 +80,29 @@ class TestRouterReuse:
         assert response_admin.status_code == 200
         assert response_public.status_code == 200
 
+    def test_api_and_router_operations_with_same_path_dispatch_by_method(self):
+        router = Router()
+
+        @router.put("/users")
+        def update_user(request):
+            return {"method": "put"}
+
+        api = NinjaAPI(urls_namespace="same-path-methods")
+
+        @api.post("/users")
+        def create_user(request):
+            return {"method": "post"}
+
+        api.add_router("", router)
+        client = TestClient(api)
+
+        assert client.post("/users").json() == {"method": "post"}
+        assert client.put("/users").json() == {"method": "put"}
+
+        response = client.delete("/users")
+        assert response.status_code == 405
+        assert {"POST", "PUT"} <= set(response["Allow"].split(", "))
+
 
 class TestDecoratorIsolation:
     """Test that decorators are isolated between mounts."""


### PR DESCRIPTION
## Summary

Fixes #1546.

When a `NinjaAPI` operation and an operation from a mounted `Router` share the same normalized path but handle different HTTP methods, Django resolves the first URL pattern and never reaches the later router pattern. The first `PathView` therefore returns 405 for the other router's method.

This change merges bound `PathView` operations by normalized route before creating Django URL patterns. Each operation keeps its own named pattern for URL reversing, while every duplicate route pattern delegates to the same merged dispatcher.

## Regression coverage

Adds a regression test for:

- `POST /users` on the API
- `PUT /users` on a router mounted at the same path
- `DELETE /users` returning 405 with both `POST` and `PUT` in `Allow`

## Validation

- `pytest tests/test_router_reuse.py -q` → 27 passed
- `ruff format --check ninja tests`
- `ruff check ninja tests`
- `mypy ninja`
- `pytest . -q` → 798 passed, 3 skipped
