### PR TITLE
Publish to PyPI via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # PyPI Trusted Publishing (OIDC) — no token needed
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - name: Set up uv
@@ -19,6 +21,4 @@ jobs:
       - name: Build
         run: uv build
       - name: Publish
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: uv publish

--- a/ninja/__init__.py
+++ b/ninja/__init__.py
@@ -1,6 +1,6 @@
 """Django Ninja - Fast Django REST framework"""
 
-__version__ = "1.7.1a1"
+__version__ = "1.7.1a2"
 
 from pydantic import Field
 


### PR DESCRIPTION
Follow-up to #1770: replaces the `PYPI_TOKEN` secret with [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) — the publish job gets `id-token: write` and bare `uv publish` auto-detects the OIDC token on GitHub Actions (same as FastAPI/typer). The trusted publisher for `publish.yml` is already configured on PyPI.

Bumps version to `1.7.1a2` to exercise the new flow with a pre-release.

Once `1.7.1a2` publishes successfully, the `PYPI_TOKEN`, `FLIT_USERNAME`, and `FLIT_PASSWORD` repo secrets can all be deleted.

https://claude.ai/code/session_01YAXYbhjvJc35vmLVYohmY7