### PR TITLE
Honor transaction.non_atomic_requests on Ninja routes

### DIFF
--- a/ninja/operation.py
+++ b/ninja/operation.py
@@ -11,6 +11,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Set,
     Type,
     Union,
     cast,
@@ -646,6 +647,22 @@ class PathView:
     def get_view(self) -> Callable:
         # Create a unique view function for this PathView
 
+        # Django's ATOMIC_REQUESTS support reads the `_non_atomic_requests`
+        # marker (set of database aliases installed by
+        # django.db.transaction.non_atomic_requests) from the URL callback.
+        # Since the callback is the wrapper created below, forward the marker
+        # from the wrapped operations. A database alias is forwarded only when
+        # every operation of the path opts out of atomic requests for it.
+        non_atomic_requests: Optional[Set[str]] = None
+        for operation in self.operations:
+            operation_non_atomic_requests = set(
+                getattr(operation.view_func, "_non_atomic_requests", ())
+            )
+            if non_atomic_requests is None:
+                non_atomic_requests = operation_non_atomic_requests
+            else:
+                non_atomic_requests &= operation_non_atomic_requests
+
         if self.is_async:
             # Create a wrapper for async view
             async def async_view_wrapper(
@@ -656,6 +673,9 @@ class PathView:
             # All django-ninja views are CSRF exempt at Django middleware level
             # Cookie-based auth (APIKeyCookie) handles CSRF checking separately
             async_view_wrapper.csrf_exempt = True  # type: ignore
+
+            if non_atomic_requests:
+                async_view_wrapper._non_atomic_requests = non_atomic_requests  # type: ignore
 
             return async_view_wrapper
         else:
@@ -668,6 +688,9 @@ class PathView:
             # All django-ninja views are CSRF exempt at Django middleware level
             # Cookie-based auth (APIKeyCookie) handles CSRF checking separately
             sync_view_wrapper.csrf_exempt = True  # type: ignore
+
+            if non_atomic_requests:
+                sync_view_wrapper._non_atomic_requests = non_atomic_requests  # type: ignore
 
             return sync_view_wrapper
 

--- a/tests/test_non_atomic_requests.py
+++ b/tests/test_non_atomic_requests.py
@@ -1,0 +1,177 @@
+"""ATOMIC_REQUESTS support: transaction.non_atomic_requests on Ninja routes.
+
+Django's ``BaseHandler.make_view_atomic`` reads the ``_non_atomic_requests``
+marker (installed by ``django.db.transaction.non_atomic_requests``) from the
+URL callback. django-ninja builds that callback in ``PathView.get_view()``, so
+the marker has to be forwarded from the wrapped operation view functions.
+
+See https://github.com/vitalik/django-ninja/issues/1767
+"""
+
+import pytest
+from django.conf import settings
+from django.core.handlers.base import BaseHandler
+from django.db import connection, transaction
+from django.test import Client
+from django.urls import path
+
+from ninja import NinjaAPI
+
+
+@pytest.fixture
+def atomic_requests():
+    """Temporarily enable ATOMIC_REQUESTS for the default connection.
+
+    ``make_view_atomic`` reads ``connections.settings``, which shares the same
+    per-alias dict objects as ``connection.settings_dict``.
+    """
+    original = connection.settings_dict.get("ATOMIC_REQUESTS")
+    connection.settings_dict["ATOMIC_REQUESTS"] = True
+    try:
+        yield
+    finally:
+        if original is None:
+            connection.settings_dict.pop("ATOMIC_REQUESTS", None)
+        else:
+            connection.settings_dict["ATOMIC_REQUESTS"] = original
+
+
+def _callback(api, path_str):
+    normalized = path_str.lstrip("/")
+    for pattern in api.urls[0]:
+        if hasattr(pattern, "pattern") and normalized in str(pattern.pattern):
+            return pattern.callback
+    raise AssertionError(f"pattern not found: {path_str}")
+
+
+# Routes + URLconf used by the end-to-end handler test below
+api = NinjaAPI(urls_namespace="test-non-atomic")
+
+
+@api.get("/plain")
+def plain(request):
+    return {"in_atomic_block": connection.in_atomic_block}
+
+
+@api.get("/non_atomic")
+@transaction.non_atomic_requests
+def non_atomic(request):
+    return {"in_atomic_block": connection.in_atomic_block}
+
+
+urlpatterns = [path("api/", api.urls)]
+
+
+def test_non_atomic_marker_forwarded_to_callback():
+    inner = NinjaAPI(urls_namespace="test-non-atomic-forwarded")
+
+    @inner.get("/non_atomic")
+    @transaction.non_atomic_requests
+    def non_atomic_view(request):
+        return {"ok": True}
+
+    @inner.get("/plain")
+    def plain_view(request):
+        return {"ok": True}
+
+    non_atomic_callback = _callback(inner, "/non_atomic")
+    plain_callback = _callback(inner, "/plain")
+
+    assert non_atomic_callback._non_atomic_requests == {"default"}
+    assert not hasattr(plain_callback, "_non_atomic_requests")
+
+
+def test_async_non_atomic_marker_forwarded_to_callback(atomic_requests):
+    inner = NinjaAPI(urls_namespace="test-non-atomic-async")
+
+    @inner.get("/non_atomic")
+    @transaction.non_atomic_requests
+    async def non_atomic_view(request):
+        return {"ok": True}
+
+    callback = _callback(inner, "/non_atomic")
+    assert callback._non_atomic_requests == {"default"}
+    # Django must not wrap an async view when the marker is present
+    # (otherwise ATOMIC_REQUESTS raises RuntimeError for async views).
+    assert BaseHandler().make_view_atomic(callback) is callback
+
+
+def test_make_view_atomic_wraps_only_unmarked_routes(atomic_requests):
+    inner = NinjaAPI(urls_namespace="test-non-atomic-wrap")
+
+    @inner.get("/non_atomic")
+    @transaction.non_atomic_requests
+    def non_atomic_view(request):
+        return {"ok": True}
+
+    @inner.get("/plain")
+    def plain_view(request):
+        return {"ok": True}
+
+    handler = BaseHandler()
+    non_atomic_callback = _callback(inner, "/non_atomic")
+    plain_callback = _callback(inner, "/plain")
+
+    assert handler.make_view_atomic(non_atomic_callback) is non_atomic_callback
+    assert handler.make_view_atomic(plain_callback) is not plain_callback
+
+
+def test_non_atomic_for_other_database_alias(atomic_requests):
+    inner = NinjaAPI(urls_namespace="test-non-atomic-other-alias")
+
+    @inner.get("/other")
+    @transaction.non_atomic_requests(using="other")
+    def other_view(request):
+        return {"ok": True}
+
+    callback = _callback(inner, "/other")
+    assert callback._non_atomic_requests == {"other"}
+    # The default alias is still wrapped: "other" is NOT in the marker set.
+    assert BaseHandler().make_view_atomic(callback) is not callback
+
+
+def test_all_operations_non_atomic_forwarded():
+    inner = NinjaAPI(urls_namespace="test-non-atomic-all")
+
+    @inner.get("/item")
+    @transaction.non_atomic_requests
+    def get_item(request):
+        return {"ok": True}
+
+    @inner.post("/item")
+    @transaction.non_atomic_requests
+    def create_item(request):
+        return {"ok": True}
+
+    callback = _callback(inner, "/item")
+    assert callback._non_atomic_requests == {"default"}
+
+
+def test_mixed_operations_stay_atomic():
+    inner = NinjaAPI(urls_namespace="test-non-atomic-mixed")
+
+    @inner.get("/item")
+    @transaction.non_atomic_requests
+    def get_item(request):
+        return {"ok": True}
+
+    @inner.post("/item")
+    def create_item(request):
+        return {"ok": True}
+
+    callback = _callback(inner, "/item")
+    # The path is shared by marked and unmarked operations -> the conservative
+    # choice is to keep the whole path atomic.
+    assert not hasattr(callback, "_non_atomic_requests")
+
+
+@pytest.mark.django_db(transaction=True)
+def test_non_atomic_requests_honored_by_django_handler(atomic_requests, monkeypatch):
+    monkeypatch.setattr(settings, "ROOT_URLCONF", __name__)
+    client = Client()
+
+    plain_response = client.get("/api/plain")
+    non_atomic_response = client.get("/api/non_atomic")
+
+    assert plain_response.json() == {"in_atomic_block": True}
+    assert non_atomic_response.json() == {"in_atomic_block": False}


### PR DESCRIPTION
Fixes #1767

**Problem**

With `"ATOMIC_REQUESTS": True` in the database settings, `@transaction.non_atomic_requests` on a Ninja route is ignored — the route still runs inside an atomic block (see #1767, including the report that the #686 workaround does not work either).

**Root cause**

Django's `BaseHandler.make_view_atomic()` reads the `_non_atomic_requests` marker — a set of database aliases installed by `django.db.transaction.non_atomic_requests` — from the **URL callback**. django-ninja builds that callback in `PathView.get_view()` (`ninja/operation.py`) as a fresh wrapper which only carried `csrf_exempt`, so the marker stayed on the operation's `view_func` and never reached Django. The issue's own reproduction shows exactly that: `Direct resolved callback attribute: None`.

**Change**

`PathView.get_view()` now forwards `_non_atomic_requests` from the path's operations onto the generated wrapper, for sync and async views alike. A database alias is forwarded only when *all* operations on that path opt out of atomic requests for it — this matches Django's whole-view granularity and avoids silently dropping atomicity for other methods sharing the same path.

**Tests** (`tests/test_non_atomic_requests.py`)

- marker forwarded to the URL callback (sync and async)
- `make_view_atomic` no longer wraps a marked route, still wraps a plain one
- per-alias handling (`@non_atomic_requests(using="other")` does not disable atomicity for `default`)
- end-to-end through Django's real handler with `ATOMIC_REQUESTS=True`: a marked route reports `connection.in_atomic_block == False` while a plain route stays `True`

**Verified**

- full suite: 813 passed / 3 skipped (Django 6.1, Python 3.13)
- new tests pass on Django 6.1, 5.2 and 4.2
- ruff format/check clean; mypy shows no new errors

Note: the `decorate_view(...)` workaround from #686 still cannot set the marker, because `decorate_view` applies decorators to `Operation.run` — a bound method that cannot hold the attribute. With this change the plain decorator works, so the workaround is no longer needed.