### PR TITLE
Import setting_changed from django.core.signals instead of django.test

### DIFF
--- a/ninja/conf.py
+++ b/ninja/conf.py
@@ -2,8 +2,8 @@ from math import inf
 from typing import Any, Dict, Optional, Set, Tuple
 
 from django.conf import settings as django_settings
+from django.core.signals import setting_changed
 from django.dispatch import receiver
-from django.test.signals import setting_changed
 from pydantic import BaseModel, ConfigDict, Field
 
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,3 +1,7 @@
+import os
+import subprocess
+import sys
+
 from django.test import override_settings
 
 from ninja.conf import settings
@@ -18,3 +22,18 @@ def test_override_settings_updates_ninja_settings():
 
     assert settings.NUM_PROXIES is None
     assert settings.PAGINATION_PER_PAGE == 100
+
+
+def test_importing_ninja_does_not_import_django_test():
+    # ninja is imported by production code; django.test pulls in the whole test
+    # framework (Client, TestCase, unittest) and is stripped from some slim
+    # deployment images.
+    code = (
+        "import os, sys, django;"
+        "os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'demo.settings');"
+        "django.setup();"
+        "import ninja;"
+        "sys.exit(1 if 'django.test' in sys.modules else 0)"
+    )
+    env = {**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)}
+    assert subprocess.run([sys.executable, "-c", code], env=env).returncode == 0


### PR DESCRIPTION
`ninja/conf.py` imports `setting_changed` from `django.test.signals`, but the signal is defined in `django.core.signals`.
`django.test.signals` only re-exports it (and attaches Django's own settings-reset receivers, which ninja doesn't need).

Importing it through `django.test` means every process that imports ninja also imports `django/test/__init__.py`, and with it `Client`, `TestCase`, and the `unittest` machinery. That's the whole test framework loaded into production, at import time.

It also breaks outright on installations where `django/test` isn't present. Slim-image builds commonly prune directories named `test`/`tests` from site-packages to save space; `django/test` looks like a test suite but is public API. Since #1761 added the receiver in 1.7.0, such images fail at the first `from ninja import NinjaAPI` with `ModuleNotFoundError: No module named 'django.test'`.

`django.core.signals.setting_changed` is the same `Signal` object, so `override_settings` behaviour is unchanged: `test_override_settings_updates_ninja_settings` still passes. Added a test asserting ninja's import graph doesn't reach `django.test`.